### PR TITLE
feat(retention): purge embed sessions and clear their visitor id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
-- Conversation retention (GDPR): conversations are now kept 30 days by default, on every workspace; a periodic job erases the content of older conversations (messages, tool calls, titles, form state, feedback text, attachments) and their Langfuse traces, while conversation counts, categories and feedback votes remain available in analytics. Workspace admins can change the duration, or clear it to keep conversations forever, in the workspace settings
+- Conversation retention (GDPR): conversations are now kept 30 days by default, on every workspace; a periodic job erases the content of older conversations (messages, tool calls, titles, form state, feedback text, attachments) and their Langfuse traces, while conversation counts, categories and feedback votes remain available in analytics. Workspace admins can change the duration, or clear it to keep conversations forever, in the workspace settings. Embed (public widget) conversations follow the same retention: their content is erased on the same schedule and the external visitor identifier is cleared, so a purged session no longer links to a person
 - (beta) Gemma and MedGemma agents accept PDF documents in chat and extraction.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
-- Conversation retention (GDPR). The platform keeps conversations for 30 days by default. Each day, a job erases the content of older conversations: messages, tool calls, titles, form state, feedback text, attachments, and Langfuse traces. Analytics keep the conversation counts, the categories, and the feedback votes. Workspace admins can change the number of days in the workspace settings. An empty value keeps conversations forever. Embed conversations follow the same rule. The purge also erases the external visitor identifier.
+- Conversation retention: conversations are now kept 30 days by default, configurable per workspace.
 - (beta) Gemma and MedGemma agents accept PDF documents in chat and extraction.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
-- Conversation retention (GDPR): conversations are now kept 30 days by default, on every workspace; a periodic job erases the content of older conversations (messages, tool calls, titles, form state, feedback text, attachments) and their Langfuse traces, while conversation counts, categories and feedback votes remain available in analytics. Workspace admins can change the duration, or clear it to keep conversations forever, in the workspace settings. Embed (public widget) conversations follow the same retention: their content is erased on the same schedule and the external visitor identifier is cleared, so a purged session no longer links to a person
+- Conversation retention (GDPR). The platform keeps conversations for 30 days by default. Each day, a job erases the content of older conversations: messages, tool calls, titles, form state, feedback text, attachments, and Langfuse traces. Analytics keep the conversation counts, the categories, and the feedback votes. Workspace admins can change the number of days in the workspace settings. An empty value keeps conversations forever. Embed conversations follow the same rule. The purge also erases the external visitor identifier.
 - (beta) Gemma and MedGemma agents accept PDF documents in chat and extraction.
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,15 @@ All commands should be run from the root directory using Turbo (via npm scripts)
 - Private packages with internal dependencies using `*` version specifier
 - Engines requirement: Node.js >= 18
 
+## Changelog
+
+Any edit to `CHANGELOG.md` follows the `end-feature` skill rules, whether or not that skill is invoked. The two that get violated most:
+
+- **One sentence per entry**, max 20 words. Never chain clauses with ";", "—", or "so". No sub-bullets.
+- **Write for end users**: name the capability, not the mechanics (no entities, services, migrations, jobs, or column names).
+
+Target shape: `Conversation retention: conversations are now kept 30 days by default, configurable per workspace.`
+
 ## Git
 
 - Use semantic commit messages consistent with the repo history: `feat: ...`, `fix: ...`, `chore: ...`.

--- a/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.spec.ts
@@ -4,10 +4,18 @@ import {
   setupE2eTestDatabase,
   teardownE2eTestDatabase,
 } from "@/common/test/test-database"
+import { agentFactory } from "@/domains/agents/agent.factory"
+import type { ConversationAgentSession } from "@/domains/agents/conversation-agent-sessions/conversation-agent-session.entity"
+import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
 import { agentMessageFactory } from "@/domains/agents/shared/agent-session-messages/agent-messages.factory"
 import { agentMessageFeedbackFactory } from "@/domains/agents/shared/agent-session-messages/feedback/agent-message-feedback.factory"
 import type { IFileStorage } from "@/domains/documents/storage/file-storage.interface"
