### PR TITLE
fix(llm): validate pdf-converter responses instead of trusting the cast

### DIFF
--- a/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
@@ -21,6 +21,18 @@ const RENDER_REQUEST_TIMEOUT_MS = 120_000
 // converter runs open and no header is sent.
 const GOOGLE_IAM_AUTH_MODE = "google-iam"
 
+// AbortSignal.timeout can fire while awaiting fetch() or later while reading
+// the response body; both reject with a DOMException named TimeoutError. The
+// DOMException may come from another realm (e.g. under Jest's VM sandbox), so
+// match on name instead of instanceof.
+const isTimeoutError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { name?: unknown }).name === "TimeoutError"
+
+const timeoutError = (path: string): Error =>
+  new Error(`pdf-converter request to /${path} timed out after ${RENDER_REQUEST_TIMEOUT_MS}ms`)
+
 @Injectable()
 export class PdfConverterClient {
   private googleAuth: GoogleAuth | undefined
@@ -73,18 +85,28 @@ export class PdfConverterClient {
         signal: AbortSignal.timeout(RENDER_REQUEST_TIMEOUT_MS),
       })
     } catch (error) {
-      if (error instanceof Error && error.name === "TimeoutError") {
-        throw new Error(
-          `pdf-converter request to /${path} timed out after ${RENDER_REQUEST_TIMEOUT_MS}ms`,
-        )
-      }
+      if (isTimeoutError(error)) throw timeoutError(path)
       const reason = error instanceof Error ? error.message : String(error)
       throw new Error(`could not reach pdf-converter at ${converterUrl}: ${reason}`)
     }
     if (!response.ok) {
       throw new Error(await this.extractErrorMessage(response))
     }
-    return (await response.json()) as { pageCount: number }
+    let body: unknown
+    try {
+      body = await response.json()
+    } catch (error) {
+      if (isTimeoutError(error)) throw timeoutError(path)
+      throw new Error(`pdf-converter returned a non-json response from /${path}`)
+    }
+    // A misconfigured PDF_CONVERTER_URL or intercepting proxy can return a 200
+    // with a different shape; an undefined pageCount would pass the page-limit
+    // check and silently render zero pages, so it must fail loudly here.
+    const pageCount = (body as { pageCount?: unknown } | null)?.pageCount
+    if (typeof pageCount !== "number" || !Number.isInteger(pageCount) || pageCount < 0) {
+      throw new Error(`pdf-converter response from /${path} did not include a valid pageCount`)
+    }
+    return { pageCount }
   }
 
   private resolveConverterUrl(): string {

--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
@@ -106,6 +106,58 @@ describe("PdfPagesService", () => {
     expect(onPageCountUpdate).not.toHaveBeenCalled()
   })
 
+  it("rejects when the converter returns a 200 without a valid pageCount", async () => {
+    process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
+    jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ pages: 2 }), { status: 200 }))
+    const onPageCountUpdate = jest.fn()
+
+    await expect(
+      buildService().getImageUrls({
+        document: { storageRelativePath: "org1/proj1/doc1.pdf", pdfPageCount: null },
+        onPageCountUpdate,
+        fileStorageService: buildFileStorageService(),
+      }),
+    ).rejects.toThrow("pdf-converter response from /page-count did not include a valid pageCount")
+    expect(onPageCountUpdate).not.toHaveBeenCalled()
+  })
+
+  it("rejects with a descriptive error when the converter returns a non-json 200", async () => {
+    process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
+    jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("<html>proxy error</html>", { status: 200 }))
+    const onPageCountUpdate = jest.fn()
+
+    await expect(
+      buildService().getImageUrls({
+        document: { storageRelativePath: "org1/proj1/doc1.pdf", pdfPageCount: null },
+        onPageCountUpdate,
+        fileStorageService: buildFileStorageService(),
+      }),
+    ).rejects.toThrow("pdf-converter returned a non-json response from /page-count")
+    expect(onPageCountUpdate).not.toHaveBeenCalled()
+  })
+
+  it("reports a timeout when the request times out while reading the response body", async () => {
+    process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
+    jest.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new DOMException("The operation timed out", "TimeoutError")),
+    } as unknown as Response)
+    const onPageCountUpdate = jest.fn()
+
+    await expect(
+      buildService().getImageUrls({
+        document: { storageRelativePath: "org1/proj1/doc1.pdf", pdfPageCount: null },
+        onPageCountUpdate,
+        fileStorageService: buildFileStorageService(),
+      }),
+    ).rejects.toThrow("pdf-converter request to /page-count timed out after 120000ms")
+    expect(onPageCountUpdate).not.toHaveBeenCalled()
+  })
+
   it("surfaces the converter's error message", async () => {
     process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
     jest.spyOn(globalThis, "fetch").mockResolvedValue(


### PR DESCRIPTION
## Summary

Follow-up to #675, addressing [this review comment](https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088692): `postToConverter` cast `response.json()` to `{ pageCount: number }` without validation, so a misconfigured `PDF_CONVERTER_URL` or intercepting proxy returning a 200 with an unexpected body propagated an `undefined` page count silently — passing the page-limit check, no-op'ing persistence, and sending the LLM request with zero page images.

- Validate the parsed body: `pageCount` must be a non-negative integer, otherwise throw a descriptive error.
- Map a non-JSON 200 body to a descriptive error instead of a bare `SyntaxError`.
- Move the body parse inside a try/catch so a timeout firing during body read gets the same descriptive timeout message as one during fetch.
- The timeout check now matches on `error.name` instead of `instanceof Error`, since the `TimeoutError` `DOMException` can come from another realm (e.g. Jest's VM sandbox).

## Test plan

- Three new tests in `pdf-pages.service.spec.ts`, one per failure mode (wrong-shape 200, non-JSON 200, timeout during body read); each failed before the fix and passes after.
- Full API suite (`test:parallel`): 2217 passed. `biome:check`, `typecheck`, and `check:boundaries` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)