### PR TITLE
perf(pdf-converter): concurrent page uploads, single-shot writes, one-RPC source fetch

### DIFF
--- a/apps/pdf-converter/go.mod
+++ b/apps/pdf-converter/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.65.0
 	github.com/klippa-app/go-pdfium v1.19.8
 	github.com/tetratelabs/wazero v1.12.0
+	golang.org/x/sync v0.22.0
 )
 
 require (
@@ -46,7 +47,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/apps/pdf-converter/server.go
+++ b/apps/pdf-converter/server.go
@@ -10,8 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/bayesimpact/bayes-platform/apps/pdf-converter/internal/render"
 )
+
+// uploadConcurrency bounds parallel page uploads per request; enough to hide
+// GCS latency behind rendering without holding many page buffers in memory.
+const uploadConcurrency = 4
 
 type renderDocumentRequest struct {
 	SourceObject     string `json:"sourceObject"`
@@ -38,8 +44,8 @@ func validObjectPath(path string) bool {
 	return path != "" && !strings.HasPrefix(path, "/") && !strings.Contains(path, "..")
 }
 
-// fetchSourcePdf stats and downloads the source pdf, writing the error
-// response and returning ok=false when it cannot.
+// fetchSourcePdf downloads the source pdf, writing the error response and
+// returning ok=false when it cannot.
 func fetchSourcePdf(
 	response http.ResponseWriter,
 	request *http.Request,
@@ -47,25 +53,15 @@ func fetchSourcePdf(
 	sourceObject string,
 	maxSourceBytes int64,
 ) ([]byte, bool) {
-	size, err := store.Size(request.Context(), sourceObject)
+	pdfBytes, err := store.Download(request.Context(), sourceObject, maxSourceBytes)
 	if errors.Is(err, errObjectNotFound) {
 		writeError(response, http.StatusNotFound, "source pdf not found")
 		return nil, false
 	}
-	if err != nil {
-		log.Printf("size check failed: %v", err)
-		writeError(response, http.StatusInternalServerError, "failed to stat source pdf")
-		return nil, false
-	}
-	if size > maxSourceBytes {
+	var tooLarge *objectTooLargeError
+	if errors.As(err, &tooLarge) {
 		writeError(response, http.StatusRequestEntityTooLarge,
-			fmt.Sprintf("source pdf is %dMB, max is %dMB", size/1024/1024, maxSourceBytes/1024/1024))
-		return nil, false
-	}
-
-	pdfBytes, err := store.Download(request.Context(), sourceObject)
-	if errors.Is(err, errObjectNotFound) {
-		writeError(response, http.StatusNotFound, "source pdf not found")
+			fmt.Sprintf("source pdf is %dMB, max is %dMB", tooLarge.size/1024/1024, tooLarge.maxBytes/1024/1024))
 		return nil, false
 	}
 	if err != nil {
@@ -112,21 +108,40 @@ func newServer(
 
 		renderCtx, cancelRender := context.WithTimeout(request.Context(), renderTimeout)
 		defer cancelRender()
+		// Pages upload concurrently with rendering: emit hands each PNG to a
+		// bounded errgroup so GCS round trips overlap with pdfium instead of
+		// blocking it. SetLimit gives backpressure — at most
+		// uploadConcurrency page buffers are in flight at once.
+		uploads, uploadCtx := errgroup.WithContext(renderCtx)
+		uploads.SetLimit(uploadConcurrency)
 		pageCount, err := renderer.RenderPages(renderCtx, pdfBytes, body.MaxPages, body.MaxPixelsPerPage,
 			func(pageNumber int, pngBytes []byte) error {
-				object := fmt.Sprintf("%spage-%d.png", body.OutputPrefix, pageNumber)
-				return store.Upload(renderCtx, object, "image/png", pngBytes)
+				// Stop rendering as soon as any upload has failed.
+				if uploadErr := uploadCtx.Err(); uploadErr != nil {
+					return uploadErr
+				}
+				uploads.Go(func() error {
+					object := fmt.Sprintf("%spage-%d.png", body.OutputPrefix, pageNumber)
+					return store.Upload(uploadCtx, object, "image/png", pngBytes)
+				})
+				return nil
 			})
+		uploadErr := uploads.Wait()
 		if errors.Is(err, render.ErrTooManyPages) {
 			writeError(response, http.StatusUnprocessableEntity, err.Error())
 			return
 		}
-		if errors.Is(err, render.ErrAborted) {
+		if errors.Is(err, render.ErrAborted) || (uploadErr != nil && renderCtx.Err() != nil) {
 			writeError(response, http.StatusGatewayTimeout, "pdf rendering timed out or was cancelled")
 			return
 		}
 		if errors.Is(err, render.ErrInvalidPdf) {
 			writeError(response, http.StatusBadRequest, err.Error())
+			return
+		}
+		if uploadErr != nil {
+			log.Printf("upload failed: %v", uploadErr)
+			writeError(response, http.StatusInternalServerError, "failed to upload page images")
 			return
 		}
 		if err != nil {

--- a/apps/pdf-converter/server_test.go
+++ b/apps/pdf-converter/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,26 +16,26 @@ import (
 )
 
 type fakeStore struct {
+	mutex   sync.Mutex
 	objects map[string][]byte
 }
 
-func (store *fakeStore) Size(ctx context.Context, object string) (int64, error) {
-	data, found := store.objects[object]
-	if !found {
-		return 0, errObjectNotFound
-	}
-	return int64(len(data)), nil
-}
-
-func (store *fakeStore) Download(ctx context.Context, object string) ([]byte, error) {
+func (store *fakeStore) Download(ctx context.Context, object string, maxBytes int64) ([]byte, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
 	data, found := store.objects[object]
 	if !found {
 		return nil, errObjectNotFound
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, &objectTooLargeError{size: int64(len(data)), maxBytes: maxBytes}
 	}
 	return data, nil
 }
 
 func (store *fakeStore) Upload(ctx context.Context, object string, contentType string, data []byte) error {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
 	store.objects[object] = data
 	return nil
 }
@@ -100,36 +101,19 @@ func TestRenderDocumentSourceMissing(t *testing.T) {
 	}
 }
 
-// sourceDeletedBetweenSizeAndDownloadStore simulates the TOCTOU window where a
-// source object is removed after Size() succeeds but before Download() runs:
-// Size() reports a size, while Download() returns errObjectNotFound, exactly
-// as gcsStore's Download does when the underlying object is gone.
-type sourceDeletedBetweenSizeAndDownloadStore struct {
-	sourceSize int64
-}
-
-func (store *sourceDeletedBetweenSizeAndDownloadStore) Size(ctx context.Context, object string) (int64, error) {
-	return store.sourceSize, nil
-}
-
-func (store *sourceDeletedBetweenSizeAndDownloadStore) Download(ctx context.Context, object string) ([]byte, error) {
-	return nil, errObjectNotFound
-}
-
-func (store *sourceDeletedBetweenSizeAndDownloadStore) Upload(ctx context.Context, object string, contentType string, data []byte) error {
-	return nil
-}
-
-func TestRenderDocumentSourceMissingOnDownload(t *testing.T) {
+func TestRenderDocumentSourceTooLarge(t *testing.T) {
+	store := &fakeStore{objects: map[string][]byte{
+		"org1/proj1/doc1.pdf": pdftest.BuildPdfWithPages(1, 200),
+	}}
 	renderer, err := render.NewRenderer()
 	if err != nil {
 		t.Fatalf("NewRenderer: %v", err)
 	}
-	handler := newServer(&sourceDeletedBetweenSizeAndDownloadStore{sourceSize: 1024}, renderer, 50*1024*1024, time.Minute)
+	handler := newServer(store, renderer, 1, time.Minute)
 	response := postRender(handler,
 		`{"sourceObject":"org1/proj1/doc1.pdf","outputPrefix":"org1/proj1/derived/doc1/","maxPages":20,"maxPixelsPerPage":4000000}`)
-	if response.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", response.Code, response.Body.String())
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", response.Code, response.Body.String())
 	}
 }
 
@@ -163,11 +147,7 @@ type stalledUploadStore struct {
 	objects map[string][]byte
 }
 
-func (store *stalledUploadStore) Size(ctx context.Context, object string) (int64, error) {
-	return int64(len(store.objects[object])), nil
-}
-
-func (store *stalledUploadStore) Download(ctx context.Context, object string) ([]byte, error) {
+func (store *stalledUploadStore) Download(ctx context.Context, object string, maxBytes int64) ([]byte, error) {
 	return store.objects[object], nil
 }
 

--- a/apps/pdf-converter/store.go
+++ b/apps/pdf-converter/store.go
@@ -13,9 +13,19 @@ import (
 // test fakes so the handler can map it to a 404.
 var errObjectNotFound = errors.New("object not found")
 
+// objectTooLargeError reports an object whose size exceeds the caller's
+// limit, before any of its content is read.
+type objectTooLargeError struct {
+	size     int64
+	maxBytes int64
+}
+
+func (err *objectTooLargeError) Error() string {
+	return fmt.Sprintf("object is %d bytes, max is %d", err.size, err.maxBytes)
+}
+
 type objectStore interface {
-	Size(ctx context.Context, object string) (int64, error)
-	Download(ctx context.Context, object string) ([]byte, error)
+	Download(ctx context.Context, object string, maxBytes int64) ([]byte, error)
 	Upload(ctx context.Context, object string, contentType string, data []byte) error
 }
 
@@ -23,18 +33,7 @@ type gcsStore struct {
 	bucket *storage.BucketHandle
 }
 
-func (store *gcsStore) Size(ctx context.Context, object string) (int64, error) {
-	attrs, err := store.bucket.Object(object).Attrs(ctx)
-	if errors.Is(err, storage.ErrObjectNotExist) {
-		return 0, errObjectNotFound
-	}
-	if err != nil {
-		return 0, fmt.Errorf("stat %s: %w", object, err)
-	}
-	return attrs.Size, nil
-}
-
-func (store *gcsStore) Download(ctx context.Context, object string) ([]byte, error) {
+func (store *gcsStore) Download(ctx context.Context, object string, maxBytes int64) ([]byte, error) {
 	reader, err := store.bucket.Object(object).NewReader(ctx)
 	if errors.Is(err, storage.ErrObjectNotExist) {
 		return nil, errObjectNotFound
@@ -43,6 +42,11 @@ func (store *gcsStore) Download(ctx context.Context, object string) ([]byte, err
 		return nil, fmt.Errorf("open %s: %w", object, err)
 	}
 	defer reader.Close()
+	// The reader's own attrs carry the size, so no separate stat RPC is
+	// needed to enforce the limit before buffering the object.
+	if reader.Attrs.Size > maxBytes {
+		return nil, &objectTooLargeError{size: reader.Attrs.Size, maxBytes: maxBytes}
+	}
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", object, err)
@@ -53,6 +57,10 @@ func (store *gcsStore) Download(ctx context.Context, object string) ([]byte, err
 func (store *gcsStore) Upload(ctx context.Context, object string, contentType string, data []byte) error {
 	writer := store.bucket.Object(object).NewWriter(ctx)
 	writer.ContentType = contentType
+	// The payload is fully in memory and small (a page PNG); ChunkSize 0
+	// uploads it in a single request instead of staging a 16MiB resumable
+	// buffer.
+	writer.ChunkSize = 0
 	if _, err := writer.Write(data); err != nil {
 		writer.Close()
 		return fmt.Errorf("write %s: %w", object, err)


### PR DESCRIPTION
## Summary

Follow-up to #675, addressing the upload-efficiency review finding (https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088846):

- **Concurrent page uploads**: `emit` now hands each rendered PNG to a bounded errgroup (limit 4), so GCS round trips overlap with pdfium rendering instead of blocking the render loop — previously ~20 serial round trips per 20-page document. `SetLimit` doubles as backpressure so at most 4 page buffers are in flight; rendering aborts early if an upload fails, and the handler drains the group before responding.
- **Single-shot uploads**: `writer.ChunkSize = 0` — a few-hundred-KB page PNG goes up in one request instead of allocating a 16MiB resumable staging buffer per page.
- **One RPC per source fetch**: `Size` is gone from the `objectStore` interface; `Download` takes `maxBytes` and enforces the limit via `reader.Attrs.Size` before buffering, returning a typed `objectTooLargeError` mapped to 413. This also removes the Size/Download TOCTOU window, so that test is deleted; a new test covers the previously untested 413 path.

`golang.org/x/sync` moves from indirect to direct at the same pinned version — no new dependency enters the module graph.

## Test plan

- `go vet`, `go build`, `go test` pass
- `go test -race` passes (run in a `golang:1.25` container; host has no C compiler)
- Timeout semantics preserved: an upload failure after the request deadline still maps to 504 (`TestRenderDocumentTimesOutWhenRenderingStalls`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)