-import { createOrganizationWithAgentMessage } from "@/domains/organizations/organization.factory"
+import {
+  createOrganizationWithAgentMessage,
+  createOrganizationWithProject,
+} from "@/domains/organizations/organization.factory"
+import { agentEmbedConfigFactory } from "@/domains/public-chat/agent-embed-configs/agent-embed-config.factory"
+import { publicAgentSessionFactory } from "@/domains/public-chat/public-agent-sessions/public-agent-session.factory"
 import { ConversationAgentSessionPurgeService } from "./conversation-agent-session-purge.service"
 
 describe("ConversationAgentSessionPurgeService", () => {
@@ -113,5 +121,69 @@ describe("ConversationAgentSessionPurgeService", () => {
   it("returns purged false for an unknown session", async () => {
     const { purged } = await service.purgeSessionContent("00000000-0000-0000-0000-000000000000")
     expect(purged).toBe(false)
+  })
+
+  const createPurgeablePublicSession = async () => {
+    const { organization, project } = await createOrganizationWithProject(repositories)
+    const agent = agentFactory.transient({ organization, project }).build()
+    await repositories.agentRepository.save(agent)
+    const agentSettings = agentSettingsFactory.transient({ organization, project, agent }).build()
+    await repositories.agentSettingsRepository.save(agentSettings)
+    const embedConfig = agentEmbedConfigFactory
+      .transient({ organization, project, agent })
+      .build({ isEnabled: true })
+    await repositories.agentEmbedConfigRepository.save(embedConfig)
+
+    const publicSession = publicAgentSessionFactory.transient({ embedConfig }).build({
+      title: "Embed session title",
+      result: { field: "embed value" },
+      externalVisitorId: "visitor-42",
+    })
+    await repositories.publicAgentSessionRepository.save(publicSession)
+
+    const publicMessage = agentMessageFactory
+      .user()
+      .transient({
+        organization,
+        project,
+        session: publicSession as unknown as ConversationAgentSession,
+        agentSettings,
+      })
+      .build({
+        content: "A visitor question with personal data",
+        toolCalls: [{ id: "tool-1", name: "lookup", arguments: { query: "sample" } }],
+      })
+    await repositories.agentMessageRepository.save(publicMessage)
+
+    return { publicSession, publicMessage }
+  }
+
+  it("purges a public session: content and visitor id go, rows and categories stay", async () => {
+    const { publicSession, publicMessage } = await createPurgeablePublicSession()
+
+    const { purged } = await service.purgePublicSessionContent(publicSession.id)
+    expect(purged).toBe(true)
+
+    const message = await repositories.agentMessageRepository.findOneByOrFail({
+      id: publicMessage.id,
+    })
+    expect(message.content).toBe("")
+    expect(message.toolCalls).toBeNull()
+
+    const session = await repositories.publicAgentSessionRepository.findOneByOrFail({
+      id: publicSession.id,
+    })
+    expect(session.title).toBeNull()
+    expect(session.result).toBeNull()
+    expect(session.externalVisitorId).toBeNull()
+    expect(session.purgedAt).not.toBeNull()
+    expect(session.createdAt).toEqual(publicSession.createdAt)
+  })
+
+  it("public purge is idempotent: a second run does nothing", async () => {
+    const { publicSession } = await createPurgeablePublicSession()
+    await service.purgePublicSessionContent(publicSession.id)
+    const secondRun = await service.purgePublicSessionContent(publicSession.id)
+    expect(secondRun.purged).toBe(false)
   })
 })

--- a/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from "@nestjs/common"
 import { InjectDataSource } from "@nestjs/typeorm"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
-import { DataSource, In } from "typeorm"
+import { DataSource, type EntityManager, In } from "typeorm"
 import {
   FILE_STORAGE_SERVICE,
   type IFileStorage,
@@ -34,46 +34,8 @@ export class ConversationAgentSessionPurgeService {
       })
       if (!session || session.purgedAt) return false
 
-      const messages = await entityManager.find(AgentMessage, {
-        where: { sessionId },
-        select: { id: true, documentId: true, attachmentDocumentId: true },
-      })
-      const messageIds = messages.map((message) => message.id)
+      attachmentStoragePaths.push(...(await this.purgeSessionMessages(entityManager, sessionId)))
 
-      if (messageIds.length > 0) {
-        // Feedback free text is user content; the row and its vote stay for stats.
-        await entityManager.update(
-          AgentMessageFeedback,
-          { agentMessageId: In(messageIds) },
-          { content: "" },
-        )
-      }
-
-      const attachmentDocumentIds = messages
-        .map((message) => message.attachmentDocumentId)
-        .filter((id): id is string => Boolean(id))
-      if (attachmentDocumentIds.length > 0) {
-        const attachments = await entityManager.find(AgentMessageAttachmentDocument, {
-          where: { id: In(attachmentDocumentIds) },
-        })
-        attachmentStoragePaths.push(
-          ...attachments.map((attachment) => attachment.storageRelativePath),
-        )
-        await entityManager.delete(AgentMessageAttachmentDocument, {
-          id: In(attachmentDocumentIds),
-        })
-      }
-
-      const generatedDocumentIds = messages
-        .map((message) => message.documentId)
-        .filter((id): id is string => Boolean(id))
-      if (generatedDocumentIds.length > 0) {
-        // Deleted by entity name: importing the Document entity here would be a
-        // cross-domain entity import (no-cross-domain-entity-import).
-        await entityManager.delete("Document", { id: In(generatedDocumentIds) })
-      }
-
-      await entityManager.update(AgentMessage, { sessionId }, { content: "", toolCalls: null })
       await entityManager.update(
         ConversationAgentSession,
         { id: sessionId },
@@ -82,8 +44,96 @@ export class ConversationAgentSessionPurgeService {
       return true
     })
 
-    // Storage cleanup happens after commit: a storage hiccup must not resurrect
-    // the DB content, and a missing file is not an error.
+    await this.deleteAttachmentFiles(attachmentStoragePaths, sessionId)
+    return { purged }
+  }
+
+  /**
+   * Same purge for an embed (public) session: the session row, its categories
+   * and timestamps stay for stats, but externalVisitorId is also cleared so
+   * the purged session no longer links to a person.
+   */
+  async purgePublicSessionContent(sessionId: string): Promise<{ purged: boolean }> {
+    const attachmentStoragePaths: string[] = []
+
+    const purged = await this.dataSource.transaction(async (entityManager) => {
+      // Loaded by entity name: importing the PublicAgentSession entity here
+      // would be a cross-domain entity import (no-cross-domain-entity-import).
+      const session = (await entityManager.findOne("PublicAgentSession", {
+        where: { id: sessionId },
+      })) as { id: string; purgedAt: Date | null } | null
+      if (!session || session.purgedAt) return false
+
+      attachmentStoragePaths.push(...(await this.purgeSessionMessages(entityManager, sessionId)))
+
+      await entityManager.update(
+        "PublicAgentSession",
+        { id: sessionId },
+        { title: null, result: null, externalVisitorId: null, purgedAt: new Date() },
+      )
+      return true
+    })
+
+    await this.deleteAttachmentFiles(attachmentStoragePaths, sessionId)
+    return { purged }
+  }
+
+  /** Empties the messages of a session; returns the storage paths of deleted attachments. */
+  private async purgeSessionMessages(
+    entityManager: EntityManager,
+    sessionId: string,
+  ): Promise<string[]> {
+    const attachmentStoragePaths: string[] = []
+
+    const messages = await entityManager.find(AgentMessage, {
+      where: { sessionId },
+      select: { id: true, documentId: true, attachmentDocumentId: true },
+    })
+    const messageIds = messages.map((message) => message.id)
+
+    if (messageIds.length > 0) {
+      // Feedback free text is user content; the row and its vote stay for stats.
+      await entityManager.update(
+        AgentMessageFeedback,
+        { agentMessageId: In(messageIds) },
+        { content: "" },
+      )
+    }
+
+    const attachmentDocumentIds = messages
+      .map((message) => message.attachmentDocumentId)
+      .filter((id): id is string => Boolean(id))
+    if (attachmentDocumentIds.length > 0) {
+      const attachments = await entityManager.find(AgentMessageAttachmentDocument, {
+        where: { id: In(attachmentDocumentIds) },
+      })
+      attachmentStoragePaths.push(
+        ...attachments.map((attachment) => attachment.storageRelativePath),
+      )
+      await entityManager.delete(AgentMessageAttachmentDocument, {
+        id: In(attachmentDocumentIds),
+      })
+    }
+
+    const generatedDocumentIds = messages
+      .map((message) => message.documentId)
+      .filter((id): id is string => Boolean(id))
+    if (generatedDocumentIds.length > 0) {
+      // Deleted by entity name: importing the Document entity here would be a
+      // cross-domain entity import (no-cross-domain-entity-import).
+      await entityManager.delete("Document", { id: In(generatedDocumentIds) })
+    }
+
+    await entityManager.update(AgentMessage, { sessionId }, { content: "", toolCalls: null })
+    return attachmentStoragePaths
+  }
+
+  // Storage cleanup happens after commit: a storage hiccup must not resurrect
+  // the DB content, and a missing file is not an error.
+  private async deleteAttachmentFiles(
+    attachmentStoragePaths: string[],
+    sessionId: string,
+  ): Promise<void> {
     for (const storageRelativePath of attachmentStoragePaths) {
       try {
         await this.fileStorage.deleteFile(storageRelativePath)
@@ -93,7 +143,5 @@ export class ConversationAgentSessionPurgeService {
         )
       }
     }
-
-    return { purged }
   }
 }

