### PR TITLE
fix: let embed hint bubble clicks pass through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - PDF documents sent to Gemma and MedGemma agents are now converted to images by a dedicated service, so heavy PDF processing no longer slows down the platform.
 
 ### Fixed
+- The chat widget hint no longer blocks clicks on the page underneath.
 - (beta) The MCP Servers tab on the agent editor shows translated labels and each server's saved state.
 - Chat shows an error message instead of an empty reply when the model fails.
 - Agent replies no longer show a leaked internal tool-call tag; the platform hides it and still runs the tool.

--- a/apps/web-embed/src/launcher/TriggerButton.stories.tsx
+++ b/apps/web-embed/src/launcher/TriggerButton.stories.tsx
@@ -182,20 +182,24 @@ function FullWidget({
           </div>
         )
       )}
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-only listeners for hint bubble visibility */}
       <div
-        className="fixed bottom-6 flex items-center gap-[10px]"
+        className="pointer-events-none fixed bottom-6 flex items-center gap-[10px]"
         style={isRight ? { right: 24 } : { left: 24 }}
-        onMouseEnter={() => setButtonHovered(true)}
-        onMouseLeave={() => setButtonHovered(false)}
       >
         {hint && <HintBubble text={hint} isRight={isRight} hovered={buttonHovered} />}
-        <TriggerButton
-          isOpen={isOpen}
-          onClick={() => setIsOpen((prev) => !prev)}
-          primaryColor={primaryColor}
-          position={position}
-        />
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-only listeners for hint bubble visibility */}
+        <div
+          className="pointer-events-auto"
+          onMouseEnter={() => setButtonHovered(true)}
+          onMouseLeave={() => setButtonHovered(false)}
+        >
+          <TriggerButton
+            isOpen={isOpen}
+            onClick={() => setIsOpen((prev) => !prev)}
+            primaryColor={primaryColor}
+            position={position}
+          />
+        </div>
       </div>
     </>
   )
@@ -303,20 +307,24 @@ function DrawerDemo({
       </div>
 
       {/* FAB button */}
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-only listeners for hint bubble visibility */}
       <div
-        className="absolute bottom-6 flex items-center gap-[10px]"
+        className="pointer-events-none absolute bottom-6 flex items-center gap-[10px]"
         style={isRight ? { right: 24 } : { left: 24 }}
-        onMouseEnter={() => setButtonHovered(true)}
-        onMouseLeave={() => setButtonHovered(false)}
       >
         {hint && !isOpen && <HintBubble text={hint} isRight={isRight} hovered={buttonHovered} />}
-        <TriggerButton
-          isOpen={isOpen}
-          onClick={() => setIsOpen((prev) => !prev)}
-          primaryColor={primaryColor}
-          position={position}
-        />
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-only listeners for hint bubble visibility */}
+        <div
+          className="pointer-events-auto"
+          onMouseEnter={() => setButtonHovered(true)}
+          onMouseLeave={() => setButtonHovered(false)}
+        >
+          <TriggerButton
+            isOpen={isOpen}
+            onClick={() => setIsOpen((prev) => !prev)}
+            primaryColor={primaryColor}
+            position={position}
+          />
+        </div>
       </div>
     </div>
   )

