### PR TITLE
fix: show MCP Servers tab labels and saved toggle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - PDF documents sent to Gemma and MedGemma agents are now converted to images by a dedicated service, so heavy PDF processing no longer slows down the platform.
 
 ### Fixed
+- (beta) The MCP Servers tab on the agent editor shows translated labels and each server's saved state.
 - Chat shows an error message instead of an empty reply when the model fails.
 - Agent replies no longer show a leaked internal tool-call tag; the platform hides it and still runs the tool.
 - Chat: a server error carrying no message now ends the reply with an error instead of being dropped.

--- a/apps/api/src/common/context/resolvers/agent-context.resolver.ts
+++ b/apps/api/src/common/context/resolvers/agent-context.resolver.ts
@@ -35,7 +35,12 @@ export class AgentContextResolver implements ContextResolver {
           organizationId: requestWithProject.organizationId,
           projectId: requestWithProject.project.id,
         },
-        relations: ["documentTags", "sessionCategories", "resourceLibraries"],
+        relations: {
+          documentTags: true,
+          sessionCategories: true,
+          resourceLibraries: true,
+          agentMcpServers: { mcpServer: true },
+        },
       })) ?? undefined
     if (!agent) throw new NotFoundException()
 

--- a/apps/api/src/domains/agents/settings/e2e-tests/get-all.spec.ts
+++ b/apps/api/src/domains/agents/settings/e2e-tests/get-all.spec.ts
@@ -16,6 +16,8 @@ import {
 import { removeNullish } from "@/common/utils/remove-nullish"
 import { agentFactory } from "@/domains/agents/agent.factory"
 import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
+import { agentMcpServerFactory } from "@/domains/mcp-servers/agent-mcp-server.factory"
+import { mcpServerFactory } from "@/domains/mcp-servers/mcp-server.factory"
 import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
 import { sdk } from "@/external/llm/open-telemetry-init"
 import { setupUserGuardForTesting } from "../../../../../test/e2e.helpers"
@@ -187,6 +189,23 @@ describe("Agent Settings - getAll", () => {
       updatedAt: storedRevision2.updatedAt.getTime(),
       priorityCallsEnabled: false,
     })
+  })
+
+  it("should include enabled MCP servers on each revision", async () => {
+    const { project, agent } = await createContext()
+
+    const mcpServer = mcpServerFactory.build({ name: "Helpful Tools", projectId: project.id })
+    await repositories.mcpServerRepository.save(mcpServer)
+    await repositories.agentMcpServerRepository.save(
+      agentMcpServerFactory.transient({ agent, mcpServer }).build(),
+    )
+
+    const response = await subject()
+
+    expectResponse(response, 200)
+    expect(response.body.data[0]?.mcpServers).toEqual([
+      { id: mcpServer.id, name: "Helpful Tools", enabled: true },
+    ])
   })
 
   it("should omit archived revisions from the history", async () => {

--- a/apps/web/src/studio/features/agents/agent-settings/components/tabs/McpServersTab.tsx
+++ b/apps/web/src/studio/features/agents/agent-settings/components/tabs/McpServersTab.tsx
@@ -61,8 +61,8 @@ export function McpServersTab({
           <EmptyMedia variant="icon">
             <ServerIcon />
           </EmptyMedia>
-          <EmptyTitle>{t("agent:mcpServers.emptyTitle")}</EmptyTitle>
-          <EmptyDescription>{t("agent:mcpServers.emptyDescription")}</EmptyDescription>
+          <EmptyTitle>{t("agentSettings:mcpServers.emptyTitle")}</EmptyTitle>
+          <EmptyDescription>{t("agentSettings:mcpServers.emptyDescription")}</EmptyDescription>
         </EmptyHeader>
       </Empty>
     )
@@ -71,14 +71,14 @@ export function McpServersTab({
   return (
     <FieldGroup>
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium">{t("agent:mcpServers.label")}</span>
+        <span className="text-sm font-medium">{t("agentSettings:mcpServers.label")}</span>
         <Link
           to={managerPath}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
-          {t("agent:mcpServers.manage")}
+          {t("agentSettings:mcpServers.manage")}
           <ExternalLinkIcon className="size-3.5" />
         </Link>
       </div>

--- a/apps/web/src/studio/features/mcp-servers/mcp-servers.middleware.ts
+++ b/apps/web/src/studio/features/mcp-servers/mcp-servers.middleware.ts
@@ -1,5 +1,5 @@
 import { createListenerMiddleware, isAnyOf } from "@reduxjs/toolkit"
-import { listAgents } from "@/common/features/agents/agents.thunks"
+import { listAgentSettings } from "@/common/features/agents/agent-settings/agent-settings.thunks"
 import { notificationsActions } from "@/common/features/notifications/notifications.slice"
 import { projectsActions } from "@/common/features/projects/projects.slice"
 import type { AppDispatch, RootState } from "@/common/store/types"
@@ -69,8 +69,8 @@ function registerListeners() {
   })
   listenerMiddleware.startListening({
     actionCreator: enableMcpServerForAgent.fulfilled,
-    effect: async (_, listenerApi) => {
-      listenerApi.dispatch(listAgents())
+    effect: async (action, listenerApi) => {
+      listenerApi.dispatch(listAgentSettings({ agentId: action.meta.arg.agentId }))
       listenerApi.dispatch(
         notificationsActions.show({ title: "MCP server enabled", type: "success" }),
       )
@@ -79,8 +79,8 @@ function registerListeners() {
 
   listenerMiddleware.startListening({
     actionCreator: disableMcpServerForAgent.fulfilled,
-    effect: async (_, listenerApi) => {
-      listenerApi.dispatch(listAgents())
+    effect: async (action, listenerApi) => {
+      listenerApi.dispatch(listAgentSettings({ agentId: action.meta.arg.agentId }))
       listenerApi.dispatch(
         notificationsActions.show({ title: "MCP server disabled", type: "success" }),
       )


### PR DESCRIPTION
## Summary
- Fixes raw `mcpServers.label` / `mcpServers.manage` keys on the agent editor MCP Servers tab by looking them up in the `agentSettings` namespace.
- Loads the agent's MCP server links when fetching settings, so each toggle matches the saved on/off state.
- After enabling or disabling a server, refetches agent settings so the switches update immediately.

Fixes https://github.com/bayesimpact/bayes-platform/issues/682

## Test plan
- [ ] Open a conversation agent with the MCP feature and at least one project MCP server.
- [ ] MCP Servers tab shows translated "MCP Servers" / "Manage servers" (EN and FR).
- [ ] A server already enabled for the agent shows an on toggle.
- [ ] Toggling a server on or off updates the switch without a reload, and the state persists after refresh.


Made with [Cursor](https://cursor.com)