--- a/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-retention-sweep.service.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-retention-sweep.service.spec.ts
@@ -5,6 +5,16 @@ import type { ConversationAgentSessionPurgeService } from "./conversation-agent-
 import { ConversationRetentionSweepService } from "./conversation-retention-sweep.service"
 
 function buildService(...batches: Partial<ConversationAgentSession>[][]) {
+  return buildServiceWithPublicBatches({ batches, publicBatches: [] })
+}
+
+function buildServiceWithPublicBatches({
+  batches,
+  publicBatches,
+}: {
+  batches: Partial<ConversationAgentSession>[][]
+  publicBatches: { id: string }[][]
+}) {
   const getMany = jest.fn().mockResolvedValue([])
   for (const batch of batches) getMany.mockResolvedValueOnce(batch)
   const queryBuilder = {
@@ -15,11 +25,25 @@ function buildService(...batches: Partial<ConversationAgentSession>[][]) {
     limit: jest.fn().mockReturnThis(),
     getMany,
   }
+  const getRawMany = jest.fn().mockResolvedValue([])
+  for (const batch of publicBatches) getRawMany.mockResolvedValueOnce(batch)
+  const rawQueryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getRawMany,
+  }
   const sessionRepository = {
     createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    manager: { createQueryBuilder: jest.fn().mockReturnValue(rawQueryBuilder) },
   } as unknown as Repository<ConversationAgentSession>
   const purgeService = {
     purgeSessionContent: jest.fn().mockResolvedValue({ purged: true }),
+    purgePublicSessionContent: jest.fn().mockResolvedValue({ purged: true }),
   }
   const langfuseAdminService = {
     deleteTrace: jest.fn().mockResolvedValue(true),
@@ -81,5 +105,33 @@ describe("ConversationRetentionSweepService", () => {
 
     expect(purgedCount).toBe(201)
     expect(purgeService.purgeSessionContent).toHaveBeenCalledTimes(201)
+  })
+
+  it("purges expired public sessions and deletes their trace by session id", async () => {
+    const { service, purgeService, langfuseAdminService } = buildServiceWithPublicBatches({
+      batches: [],
+      publicBatches: [[{ id: "public-1" }, { id: "public-2" }]],
+    })
+
+    const { purgedCount } = await service.sweepExpiredConversations()
+
+    expect(purgedCount).toBe(2)
+    expect(purgeService.purgePublicSessionContent).toHaveBeenCalledTimes(2)
+    expect(langfuseAdminService.deleteTrace).toHaveBeenCalledWith("public-1")
+    expect(langfuseAdminService.deleteTrace).toHaveBeenCalledWith("public-2")
+  })
+
+  it("counts internal and public sessions together and skips unpurged public ones", async () => {
+    const { service, purgeService, langfuseAdminService } = buildServiceWithPublicBatches({
+      batches: [[{ id: "session-1", traceId: "trace-1" }]],
+      publicBatches: [[{ id: "public-1" }]],
+    })
+    purgeService.purgePublicSessionContent.mockResolvedValue({ purged: false })
+
+    const { purgedCount } = await service.sweepExpiredConversations()
+
+    expect(purgedCount).toBe(1)
+    expect(langfuseAdminService.deleteTrace).toHaveBeenCalledTimes(1)
+    expect(langfuseAdminService.deleteTrace).toHaveBeenCalledWith("trace-1")
   })
 })

