### PR TITLE
fix(pdf-converter): clamp page render dimensions to at least one pixel

### DIFF
--- a/apps/pdf-converter/internal/render/pdftest/pdftest.go
+++ b/apps/pdf-converter/internal/render/pdftest/pdftest.go
@@ -9,6 +9,14 @@ import (
 // BuildPdfWithPages returns a minimal but valid PDF containing pageCount empty
 // pages of pageSizePoints x pageSizePoints.
 func BuildPdfWithPages(pageCount int, pageSizePoints int) []byte {
+	size := float64(pageSizePoints)
+	return BuildPdfWithPageDimensions(pageCount, size, size)
+}
+
+// BuildPdfWithPageDimensions returns a minimal but valid PDF containing
+// pageCount empty pages of widthPoints x heightPoints, allowing degenerate
+// (sub-point) and extreme aspect-ratio pages.
+func BuildPdfWithPageDimensions(pageCount int, widthPoints, heightPoints float64) []byte {
 	kids := make([]string, pageCount)
 	for pageIndex := range kids {
 		kids[pageIndex] = fmt.Sprintf("%d 0 R", pageIndex+3)
@@ -20,8 +28,8 @@ func BuildPdfWithPages(pageCount int, pageSizePoints int) []byte {
 	}
 	for pageIndex := 0; pageIndex < pageCount; pageIndex++ {
 		objects = append(objects, fmt.Sprintf(
-			"%d 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 %d %d] >>\nendobj\n",
-			pageIndex+3, pageSizePoints, pageSizePoints))
+			"%d 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 %g %g] >>\nendobj\n",
+			pageIndex+3, widthPoints, heightPoints))
 	}
 	body := "%PDF-1.4\n"
 	offsets := make([]int, 0, len(objects))

--- a/apps/pdf-converter/internal/render/render.go
+++ b/apps/pdf-converter/internal/render/render.go
@@ -156,10 +156,24 @@ func (renderer *Renderer) RenderPages(
 			if size.Width*size.Height*scale*scale > float64(maxPixelsPerPage) {
 				scale = math.Sqrt(float64(maxPixelsPerPage) / (size.Width * size.Height))
 			}
+			// Floor to 1px: a dimension truncated to 0 would either fail the
+			// render (0x0) or be silently recomputed from the page aspect
+			// ratio by go-pdfium (single 0), bypassing maxPixelsPerPage.
+			width := max(1, int(size.Width*scale))
+			height := max(1, int(size.Height*scale))
+			// Flooring a sub-pixel dimension to 1 can leave the other past
+			// the budget on extreme aspect ratios; cap it.
+			if width*height > maxPixelsPerPage {
+				if width > height {
+					width = maxPixelsPerPage / height
+				} else {
+					height = maxPixelsPerPage / width
+				}
+			}
 			rendered, err := instance.RenderPageInPixels(&requests.RenderPageInPixels{
 				Page:   page,
-				Width:  int(size.Width * scale),
-				Height: int(size.Height * scale),
+				Width:  width,
+				Height: height,
 			})
 			if err != nil {
 				return 0, fmt.Errorf("render page %d: %w", pageIndex+1, err)

--- a/apps/pdf-converter/internal/render/render_test.go
+++ b/apps/pdf-converter/internal/render/render_test.go
@@ -120,6 +120,35 @@ func TestCapsPixelsPerPage(t *testing.T) {
 	}
 }
 
+func TestRendersDegenerateTinyPageAsOnePixel(t *testing.T) {
+	renderer := newTestRenderer(t)
+	// 0.2pt at scale 2 truncates to 0x0 pixels; the render must clamp to 1x1
+	// instead of failing the whole document.
+	_, rendered := collectPages(t, renderer, pdftest.BuildPdfWithPageDimensions(1, 0.2, 0.2), 20, 4_000_000)
+	image, err := png.Decode(bytes.NewReader(rendered[0]))
+	if err != nil {
+		t.Fatalf("page is not a png: %v", err)
+	}
+	if image.Bounds().Dx() < 1 || image.Bounds().Dy() < 1 {
+		t.Fatalf("expected at least 1x1, got %v", image.Bounds())
+	}
+}
+
+func TestCapsPixelsOnExtremeAspectRatioPage(t *testing.T) {
+	renderer := newTestRenderer(t)
+	// 40000x0.4pt: the pixel budget scales the height below one pixel, and the
+	// clamp to one pixel must not let the width blow past the budget.
+	_, rendered := collectPages(t, renderer, pdftest.BuildPdfWithPageDimensions(1, 40000, 0.4), 20, 10_000)
+	image, err := png.Decode(bytes.NewReader(rendered[0]))
+	if err != nil {
+		t.Fatalf("page is not a png: %v", err)
+	}
+	pixels := image.Bounds().Dx() * image.Bounds().Dy()
+	if pixels > 10_000 {
+		t.Fatalf("expected <= 10000 pixels, got %d (%v)", pixels, image.Bounds())
+	}
+}
+
 func TestRejectsTooManyPages(t *testing.T) {
 	renderer := newTestRenderer(t)
 	_, err := renderer.RenderPages(context.Background(), pdftest.BuildPdfWithPages(3, 200), 2, 4_000_000,


### PR DESCRIPTION
## Summary

Follow-up to #675, addressing https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088727.

`int(size.Width*scale)` / `int(size.Height*scale)` had no floor, so a degenerate page could truncate a dimension to 0. Verified against go-pdfium v1.19.8:

- **0×0** → go-pdfium errors with `no width or height given`, turning one bad page into a failure for the whole document.
- **A single 0** → go-pdfium treats it as "not set" and recomputes it from the page aspect ratio, silently bypassing `maxPixelsPerPage`.

The fix floors both dimensions to 1px, then re-caps the larger dimension when the product exceeds the budget — `max(1, ...)` alone is not enough: on a 40000×0.4pt page with a 10,000px budget, flooring the height to 1 still left the width at 31,622px. The re-cap only triggers when flooring bumped a sub-pixel dimension, so normal pages render exactly as before.

Both regression tests were watched failing before the fix (whole-document error, and 31,622px rendered against a 10,000px budget).

No changelog entry: the bug was never in a released version (the pdf-converter service ships unreleased in #675).

## Test plan

- `go test ./...` in `apps/pdf-converter` — all pass, including the two new regression tests (`TestRendersDegenerateTinyPageAsOnePixel`, `TestCapsPixelsOnExtremeAspectRatioPage`).
- `gofmt -l` clean, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)