### PR TITLE
fix(web): materialize injected slice state before mounting route children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Agent replies no longer show a leaked internal tool-call tag; the platform hides it and still runs the tool.
 - Chat: a server error carrying no message now ends the reply with an error instead of being dropped.
 - Agent and session pages now display correctly on small screens.
+- Opening a workspace no longer intermittently shows an unexpected error page.
 
 ### Security
 

--- a/apps/web/src/common/hooks/use-init-store.ts
+++ b/apps/web/src/common/hooks/use-init-store.ts
@@ -16,6 +16,10 @@ export function useInitStore({
   useEffect(() => {
     if (!condition) return
     inject()
+    // combineSlices().inject() does not materialize the new slice state in
+    // getState() until the next dispatch — force one before children mount,
+    // otherwise their selectors read undefined slice state.
+    dispatch({ type: "@@init-store/slices-injected" })
     setDone(true)
     return () => {
       reset(dispatch)


### PR DESCRIPTION
## Summary

Fixes an intermittent `TypeError: Cannot read properties of undefined (reading 'agentId')` crash (React Router error page) when opening studio/desk/eval/tester/reviewer/backoffice routes.

**Root cause**: RTK's `combineSlices().inject()` registers a slice reducer but does **not** materialize its state into `store.getState()` until the next action is dispatched. `useInitStore` flipped `initDone` immediately after `inject()`, so route children behind the gate rendered before any dispatch and read `undefined` slice state — e.g. `selectCurrentAgentId` reading `state.currentIds.agentId` in `RestrictedAccess`. The crash was intermittent because any unrelated action landing between inject and render masked it.

**Fix**: dispatch a no-op action (`@@init-store/slices-injected`) right after `inject()` and before `setDone(true)`, forcing the root reducer to run once so every injected slice's initial state exists before children mount. Reducers ignore the unknown action type.

Verified the RTK behavior in isolation: after `inject()`, `getState().currentIds` is `undefined`; after one no-op dispatch it is `{ agentId: null }`.

Note: middleware predicates reading injected slice state on root-level actions (e.g. `hasAgentChanged`) can still see `undefined` outside the `initDone` gate — their existing optional guards remain necessary.

## Checks

- `npm run biome:check` ✅
- `npx tsc --noEmit` (apps/web) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)