--- a/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-retention-sweep.service.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-retention-sweep.service.ts
@@ -31,10 +31,24 @@ export class ConversationRetentionSweepService {
       if (expiredSessions.length < CONVERSATION_RETENTION_SWEEP_BATCH_LIMIT) break
     }
 
+    purgedCount += await this.sweepExpiredPublicSessions()
+
     if (purgedCount > 0) {
       this.logger.log(`Retention sweep purged ${purgedCount} conversation session(s).`)
     }
     return { purgedCount }
+  }
+
+  /** Embed (public) sessions follow the same per-project retention rule. */
+  private async sweepExpiredPublicSessions(): Promise<number> {
+    let purgedCount = 0
+    for (let batch = 0; batch < CONVERSATION_RETENTION_SWEEP_MAX_BATCHES_PER_RUN; batch++) {
+      const expiredSessions = await this.findExpiredPublicSessionsBatch()
+      if (expiredSessions.length === 0) break
+      purgedCount += await this.purgePublicBatch(expiredSessions)
+      if (expiredSessions.length < CONVERSATION_RETENTION_SWEEP_BATCH_LIMIT) break
+    }
+    return purgedCount
   }
 
   private async findExpiredSessionsBatch(): Promise<ConversationAgentSession[]> {
@@ -55,26 +69,61 @@ export class ConversationRetentionSweepService {
     )
   }
 