--- a/apps/web-embed/src/launcher/TriggerButton.tsx
+++ b/apps/web-embed/src/launcher/TriggerButton.tsx
@@ -28,7 +28,7 @@ export function TriggerButton({
       onClick={onClick}
       style={{ backgroundColor: primaryColor }}
       className={cn(
-        "flex size-14 items-center justify-center rounded-full text-white shadow-lg",
+        "pointer-events-auto flex size-14 items-center justify-center rounded-full text-white shadow-lg",
         "transition-all duration-200 hover:brightness-90 hover:scale-105 active:scale-95",
         position === "bottom-right" ? "self-end" : "self-start",
         className,

--- a/apps/web-embed/src/launcher/index.ts
+++ b/apps/web-embed/src/launcher/index.ts
@@ -91,6 +91,8 @@ function injectModalWidget({ position, color, iframeSrc, hint }: WidgetOptions) 
     isRight ? "align-items: flex-end" : "align-items: flex-start",
     "gap: 12px",
     "font-family: sans-serif",
+    // Let clicks over empty container space (e.g. the hint) reach the host page.
+    "pointer-events: none",
   ].join(";")
 
   const iframe = document.createElement("iframe")
@@ -104,6 +106,7 @@ function injectModalWidget({ position, color, iframeSrc, hint }: WidgetOptions) 
     "box-shadow: 0 8px 32px rgba(0,0,0,0.18)",
     "display: none",
     "background: white",
+    "pointer-events: auto",
   ].join(";")
   iframe.setAttribute("allow", "microphone; clipboard-write")
   iframe.setAttribute("title", "Chat")
@@ -195,7 +198,10 @@ function injectDrawerWidget({ position, color, iframeSrc, hint }: WidgetOptions)
   const open = () => {
     iframe.style.transform = "translateX(0)"
     row.style.opacity = "0"
-    row.style.pointerEvents = "none"
+    // Row stays pointer-events: none so the hint never captures clicks. Disable
+    // the FAB itself — children with pointer-events: auto still receive events
+    // under a none parent.
+    button.style.pointerEvents = "none"
     // Lock host-page scroll and compensate for scrollbar disappearing to avoid layout shift.
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
     savedBodyOverflow = document.body.style.overflow
@@ -210,7 +216,7 @@ function injectDrawerWidget({ position, color, iframeSrc, hint }: WidgetOptions)
   const close = () => {
     iframe.style.transform = translateOut
     row.style.opacity = "1"
-    row.style.pointerEvents = "auto"
+    button.style.pointerEvents = "auto"
     document.body.style.overflow = savedBodyOverflow
     document.body.style.paddingRight = savedBodyPaddingRight
     isOpen = false
@@ -242,7 +248,14 @@ function makeFabRow(
   isRight: boolean,
 ): { row: HTMLDivElement } {
   const row = document.createElement("div")
-  row.style.cssText = ["display: flex", "align-items: center", "gap: 10px"].join(";")
+  row.style.cssText = [
+    "display: flex",
+    "align-items: center",
+    "gap: 10px",
+    // The hint is decorative and hidden with opacity, so it would otherwise
+    // keep swallowing clicks on the host page. Re-enable on the FAB only.
+    "pointer-events: none",
+  ].join(";")
 
   if (hint) {
     const bubble = document.createElement("div")
@@ -321,6 +334,7 @@ function makeFabButton(color: string): HTMLButtonElement {
     "justify-content: center",
     "box-shadow: 0 4px 12px rgba(0,0,0,0.25)",
     "transition: transform 0.15s ease",
+    "pointer-events: auto",
   ].join(";")
   button.innerHTML = chatIconSvg()
   return button


### PR DESCRIPTION
## Summary
- Fixes [#647](https://github.com/bayesimpact/bayes-platform/issues/647): the embed/help hint bubble (even when faded out) sat in a max-z-index flex row and swallowed clicks on the host page.
- Wrappers now use `pointer-events: none`; only the FAB and iframe accept clicks. Drawer open/close toggles the button, not the row, so closing the chat does not bring the hole back.

## Test plan
- [ ] `cd apps/web-embed && npm run build:launcher`, then hard-refresh a Studio page that shows the help FAB (e.g. project members)
- [ ] Wait for the hint to fade (or hover then leave the FAB). Clicks in the strip left of the FAB should hit the page, not an empty div
- [ ] Confirm: `document.elementFromPoint(window.innerWidth - 140, window.innerHeight - 50)` is page content, not the launcher row
- [ ] FAB still opens the drawer; hovering it still shows the hint
- [ ] Repeat with an embed snippet that uses `data-display-mode="modal"` and `data-hint` if easy

Fixes #647


Made with [Cursor](https://cursor.com)