### PR TITLE
fix(api): split CORS policies between public embed and platform endpoints

### DIFF
--- a/.claude/skills/end-feature/SKILL.md
+++ b/.claude/skills/end-feature/SKILL.md
@@ -8,12 +8,14 @@ Wrap up a feature by running its final steps. Present a checklist form, then exe
 
 ## Step 0 — Show the checklist form
 
-Before doing anything, call `AskUserQuestion` with a single **multi-select** question so the user can check/uncheck the steps. All four steps are pre-selected by default (list them as the options; the user unchecks any they want to skip):
+Before doing anything, call `AskUserQuestion` with a single **multi-select** question so the user can check/uncheck the steps (list them as the options; the user unchecks any they want to skip):
 
 - **Update changelog** — add an entry under `## [Unreleased]` in `CHANGELOG.md`
 - **Create a branch** — move current work onto a feature branch
 - **Run tests-parallel** — `make tests-parallel`
 - **Create a PR** — open a pull request with `gh`
+
+All steps are pre-selected by default EXCEPT the changelog, which is optional: pre-select it only when the change is visible to end users or security-relevant. Leave it unchecked for internal work — refactors, CI/tooling, docs, tests. Mention in the question why you left it unchecked; the user can still check it.
 
 Use `header: "Steps"`, `multiSelect: true`. Whatever the user leaves checked is the set to run.
 
@@ -23,7 +25,7 @@ Then run the checked steps **strictly in this order** (skip unchecked ones):
 
 Only if checked. Edit `CHANGELOG.md`, adding a line under `## [Unreleased]`:
 
-- New capability → `### Added`; modified behavior → `### Changed`; bug fix → `### Fixed`.
+- New capability → `### Added`; modified behavior → `### Changed`; bug fix → `### Fixed`; security hardening or vulnerability fix → `### Security`.
 - **Write for end users, not developers** — describe the visible outcome, not entities/services/migrations.
 - Prefix with `(beta)` if the feature is behind a flag or not yet exposed in the UI.
 - **Write in STE (Simplified Technical English)**: short sentences (max 20 words), one fact per sentence, active voice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Studio no longer crashes when a project opens right after onboarding restarts.
 
 ### Security
+- Cross-origin browser calls to authenticated endpoints are now limited to the platform's own domains.
+
 ## [26.07.3] - 2026-07-24
 
 ### Added

--- a/apps/api/src/config/cors.spec.ts
+++ b/apps/api/src/config/cors.spec.ts
@@ -9,8 +9,19 @@ describe("parseFrontendUrls", () => {
     ])
   })
 
