### PR TITLE
refactor(llm): build pdf page image parts without side-effect map

### DIFF
--- a/apps/api/src/domains/agents/extraction-agent-sessions/extraction-agent-session-runner.service.ts
+++ b/apps/api/src/domains/agents/extraction-agent-sessions/extraction-agent-session-runner.service.ts
@@ -246,7 +246,11 @@ export class ExtractionAgentSessionRunnerService extends ServiceWithLLM {
             fileStorageService: this.fileStorageService,
           })
           const content = llmMessage.content as Array<ImagePart>
-          imageUrls.map((url) => content.push({ type: "image", image: new URL(url) }))
+          content.push(
+            ...imageUrls.map(
+              (imageUrl): ImagePart => ({ type: "image", image: new URL(imageUrl) }),
+            ),
+          )
         } else {
           // Other models accept pdf file parts directly (signed URL; the AI
           // SDK downloads it when the provider doesn't support URLs).

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/agent-llm-request.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/agent-llm-request.service.ts
@@ -299,7 +299,11 @@ export class AgentLlmRequestService extends ServiceWithLLM {
               fileStorageService: this.fileStorageService,
             })
             const content = llmMessage.content as Array<ImagePart>
-            imageUrls.map((url) => content.push({ type: "image", image: new URL(url) }))
+            content.push(
+              ...imageUrls.map(
+                (imageUrl): ImagePart => ({ type: "image", image: new URL(imageUrl) }),
+              ),
+            )
           } else {
             // Other models accept pdf file parts directly (signed URL; the AI
             // SDK downloads it when the provider doesn't support URLs).


### PR DESCRIPTION
## Summary

Addresses the review comment on #675: https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088851

`imageUrls.map((url) => content.push(...))` used `Array.prototype.map` purely for side effects, allocating and discarding an array of `push()` return values. Both occurrences (agent-llm-request.service.ts and its duplicate in extraction-agent-session-runner.service.ts) now build the `ImagePart`s with `map` and spread them into a single `content.push(...)`.

No behavior change. Verified with `biome:check`, `tsc --noEmit`, and the two owning specs (21 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)