### PR TITLE
fix(documents): cache GCS signed read urls to avoid re-signing every page each turn

### DIFF
--- a/apps/api/src/domains/documents/storage/gcs-storage.service.spec.ts
+++ b/apps/api/src/domains/documents/storage/gcs-storage.service.spec.ts
@@ -1,0 +1,74 @@
+import type { ConfigService } from "@nestjs/config"
+import { GcsStorageService } from "./gcs-storage.service"
+
+const getSignedUrl = jest.fn()
+
+jest.mock("@google-cloud/storage", () => ({
+  Storage: jest.fn().mockImplementation(() => ({
+    bucket: jest.fn().mockReturnValue({
+      file: jest
+        .fn()
+        .mockReturnValue({ getSignedUrl: (...args: unknown[]) => getSignedUrl(...args) }),
+    }),
+  })),
+}))
+
+describe("GcsStorageService - getTemporaryUrl signed URL cache", () => {
+  let service: GcsStorageService
+
+  const configService = {
+    get: (key: string) => (key === "GCS_STORAGE_BUCKET_NAME" ? "test-bucket" : undefined),
+  } as unknown as ConfigService
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: new Date("2026-08-31T10:00:00Z") })
+    getSignedUrl.mockReset()
+    let signatureCount = 0
+    getSignedUrl.mockImplementation(async () => {
+      signatureCount += 1
+      return [`https://storage.example.com/signed-${signatureCount}`]
+    })
+    service = new GcsStorageService(configService)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("should sign once and serve repeat requests for the same path from the cache", async () => {
+    const firstUrl = await service.getTemporaryUrl("org/proj/doc.pdf")
+    const secondUrl = await service.getTemporaryUrl("org/proj/doc.pdf")
+
+    expect(firstUrl).toBe("https://storage.example.com/signed-1")
+    expect(secondUrl).toBe(firstUrl)
+    expect(getSignedUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it("should sign each distinct path separately", async () => {
+    const pageOneUrl = await service.getTemporaryUrl("org/proj/derived/doc/page-1.png")
+    const pageTwoUrl = await service.getTemporaryUrl("org/proj/derived/doc/page-2.png")
+
+    expect(pageOneUrl).not.toBe(pageTwoUrl)
+    expect(getSignedUrl).toHaveBeenCalledTimes(2)
+  })
+
+  it("should re-sign after the cache entry expires", async () => {
+    const firstUrl = await service.getTemporaryUrl("org/proj/doc.pdf")
+
+    jest.advanceTimersByTime(10 * 60 * 1000 + 1)
+    const refreshedUrl = await service.getTemporaryUrl("org/proj/doc.pdf")
+
+    expect(refreshedUrl).not.toBe(firstUrl)
+    expect(getSignedUrl).toHaveBeenCalledTimes(2)
+  })
+
+  it("should keep serving the cached url just before the cache expiry", async () => {
+    const firstUrl = await service.getTemporaryUrl("org/proj/doc.pdf")
+
+    jest.advanceTimersByTime(10 * 60 * 1000 - 1)
+    const cachedUrl = await service.getTemporaryUrl("org/proj/doc.pdf")
+
+    expect(cachedUrl).toBe(firstUrl)
+    expect(getSignedUrl).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/api/src/domains/documents/storage/gcs-storage.service.ts
+++ b/apps/api/src/domains/documents/storage/gcs-storage.service.ts
@@ -7,11 +7,18 @@ import type { RequiredConnectScope } from "@/common/entities/connect-required-fi
 import type { MulterFile } from "@/common/types"
 import type { IFileStorage } from "./file-storage.interface"
 
+// Signed read URL cache configuration
+const SIGNED_READ_URL_LIFETIME_MS = 15 * 60 * 1000 // 15 minutes
+// Shorter than the URL lifetime so a cache hit always has at least 5 minutes of validity left.
+const SIGNED_READ_URL_CACHE_TTL_MS = 10 * 60 * 1000 // 10 minutes
+const SIGNED_READ_URL_CACHE_MAX_ENTRIES = 5000 // Maximum number of cached signed read URLs
+
 @Injectable()
 export class GcsStorageService implements IFileStorage {
   private readonly logger = new Logger(GcsStorageService.name)
   private readonly storage: Storage
   private readonly bucketName: string
+  private readonly signedReadUrlCache = new Map<string, { url: string; expiresAtMs: number }>()
 
   constructor(private readonly configService: ConfigService) {
     this.storage = new Storage({
@@ -35,6 +42,7 @@ export class GcsStorageService implements IFileStorage {
   }
 
   async deleteFile(storageRelativePath: string): Promise<void> {
+    this.signedReadUrlCache.delete(storageRelativePath)
     await this.storage
       .bucket(this.bucketName)
       .file(storageRelativePath)
@@ -54,18 +62,44 @@ export class GcsStorageService implements IFileStorage {
   }
 
   async getTemporaryUrl(storageRelativePath: string): Promise<string> {
-    // Construct the temporary URL for the file in GCS
-    // Generate a signed URL for temporary access (default: 15 minutes)
+    // With keyless (IAM-based) signing, every getSignedUrl is a signBlob HTTP call, and page-image
+    // consumers request the same objects on every turn — so cache signed read URLs per object path.
+    const cached = this.signedReadUrlCache.get(storageRelativePath)
+    if (cached && cached.expiresAtMs > Date.now()) {
+      return cached.url
+    }
+
     const bucket = this.storage.bucket(this.bucketName)
     const file = bucket.file(storageRelativePath)
-    const expires = Date.now() + 15 * 60 * 1000 // 15 minutes
     // V4: same keyless IAM signing path as the upload URLs; V2 is legacy.
     const [url] = await file.getSignedUrl({
       version: "v4",
       action: "read",
-      expires,
+      expires: Date.now() + SIGNED_READ_URL_LIFETIME_MS,
     })
+    this.cacheSignedReadUrl(storageRelativePath, url)
     return url
+  }
+
+  private cacheSignedReadUrl(storageRelativePath: string, url: string): void {
+    if (this.signedReadUrlCache.size >= SIGNED_READ_URL_CACHE_MAX_ENTRIES) {
+      const now = Date.now()
+      for (const [cachedPath, entry] of this.signedReadUrlCache) {
+        if (entry.expiresAtMs <= now) {
+          this.signedReadUrlCache.delete(cachedPath)
+        }
+      }
+      // Still full after dropping expired entries: evict oldest-inserted first.
+      while (this.signedReadUrlCache.size >= SIGNED_READ_URL_CACHE_MAX_ENTRIES) {
+        const oldestPath = this.signedReadUrlCache.keys().next().value
+        if (oldestPath === undefined) break
+        this.signedReadUrlCache.delete(oldestPath)
+      }
+    }
+    this.signedReadUrlCache.set(storageRelativePath, {
+      url,
+      expiresAtMs: Date.now() + SIGNED_READ_URL_CACHE_TTL_MS,
+    })
   }
 
   async generateSignedUploadUrl({


### PR DESCRIPTION
## Summary

Addresses the post-merge review finding on #675 (https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088840): with keyless IAM signing, every V4 `getSignedUrl` is an `iamcredentials.signBlob` HTTP call, and `getImageUrls` re-signed every page on every chat turn or extraction run — 20 signBlob calls per turn for a 20-page document.

- `GcsStorageService.getTemporaryUrl` now serves signed read URLs from an in-process TTL cache keyed by object path.
- URLs are still signed for 15 minutes but cached for 10, so a cache hit always has at least 5 minutes of validity left.
- The cache is bounded at 5000 entries: expired entries are dropped first, then oldest-inserted. `deleteFile` evicts the entry for the deleted object.
- `PdfPagesService.getImageUrls` is unchanged — it goes through `getTemporaryUrl`, so the fully-cached path now signs nothing. `LocalStorageService` does not sign, so it needs no cache.

## Testing

- New unit spec `gcs-storage.service.spec.ts` (mocked `Storage`, fake timers): sign-once-then-cache, distinct paths sign separately, cache hit just before the 10-minute TTL, re-sign after expiry.
- `npm run biome:check`, `npm run typecheck`, `npm run check:boundaries`, and `npm run test:parallel` (292 suites / 2218 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)