-  it("returns no origins when unset in production", () => {
-    expect(parseFrontendUrls(undefined, true)).toEqual([])
+  it("returns the local dev URLs when blank outside production", () => {
+    expect(parseFrontendUrls(" , ", false)).toEqual([
+      "https://connect.localhost:5173",
+      "https://connect.localhost:5174",
+    ])
+  })
+
+  it("throws when unset in production", () => {
+    expect(() => parseFrontendUrls(undefined, true)).toThrow(/FRONTEND_URL must be set/)
+  })
+
+  it("throws when blank in production", () => {
+    expect(() => parseFrontendUrls(" , ", true)).toThrow(/FRONTEND_URL must be set/)
   })
 
   it("splits a comma-separated list and trims entries", () => {

--- a/apps/api/src/config/cors.spec.ts
+++ b/apps/api/src/config/cors.spec.ts
@@ -1,0 +1,66 @@
+import type { CorsOptions } from "@nestjs/common/interfaces/external/cors-options.interface"
+import { buildCorsOptionsDelegate, parseFrontendUrls } from "./cors"
+
+describe("parseFrontendUrls", () => {
+  it("returns the local dev URLs when unset outside production", () => {
+    expect(parseFrontendUrls(undefined, false)).toEqual([
+      "https://connect.localhost:5173",
+      "https://connect.localhost:5174",
+    ])
+  })
+
+  it("returns no origins when unset in production", () => {
+    expect(parseFrontendUrls(undefined, true)).toEqual([])
+  })
+
+  it("splits a comma-separated list and trims entries", () => {
+    expect(parseFrontendUrls(" https://a.example , https://b.example ", true)).toEqual([
+      "https://a.example",
+      "https://b.example",
+    ])
+  })
+
+  it("normalizes scheme-less entries to https", () => {
+    expect(parseFrontendUrls("app.example,http://local.example", true)).toEqual([
+      "https://app.example",
+      "http://local.example",
+    ])
+  })
+})
+
+describe("buildCorsOptionsDelegate", () => {
+  const frontendUrls = ["https://app.example"]
+
+  const optionsFor = (url: string | undefined): CorsOptions => {
+    let received: CorsOptions | undefined
+    buildCorsOptionsDelegate(frontendUrls)({ url }, (error, options) => {
+      expect(error).toBeNull()
+      received = options as CorsOptions
+    })
+    if (!received) {
+      throw new Error("delegate did not call back synchronously")
+    }
+    return received
+  }
+
+  it("reflects the origin on public embed endpoints", () => {
+    expect(optionsFor("/public/agents/token123/config").origin).toBe(true)
+  })
+
+  it("pins origins to the frontend URLs everywhere else", () => {
+    expect(optionsFor("/organizations/1/projects").origin).toEqual(frontendUrls)
+  })
+
+  it("pins origins when the URL is missing", () => {
+    expect(optionsFor(undefined).origin).toEqual(frontendUrls)
+  })
+
+  it('does not match paths that merely start with "public"', () => {
+    expect(optionsFor("/publications").origin).toEqual(frontendUrls)
+  })
+
+  it("never enables credentialed CORS", () => {
+    expect(optionsFor("/public/agents/token123/config").credentials).toBeUndefined()
+    expect(optionsFor("/organizations/1/projects").credentials).toBeUndefined()
+  })
+})

--- a/apps/api/src/config/cors.ts
+++ b/apps/api/src/config/cors.ts
@@ -1,0 +1,58 @@
+import type {
+  CorsOptions,
+  CorsOptionsDelegate,
+} from "@nestjs/common/interfaces/external/cors-options.interface"
+
+const DEFAULT_LOCAL_FRONTEND_URLS = [
+  // `vite dev` and `vite preview` — see apps/web/vite.config.ts.
+  "https://connect.localhost:5173",
+  "https://connect.localhost:5174",
+]
+
+/**
+ * Parses `FRONTEND_URL` into a list of CORS origins. Accepts a single URL or
+ * a comma-separated list. Each entry is trimmed and normalized to https://
+ * if no scheme is given. When the env var is unset and we're not in
+ * production, falls back to the local dev/preview URLs so a fresh checkout
+ * works without extra `.env` setup. In production, an unset env var yields
+ * an empty array (no origins allowed).
+ */
+export function parseFrontendUrls(
+  frontendUrl: string | undefined,
+  isProduction: boolean,
+): string[] {
+  if (!frontendUrl) {
+    return isProduction ? [] : DEFAULT_LOCAL_FRONTEND_URLS
+  }
+  return frontendUrl
+    .split(",")
+    .map((url) => url.trim())
+    .filter(Boolean)
+    .map((url) =>
+      url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`,
+    )
+}
+
+/**
+ * CORS strategy — two policies, split by path (#366):
+ * - Public embed endpoints (/public/*) are designed to be called from
+ *   arbitrary host pages, so the request origin is reflected. Their security
+ *   is enforced by EmbedTokenGuard (embed token + per-config allowedOrigins
+ *   check), not by CORS. Reflecting the origin (instead of '*') is required
+ *   because some browsers are stricter with '*' when custom headers
+ *   (X-Session-Token) are present.
+ * - Everything else only serves the platform front ends, so origins are
+ *   pinned to the FRONTEND_URL list. These endpoints are secured by Auth0
+ *   Bearer tokens; the one cookie-authenticated surface (Bull Board's OIDC
+ *   session) is covered by this strict policy too.
+ * No caller sends cookies or uses `credentials: 'include'`, so credentialed
+ * CORS stays off.
+ */
+export function buildCorsOptionsDelegate(
+  frontendUrls: string[],
+): CorsOptionsDelegate<{ url?: string }> {
+  return (req, callback: (error: Error | null, options: CorsOptions) => void) => {
+    const isPublicEmbed = req.url?.startsWith("/public/") ?? false
+    callback(null, { origin: isPublicEmbed ? true : frontendUrls })
+  }
+}

--- a/apps/api/src/config/cors.ts
+++ b/apps/api/src/config/cors.ts
@@ -1,3 +1,4 @@
+import { PUBLIC_PATH_PREFIX } from "@caseai-connect/api-contracts"
 import type {
   CorsOptions,
   CorsOptionsDelegate,
@@ -52,7 +53,7 @@ export function buildCorsOptionsDelegate(
   frontendUrls: string[],
 ): CorsOptionsDelegate<{ url?: string }> {
   return (req, callback: (error: Error | null, options: CorsOptions) => void) => {
-    const isPublicEmbed = req.url?.startsWith("/public/") ?? false
+    const isPublicEmbed = req.url?.startsWith(`/${PUBLIC_PATH_PREFIX}/`) ?? false
     callback(null, { origin: isPublicEmbed ? true : frontendUrls })
   }
 }

--- a/apps/api/src/config/cors.ts
+++ b/apps/api/src/config/cors.ts
@@ -13,25 +13,33 @@ const DEFAULT_LOCAL_FRONTEND_URLS = [
 /**
  * Parses `FRONTEND_URL` into a list of CORS origins. Accepts a single URL or
  * a comma-separated list. Each entry is trimmed and normalized to https://
- * if no scheme is given. When the env var is unset and we're not in
- * production, falls back to the local dev/preview URLs so a fresh checkout
- * works without extra `.env` setup. In production, an unset env var yields
- * an empty array (no origins allowed).
+ * if no scheme is given. When the list resolves to nothing (unset or blank)
+ * outside production, falls back to the local dev/preview URLs so a fresh
+ * checkout works without extra `.env` setup. In production the same case
+ * throws: an empty list would silently block every browser call to the
+ * platform, whereas a crash at boot fails the Cloud Run revision and keeps
+ * the previous one serving.
  */
 export function parseFrontendUrls(
   frontendUrl: string | undefined,
   isProduction: boolean,
 ): string[] {
-  if (!frontendUrl) {
-    return isProduction ? [] : DEFAULT_LOCAL_FRONTEND_URLS
-  }
-  return frontendUrl
+  const urls = (frontendUrl ?? "")
     .split(",")
     .map((url) => url.trim())
     .filter(Boolean)
     .map((url) =>
       url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`,
     )
+  if (urls.length > 0) {
+    return urls
+  }
+  if (isProduction) {
+    throw new Error(
+      "FRONTEND_URL must be set in production (comma-separated list of allowed CORS origins)",
+    )
+  }
+  return DEFAULT_LOCAL_FRONTEND_URLS
 }
 
 /**

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,12 +10,13 @@ import { registerBullBoardOpenIdConnect } from "./common/bull-board/bull-board-o
 import { StackTraceLoggingExceptionFilter } from "./common/filters/stack-trace-logging-exception.filter"
 import { getLogLevels, StructuredLogger } from "./common/logger/structured-logger"
 import { enableDbListeners } from "./common/sse/postgres-status-stream.service"
+import { buildCorsOptionsDelegate, parseFrontendUrls } from "./config/cors"
 
 const isProduction = process.env.NODE_ENV === "production"
 
 async function bootstrap() {
   enableDbListeners()
-  const _frontendUrls = parseFrontendUrls(process.env.FRONTEND_URL)
+  const frontendUrls = parseFrontendUrls(process.env.FRONTEND_URL, isProduction)
   const httpsOptions = loadHttpsCertificates()
   const logLevels = getLogLevels()
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -36,49 +37,16 @@ async function bootstrap() {
     }),
   )
   app.useGlobalFilters(new StackTraceLoggingExceptionFilter(app.getHttpAdapter()))
-  // CORS strategy:
-  // - Authenticated endpoints are secured by JWT — the real security layer.
-  //   No cookies are used (Auth0 Bearer tokens), so reflecting back the request
-  //   origin is safe: a cross-origin attacker cannot inject the Bearer token.
-  // - Public embed endpoints (/public/*) are designed to be called from arbitrary
-  //   host pages. Their security is enforced by EmbedTokenGuard (embed token +
-  //   per-config allowedOrigins check), not by CORS.
-  // Reflecting the origin (instead of using '*') is required because the embed
-  // widget's fetch calls don't use `credentials: 'include'`, but some browsers
-  // are stricter with '*' when custom headers (X-Session-Token) are present.
-  app.enableCors({
-    origin: (origin, callback) => callback(null, origin ?? true),
-    credentials: true,
-  })
+  // Two CORS policies, split by path — see buildCorsOptionsDelegate (#366).
+  if (isProduction && frontendUrls.length === 0) {
+    new StructuredLogger(logLevels).warn(
+      "FRONTEND_URL is not set: CORS will block every browser call to non-public endpoints",
+      "bootstrap",
+    )
+  }
+  app.enableCors(buildCorsOptionsDelegate(frontendUrls))
   const port = Number(process.env.PORT) || 3000
   await app.listen(port)
-}
-
-const DEFAULT_LOCAL_FRONTEND_URLS = [
-  // `vite dev` and `vite preview` — see apps/web/vite.config.ts.
-  "https://connect.localhost:5173",
-  "https://connect.localhost:5174",
-]
-
-/**
- * Parses `FRONTEND_URL` into a list of CORS origins. Accepts a single URL or
- * a comma-separated list. Each entry is trimmed and normalized to https://
- * if no scheme is given. When the env var is unset and we're not in
- * production, falls back to the local dev/preview URLs so a fresh checkout
- * works without extra `.env` setup. In production, an unset env var yields
- * an empty array (no origins allowed).
- */
-function parseFrontendUrls(frontendUrl: string | undefined): string[] {
-  if (!frontendUrl) {
-    return isProduction ? [] : DEFAULT_LOCAL_FRONTEND_URLS
-  }
-  return frontendUrl
-    .split(",")
-    .map((url) => url.trim())
-    .filter(Boolean)
-    .map((url) =>
-      url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`,
-    )
 }
 
 /**

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -38,12 +38,6 @@ async function bootstrap() {
   )
   app.useGlobalFilters(new StackTraceLoggingExceptionFilter(app.getHttpAdapter()))
   // Two CORS policies, split by path — see buildCorsOptionsDelegate (#366).
-  if (isProduction && frontendUrls.length === 0) {
-    new StructuredLogger(logLevels).warn(
-      "FRONTEND_URL is not set: CORS will block every browser call to non-public endpoints",
-      "bootstrap",
-    )
-  }
   app.enableCors(buildCorsOptionsDelegate(frontendUrls))
   const port = Number(process.env.PORT) || 3000
   await app.listen(port)

--- a/docs/adr/0015-public-cors-namespace-convention.md
+++ b/docs/adr/0015-public-cors-namespace-convention.md
@@ -1,0 +1,29 @@
+# ADR 0015: Public CORS Namespace Convention over Per-Controller Declaration
+
+* **Status**: Accepted
+* **Date**: 2026-08-24
+* **Deciders**: engineering (jdoucy)
+* **Scope**: API CORS policy selection — `apps/api/src/config/cors.ts`, `PUBLIC_PATH_PREFIX` in api-contracts
+
+---
+
+## Decision
+
+The API runs two CORS policies, selected per request by a path prefix (see #366): paths under the public namespace reflect the request origin (embed widget, secured by `EmbedTokenGuard`), every other path pins origins to `FRONTEND_URL`.
+
+The public namespace is a **convention**: every open-CORS endpoint lives under the `PUBLIC_PATH_PREFIX` constant exported by `api-contracts`. Route files build their paths from that constant, and the CORS delegate matches on it. One source of truth, no duplicated string between route definitions and bootstrap.
+
+## Rejected alternative: per-controller CORS declaration
+
+A decorator such as `@PublicCors()` on the controller, collected at bootstrap via `DiscoveryService`/`MetadataScanner`, was considered and rejected:
+
+- CORS must answer the `OPTIONS` preflight **before** Nest routing. No guard or interceptor sees the preflight, so the decision is always taken on the raw path by a middleware. A decorator cannot change that; it can only feed the same path list through reflection machinery.
+- The scan would produce exactly what the convention already provides: a list of path prefixes consulted by the delegate. For two controllers, the machinery does not pay for itself.
+
+Revisit if an endpoint ever needs open CORS **outside** the public namespace. That change breaks the convention and justifies the per-controller declaration in its own ADR.
+
+## Consequences
+
+- A new public endpoint must define its route under `PUBLIC_PATH_PREFIX` in api-contracts. Nothing else to register: CORS follows the path.
+- Renaming the public namespace is a one-constant change, but it is a breaking change for deployed embed snippets — do not rename it casually.
+- `main.ts` knows no path strings; it only wires `buildCorsOptionsDelegate(frontendUrls)`.

--- a/docs/adr/0015-public-cors-namespace-convention.md
+++ b/docs/adr/0015-public-cors-namespace-convention.md
@@ -15,10 +15,10 @@ The public namespace is a **convention**: every open-CORS endpoint lives under t
 
 ## Rejected alternative: per-controller CORS declaration
 
-A decorator such as `@PublicCors()` on the controller, collected at bootstrap via `DiscoveryService`/`MetadataScanner`, was considered and rejected:
+A `@PublicCors()` decorator on the controller was considered and rejected. Two distinct points:
 
-- CORS must answer the `OPTIONS` preflight **before** Nest routing. No guard or interceptor sees the preflight, so the decision is always taken on the raw path by a middleware. A decorator cannot change that; it can only feed the same path list through reflection machinery.
-- The scan would produce exactly what the convention already provides: a list of path prefixes consulted by the delegate. For two controllers, the machinery does not pay for itself.
+- **Request-time enforcement is impossible.** The `OPTIONS` preflight never reaches the controller handler, so nothing attached to the controller at request time (guard, interceptor, metadata read by a guard) runs on it. The CORS decision is always taken on the raw path by a middleware, before Nest routing.
+- **Bootstrap-time collection works but does not pay for itself.** The viable variant scans decorated controllers at startup (`DiscoveryService`/`MetadataScanner`), collects their paths, and hands the list to the middleware delegate. Its end product is exactly what the convention already provides — a list of path prefixes consulted by the delegate — at the cost of reflection machinery, for two controllers.
 
 Revisit if an endpoint ever needs open CORS **outside** the public namespace. That change breaks the convention and justifies the per-controller declaration in its own ADR.
 

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -87,7 +87,7 @@ export type * from "./projects/projects.dto"
 export { ProjectsRoutes } from "./projects/projects.routes"
 // Public Chat (anonymous embed access)
 export type * from "./public-chat/public-chat.dto"
-export { PublicChatRoutes } from "./public-chat/public-chat.routes"
+export { PUBLIC_PATH_PREFIX, PublicChatRoutes } from "./public-chat/public-chat.routes"
 // RBAC
 export * from "./rbac/permissions"
 // Resource Libraries

--- a/packages/api-contracts/src/public-chat/public-chat.routes.ts
+++ b/packages/api-contracts/src/public-chat/public-chat.routes.ts
@@ -10,7 +10,15 @@ import type {
 // SSE streaming responses do not follow the usual ResponseData<T> shape.
 export type PublicChatStreamResponse = unknown
 
-const agentBasePath = "public/agents/:embedToken"
+/**
+ * Namespace for endpoints callable from arbitrary host pages (embed widget).
+ * The API selects its open CORS policy on this prefix (ADR 0015), and their
+ * security is enforced by EmbedTokenGuard, not by CORS. Renaming it breaks
+ * deployed embed snippets.
+ */
+export const PUBLIC_PATH_PREFIX = "public"
+
+const agentBasePath = `${PUBLIC_PATH_PREFIX}/agents/:embedToken`
 const sessionBasePath = `${agentBasePath}/sessions/:sessionId`
 
 export const PublicChatRoutes = {


### PR DESCRIPTION
Closes #366

## Summary

The API reflected any request origin on every endpoint with `credentials: true`. This splits CORS into two policies, selected per request by a delegate:

- `/public/*` (embed widget) keeps reflecting the origin — security is enforced by `EmbedTokenGuard` (embed token + per-config allowedOrigins), not CORS.
- Everything else pins origins to `FRONTEND_URL`. This also covers the one cookie-authenticated surface (Bull Board's OIDC session).
- Credentialed CORS is dropped: no caller sends cookies or uses `credentials: 'include'` (verified across apps/web and the embed).

The previously dead `parseFrontendUrls` call in `main.ts` (first point of the issue) becomes the real origin list. The logic moves to `src/config/cors.ts` with an 11-test spec (parsing, public/strict split, the `/publications` look-alike trap, no credentials). In production, an unset or blank `FRONTEND_URL` throws at bootstrap: the Cloud Run revision fails and the previous one keeps serving, instead of a healthy API that silently blocks every platform call.

## ⚠️ Before merging

The deploy is dispatched to the infra repo — verify `FRONTEND_URL` is set on the Cloud Run service there. If it is unset, the API refuses to start.

## Test plan

- `npx jest src/config/cors.spec.ts` — 11 tests green
- `make tests-parallel` — full suite green
- typecheck + biome green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