+  // Queried by table name: importing the PublicAgentSession entity here would
+  // be a cross-domain entity import (no-cross-domain-entity-import). A raw
+  // FROM also skips the soft-delete filter, hence the deleted_at clause.
+  private async findExpiredPublicSessionsBatch(): Promise<{ id: string }[]> {
+    return this.sessionRepository.manager
+      .createQueryBuilder()
+      .select("session.id", "id")
+      .from("public_agent_session", "session")
+      .innerJoin("project", "project", "project.id = session.project_id")
+      .where("project.conversation_retention_days IS NOT NULL")
+      .andWhere("session.purged_at IS NULL")
+      .andWhere("session.deleted_at IS NULL")
+      .andWhere(
+        "session.created_at < now() - (project.conversation_retention_days * interval '1 day')",
+      )
+      .orderBy("session.created_at", "ASC")
+      .limit(CONVERSATION_RETENTION_SWEEP_BATCH_LIMIT)
+      .getRawMany()
+  }
+
   private async purgeBatch(expiredSessions: ConversationAgentSession[]): Promise<number> {
     let purgedCount = 0
     for (const session of expiredSessions) {
       const { purged } = await this.purgeService.purgeSessionContent(session.id)
       if (!purged) continue
       purgedCount += 1
-
-      if (session.traceId) {
-        try {
-          await this.langfuseAdminService.deleteTrace(session.traceId)
-        } catch (error) {
-          // DB content is already purged; the trace retries on the next sweep
-          // is not possible (purged_at is set), so log loudly for follow-up.
-          this.logger.error(
-            `Langfuse trace deletion failed for session ${session.id} (trace ${session.traceId}): ${(error as Error).message}`,
-          )
-        }
-      }
+      await this.deleteTrace(session.id, session.traceId)
     }
 
     return purgedCount
+  }
+
+  private async purgePublicBatch(expiredSessions: { id: string }[]): Promise<number> {
+    let purgedCount = 0
+    for (const session of expiredSessions) {
+      const { purged } = await this.purgeService.purgePublicSessionContent(session.id)
+      if (!purged) continue
+      purgedCount += 1
+      // Public streaming uses the session id as the Langfuse trace id.
+      await this.deleteTrace(session.id, session.id)
+    }
+
+    return purgedCount
+  }
+
+  private async deleteTrace(sessionId: string, traceId: string | null): Promise<void> {
+    if (!traceId) return
+    try {
+      await this.langfuseAdminService.deleteTrace(traceId)
+    } catch (error) {
+      // DB content is already purged; the trace retries on the next sweep
+      // is not possible (purged_at is set), so log loudly for follow-up.
+      this.logger.error(
+        `Langfuse trace deletion failed for session ${sessionId} (trace ${traceId}): ${(error as Error).message}`,
+      )
+    }
   }
 }

