### PR TITLE
fix(llm): reuse cached Google ID token for pdf-converter requests

### DIFF
--- a/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common"
-import { GoogleAuth } from "google-auth-library"
+import { GoogleAuth, type IdTokenClient } from "google-auth-library"
 import { PdfPageLimitExceededError } from "./pdf-page-limit-exceeded.error"
 
 // Guards against oversized vision requests: each page becomes one image sent
@@ -24,6 +24,10 @@ const GOOGLE_IAM_AUTH_MODE = "google-iam"
 @Injectable()
 export class PdfConverterClient {
   private googleAuth: GoogleAuth | undefined
+  // Cached per audience: IdTokenClient reuses its minted ID token until expiry
+  // (~1h), but only when requests go through getRequestHeaders on the same
+  // client instance.
+  private readonly idTokenClients = new Map<string, IdTokenClient>()
 
   // Returns the number of pages of a PDF document without rendering it.
   async getPageCount({ sourceObject }: { sourceObject: string }): Promise<number> {
@@ -103,10 +107,22 @@ export class PdfConverterClient {
     }
     // The audience must be the Cloud Run service root URL, not the full path.
     const audience = new URL(converterUrl).origin
+    const idTokenClient = await this.getIdTokenClient(audience)
+    const requestHeaders = await idTokenClient.getRequestHeaders()
+    const authorization = requestHeaders.get("authorization")
+    if (!authorization) {
+      throw new Error(`could not obtain a Google ID token for audience ${audience}`)
+    }
+    return { Authorization: authorization }
+  }
+
+  private async getIdTokenClient(audience: string): Promise<IdTokenClient> {
+    const cachedClient = this.idTokenClients.get(audience)
+    if (cachedClient) return cachedClient
     this.googleAuth ??= new GoogleAuth()
     const idTokenClient = await this.googleAuth.getIdTokenClient(audience)
-    const idToken = await idTokenClient.idTokenProvider.fetchIdToken(audience)
-    return { Authorization: `Bearer ${idToken}` }
+    this.idTokenClients.set(audience, idTokenClient)
+    return idTokenClient
   }
 
   private async extractErrorMessage(response: Response): Promise<string> {


### PR DESCRIPTION
## Summary

Follow-up to #675, addressing https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088837.

`PdfConverterClient.buildAuthHeaders` minted a fresh Google ID token on every converter request: `getIdTokenClient()` constructs a new `IdTokenClient` per call, and calling `idTokenProvider.fetchIdToken()` directly bypasses the only token cache (`IdTokenClient.getRequestMetadataAsync`, which reuses the token until expiry ~1h). A first render paid two mints (page-count pre-flight + render).

- Cache the `IdTokenClient` per audience on the client instance.
- Fetch the header via `getRequestHeaders()`, which caches the minted token until expiry and refreshes it automatically.
- `getRequestHeaders()` returns a fetch `Headers` object in google-auth-library v10, so the `authorization` header is extracted explicitly (with an error if absent) instead of spreading.

Only affects production (`PDF_CONVERTER_AUTH=google-iam`); locally no auth header is sent.

## Test plan

- `npm run biome:check`, `npx tsc --noEmit` (apps/api): clean
- pdf-pages jest suite: 6/6 passing (converter client is stubbed there; token reuse itself is IAM-only behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)