### PR TITLE
fix(api): preserve image parts in the MedGemma streaming chat path

### DIFF
--- a/apps/api/src/external/llm/providers/medgemma/custom-med-gemma-language-model.spec.ts
+++ b/apps/api/src/external/llm/providers/medgemma/custom-med-gemma-language-model.spec.ts
@@ -25,6 +25,26 @@ describe("CustomMedGemmaLanguageModel", () => {
       { status: 200 },
     )
 
+  const streamingChatCompletionsResponse = () => {
+    const answer = JSON.stringify({ type: "answer", content: "ok" })
+    const sse = [
+      `data: ${JSON.stringify({
+        choices: [{ delta: { content: answer }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      })}`,
+      "data: [DONE]",
+      "",
+    ].join("\n")
+    return new Response(sse, { status: 200 })
+  }
+
+  const drain = async (stream: ReadableStream<unknown>) => {
+    const reader = stream.getReader()
+    while (!(await reader.read()).done) {
+      // consume the stream so the SSE parsing in `start` completes
+    }
+  }
+
   afterEach(() => {
     jest.restoreAllMocks()
   })
@@ -69,6 +89,35 @@ describe("CustomMedGemmaLanguageModel", () => {
     const base64 = Buffer.from([1, 2, 3]).toString("base64")
     expect(body.messages[0].content).toEqual([
       { type: "image_url", image_url: { url: `data:image/jpeg;base64,${base64}` } },
+    ])
+  })
+
+  it("preserves image parts in the streaming chat path (doStreamWithTools)", async () => {
+    const fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(streamingChatCompletionsResponse())
+    const imageUrl =
+      "https://storage.googleapis.com/bucket/org/project/derived/doc/page-1.png?X-Goog-Signature=abc"
+
+    const { stream } = await buildModel().doStream({
+      prompt: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this document" },
+            { type: "file", mediaType: "image/png", data: new URL(imageUrl) },
+          ],
+        },
+      ],
+      providerOptions: { custom: { callOrigin: CallOrigin.streamChatResponse_withTools } },
+    })
+    await drain(stream)
+
+    const [, calledInit] = fetchSpy.mock.calls[0]!
+    const body = JSON.parse(String(calledInit?.body))
+    expect(body.messages[0].content).toEqual([
+      { type: "text", text: "Describe this document" },
+      { type: "image_url", image_url: { url: imageUrl } },
     ])
   })
 

--- a/apps/api/src/external/llm/providers/medgemma/custom-med-gemma-language-model.ts
+++ b/apps/api/src/external/llm/providers/medgemma/custom-med-gemma-language-model.ts
@@ -262,14 +262,29 @@ export class CustomMedGemmaLanguageModel implements LanguageModelV3 {
           .map((c) => `<tool_result name="${c.toolName}">${JSON.stringify(c.result)}</tool_result>`)
           .join("\n")
         messages.push({ role: "user", content: resultsText })
-      } else {
-        let content = ""
-        if (Array.isArray(msg.content)) {
-          content = msg.content.map((c) => c.text || "").join("")
+      } else if (Array.isArray(msg.content)) {
+        // Image parts must reach the request body as OpenAI-style content
+        // parts; text-only messages keep the plain-string shape vLLM already
+        // handles.
+        if (msg.content.some((part) => part.type === "image_url")) {
+          const contentParts = msg.content
+            .map((part) =>
+              part.type === "image_url"
+                ? part
+                : part.text
+                  ? { type: "text", text: part.text }
+                  : undefined,
+            )
+            .filter(Boolean)
+          messages.push({ role: msg.role, content: contentParts })
         } else {
-          content = msg.content || ""
+          messages.push({
+            role: msg.role,
+            content: msg.content.map((part) => part.text || "").join(""),
+          })
         }
-        messages.push({ role: msg.role, content })
+      } else {
+        messages.push({ role: msg.role, content: msg.content || "" })
       }
     }
     return messages


### PR DESCRIPTION
## Summary

Follow-up to #675, addressing the review finding in https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088689.

`formatMessages` (used by `doStreamWithTools`, the path every MedGemma chat conversation goes through) flattened user content with `msg.content.map((c) => c.text || "").join("")`, reducing every `image_url` part to an empty string. A PDF attached to a MedGemma chat agent therefore never reached the model — it answered confidently about pages it never saw, with no error anywhere. The URL branch added in #675 only fixed `doGenerate` (structured output).

### Changes

- `formatMessages` now preserves image parts: when a user message contains `image_url` parts (signed GCS URL passthrough or base64-inlined bytes), the message is sent as OpenAI-style content parts (`{type: "text"}` / `{type: "image_url"}`) in original order. Text-only messages keep the existing plain-string shape, so already-working paths are unchanged.
- New spec asserting the request body actually transmitted by `doStreamWithTools` keeps text and image parts (written first, watched fail on the old code).

## Test plan

- `custom-med-gemma-language-model.spec.ts` (4 tests, incl. the new streaming-path assertion) ✅
- `npm run biome:check` ✅
- `npx tsc --noEmit` (apps/api) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)