--- a/apps/api/src/domains/public-chat/public-agent-sessions/public-agent-session.entity.ts
+++ b/apps/api/src/domains/public-chat/public-agent-sessions/public-agent-session.entity.ts
@@ -35,6 +35,12 @@ export class PublicAgentSession extends Base4AllEntity {
   @Column({ type: "jsonb", name: "result", nullable: true })
   result!: Record<string, unknown> | null
 
+  // Set when the retention sweep purged this session's content (GDPR). The
+  // session and message rows survive for analytics; content fields are emptied
+  // and externalVisitorId is cleared so no link to a person remains.
+  @Column({ type: "timestamp", nullable: true, name: "purged_at" })
+  purgedAt!: Date | null
+
   @OneToMany(
     () => PublicAgentSessionCategory,
     (sessionCategory) => sessionCategory.publicAgentSession,

--- a/apps/api/src/domains/public-chat/public-agent-sessions/public-agent-session.factory.ts
+++ b/apps/api/src/domains/public-chat/public-agent-sessions/public-agent-session.factory.ts
@@ -33,6 +33,7 @@ export const publicAgentSessionFactory = PublicAgentSessionFactory.define(
       lastActivityAt: params.lastActivityAt ?? now,
       title: params.title ?? null,
       result: (params.result as Record<string, unknown> | null) ?? null,
+      purgedAt: params.purgedAt ?? null,
       sessionCategories: [],
       createdAt: params.createdAt ?? now,
       updatedAt: params.updatedAt ?? now,

--- a/apps/api/src/migrations/1787757957304-public-agent-session-purged-at.ts
+++ b/apps/api/src/migrations/1787757957304-public-agent-session-purged-at.ts
@@ -1,0 +1,13 @@
+import type { MigrationInterface, QueryRunner } from "typeorm"
+
+export class PublicAgentSessionPurgedAt1787757957304 implements MigrationInterface {
+  name = "PublicAgentSessionPurgedAt1787757957304"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "public_agent_session" ADD "purged_at" TIMESTAMP`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "public_agent_session" DROP COLUMN "purged_at"`)
+  }
+}


### PR DESCRIPTION
Follow-up to #587, second part of #626 (decided during the GDPR questionnaire review). This commit was pushed to the #587 branch minutes after its auto-merge fired, so it needed its own PR.

The retention sweep now also covers `public_agent_session` (embed widget):

- same per-project `conversation_retention_days` rule, queried by table name to respect domain boundaries
- same blanked fields: message `content` and `tool_calls`, session `title` and `result`, `purged_at` stamped (idempotent)
- same Langfuse trace deletion (the public trace id is the session id)
- `external_visitor_id` set to null in the same transaction, so a purged session no longer links to a person
- the session row, its categories and timestamps stay for statistics
- migration adds `purged_at` to `public_agent_session` (down tested by revert/re-run)

Specs: purge spec covers the public path (content, visitor id, idempotence), sweep spec covers the public batch and combined counting.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)