### PR TITLE
fix(llm): drop pdf-converter page-count pre-flight, type the render 422

### DIFF
--- a/apps/api/src/domains/agents/extraction-agent-sessions/extraction-agent-session-runner.service.spec.ts
+++ b/apps/api/src/domains/agents/extraction-agent-sessions/extraction-agent-session-runner.service.spec.ts
@@ -12,6 +12,7 @@ import type { Document } from "@/domains/documents/document.entity"
 import { documentFactory } from "@/domains/documents/document.factory"
 import { DocumentsModule } from "@/domains/documents/documents.module"
 import { PdfConverterClient } from "@/domains/documents/pdf-pages/pdf-converter.client"
+import { PdfPageLimitExceededError } from "@/domains/documents/pdf-pages/pdf-page-limit-exceeded.error"
 import { PdfPagesModule } from "@/domains/documents/pdf-pages/pdf-pages.module"
 import {
   FILE_STORAGE_SERVICE,
@@ -315,7 +316,9 @@ describe("ExtractionAgentSessionRunnerService", () => {
         model: AgentModel.Gemma4_26B,
       })
 
-      jest.spyOn(pdfConverterClient, "getPageCount").mockResolvedValue(25)
+      jest
+        .spyOn(pdfConverterClient, "generatePdfPageImages")
+        .mockRejectedValue(new PdfPageLimitExceededError(25, 20))
       const generateStructuredOutputSpy = jest.spyOn(gemmaLlmProvider, "generateStructuredOutput")
 
       await expect(

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/streaming.service.spec.ts
@@ -18,6 +18,7 @@ import type { AgentSettings } from "@/domains/agents/settings/agent-settings.ent
 import { AgentMessageAttachmentDocumentsService } from "@/domains/agents/shared/agent-session-messages/agent-message-attachment-documents.service"
 import type { AgentSessionScope } from "@/domains/agents/shared/agent-session-messages/streaming/streaming-session.types"
 import { PdfConverterClient } from "@/domains/documents/pdf-pages/pdf-converter.client"
+import { PdfPageLimitExceededError } from "@/domains/documents/pdf-pages/pdf-page-limit-exceeded.error"
 import {
   addFeature,
   createOrganizationWithAgent,
@@ -353,8 +354,9 @@ describe("StreamingService", () => {
         },
       })
 
-      jest.spyOn(pdfConverterClient, "getPageCount").mockResolvedValue(25)
-      const generatePdfPageImagesSpy = jest.spyOn(pdfConverterClient, "generatePdfPageImages")
+      const generatePdfPageImagesSpy = jest
+        .spyOn(pdfConverterClient, "generatePdfPageImages")
+        .mockRejectedValue(new PdfPageLimitExceededError(25, 20))
 
       await expect(
         buildLLMRequestForAttachment({

--- a/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
@@ -25,16 +25,11 @@ const GOOGLE_IAM_AUTH_MODE = "google-iam"
 export class PdfConverterClient {
   private googleAuth: GoogleAuth | undefined
 
-  // Returns the number of pages of a PDF document without rendering it.
-  async getPageCount({ sourceObject }: { sourceObject: string }): Promise<number> {
-    const { pageCount } = await this.postToConverter("page-count", { sourceObject })
-    return pageCount
-  }
-
   // Renders a PDF document into individual page images.
   // Returns the number of pages rendered. Throws PdfPageLimitExceededError
-  // (user-facing message) without rendering anything when the document has
-  // more pages than image-only models accept.
+  // (user-facing message) when the document has more pages than image-only
+  // models accept: the converter counts pages first and rejects with a 422
+  // before rendering anything.
   async generatePdfPageImages({
     sourceObject,
     outputPrefix,
@@ -42,10 +37,6 @@ export class PdfConverterClient {
     sourceObject: string
     outputPrefix: string
   }): Promise<number> {
-    const pageCount = await this.getPageCount({ sourceObject })
-    if (pageCount > MAX_PDF_PAGES_FOR_IMAGE_CONVERSION) {
-      throw new PdfPageLimitExceededError(pageCount, MAX_PDF_PAGES_FOR_IMAGE_CONVERSION)
-    }
     const rendered = await this.postToConverter("render-document", {
       sourceObject,
       outputPrefix,
@@ -82,7 +73,7 @@ export class PdfConverterClient {
       throw new Error(`could not reach pdf-converter at ${converterUrl}: ${reason}`)
     }
     if (!response.ok) {
-      throw new Error(await this.extractErrorMessage(response))
+      throw await this.buildErrorFromResponse(response)
     }
     return (await response.json()) as { pageCount: number }
   }
@@ -109,15 +100,20 @@ export class PdfConverterClient {
     return { Authorization: `Bearer ${idToken}` }
   }
 
-  private async extractErrorMessage(response: Response): Promise<string> {
-    const fallback = `pdf-converter responded with HTTP ${response.status}`
+  private async buildErrorFromResponse(response: Response): Promise<Error> {
+    let body: { message?: string | string[]; pageCount?: number } = {}
     try {
-      const body = (await response.json()) as { message?: string | string[] }
-      if (typeof body.message === "string") return body.message
-      if (Array.isArray(body.message)) return body.message.join(", ")
+      body = (await response.json()) as typeof body
     } catch {
       // Non-json error body: fall through to the generic message.
     }
-    return fallback
+    // 422 is the converter's page-limit rejection; its body carries the
+    // document's page count so the typed error can name it.
+    if (response.status === 422 && typeof body.pageCount === "number") {
+      return new PdfPageLimitExceededError(body.pageCount, MAX_PDF_PAGES_FOR_IMAGE_CONVERSION)
+    }
+    if (typeof body.message === "string") return new Error(body.message)
+    if (Array.isArray(body.message)) return new Error(body.message.join(", "))
+    return new Error(`pdf-converter responded with HTTP ${response.status}`)
   }
 }

--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
@@ -48,7 +48,7 @@ describe("PdfPagesService", () => {
     expect(onPageCountUpdate).not.toHaveBeenCalled()
   })
 
-  it("checks the page count, renders the document and reports the count when it is not cached", async () => {
+  it("renders the document and reports the count when it is not cached", async () => {
     process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
     const fetchSpy = jest
       .spyOn(globalThis, "fetch")
@@ -67,13 +67,8 @@ describe("PdfPagesService", () => {
       "https://storage.example.test/org1/proj1/derived/doc1/page-1.png?signature=abc",
       "https://storage.example.test/org1/proj1/derived/doc1/page-2.png?signature=abc",
     ])
-    expect(fetchSpy).toHaveBeenCalledTimes(2)
-    const [pageCountUrl, pageCountInit] = fetchSpy.mock.calls[0]!
-    expect(String(pageCountUrl)).toBe("http://pdf-converter.test/page-count")
-    expect(JSON.parse(String(pageCountInit?.body))).toEqual({
-      sourceObject: "org1/proj1/doc1.pdf",
-    })
-    const [renderUrl, renderInit] = fetchSpy.mock.calls[1]!
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [renderUrl, renderInit] = fetchSpy.mock.calls[0]!
     expect(String(renderUrl)).toBe("http://pdf-converter.test/render-document")
     expect(JSON.parse(String(renderInit?.body))).toEqual({
       sourceObject: "org1/proj1/doc1.pdf",
@@ -84,11 +79,17 @@ describe("PdfPagesService", () => {
     expect(onPageCountUpdate).toHaveBeenCalledWith(2)
   })
 
-  it("throws a user-facing error without rendering when the pdf exceeds the page limit", async () => {
+  it("throws a user-facing error when the converter rejects the pdf over the page limit", async () => {
     process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
-    const fetchSpy = jest
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({ pageCount: 25 }), { status: 200 }))
+    const fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: "page limit exceeded: pdf has 25 pages, max is 20",
+          pageCount: 25,
+        }),
+        { status: 422 },
+      ),
+    )
     const onPageCountUpdate = jest.fn()
 
     const imageUrlsPromise = buildService().getImageUrls({
@@ -102,20 +103,17 @@ describe("PdfPagesService", () => {
       "This PDF has 25 pages; the maximum is 20 pages.",
     )
     expect(fetchSpy).toHaveBeenCalledTimes(1)
-    expect(String(fetchSpy.mock.calls[0]![0])).toBe("http://pdf-converter.test/page-count")
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe("http://pdf-converter.test/render-document")
     expect(onPageCountUpdate).not.toHaveBeenCalled()
   })
 
   it("surfaces the converter's error message", async () => {
     process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
-    jest.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({ message: "page limit exceeded: pdf has 30 pages, max is 20" }),
-        {
-          status: 422,
-        },
-      ),
-    )
+    jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ message: "invalid pdf: bad header" }), { status: 400 }),
+      )
     const onPageCountUpdate = jest.fn()
 
     await expect(
@@ -124,7 +122,7 @@ describe("PdfPagesService", () => {
         onPageCountUpdate,
         fileStorageService: buildFileStorageService(),
       }),
-    ).rejects.toThrow("page limit exceeded")
+    ).rejects.toThrow("invalid pdf: bad header")
     expect(onPageCountUpdate).not.toHaveBeenCalled()
   })
 })

--- a/apps/pdf-converter/README.md
+++ b/apps/pdf-converter/README.md
@@ -10,7 +10,6 @@ are streamed directly to GCS. No local storage or subprocess management needed.
 | Method | Path | Description |
 | --- | --- | --- |
 | `POST` | `/render-document` | Body: JSON with source PDF path and output prefix. Returns `{ "pageCount": <number> }` with pages uploaded as `{outputPrefix}page-{n}.png`. |
-| `POST` | `/page-count` | Body: JSON with the source PDF path (`sourceObject` only). Returns `{ "pageCount": <number> }` without rendering anything. |
 | `GET` | `/healthz` | Liveness probe, no auth. |
 
 `POST /render-document` requires a JSON body with:
@@ -20,9 +19,6 @@ are streamed directly to GCS. No local storage or subprocess management needed.
 - `maxPages` (integer, 1–100, required) — reject PDFs with more pages (HTTP 422).
 - `maxPixelsPerPage` (integer, 1–16000000, required) — clamp each page's rendered bitmap height and width.
 
-`POST /page-count` requires a JSON body with only `sourceObject` (same
-constraints) and shares the error semantics below (no 422: it never renders).
-
 All paths must be relative (no leading `/`) and free of `..` traversal.
 
 Response on success: `{ "pageCount": <int> }` (HTTP 200).
@@ -31,7 +27,7 @@ Errors are:
 - **400** — invalid PDF, malformed JSON body, invalid parameters, or invalid object paths.
 - **404** — source PDF not found in GCS.
 - **413** — source PDF exceeds `PDF_CONVERTER_MAX_PDF_BYTES`.
-- **422** — PDF has more pages than `maxPages`.
+- **422** — PDF has more pages than `maxPages`; nothing is rendered and the body includes the document's `pageCount`.
 - **500** — server error (e.g., failed to upload page to GCS).
 - **504** — rendering exceeded `PDF_CONVERTER_RENDER_TIMEOUT_MS` (or the caller disconnected); the pdfium instance is killed and re-created, so a hostile PDF cannot wedge the service.
 
@@ -49,7 +45,7 @@ service is only bound on the developer's machine.
 - `GCS_STORAGE_BUCKET_NAME` (required) — GCS bucket for source PDFs and rendered pages.
 - `PORT` (default `3002`) — listen port.
 - `PDF_CONVERTER_MAX_PDF_BYTES` (default `52428800`, 50MB) — source PDF size limit.
-- `PDF_CONVERTER_RENDER_TIMEOUT_MS` (default `60000`, 60s) — hard per-request deadline for rendering/page-count work; must stay below the API client's 120s request timeout.
+- `PDF_CONVERTER_RENDER_TIMEOUT_MS` (default `60000`, 60s) — hard per-request deadline for rendering work; must stay below the API client's 120s request timeout.
 
 ## Local development
 

--- a/apps/pdf-converter/internal/render/render.go
+++ b/apps/pdf-converter/internal/render/render.go
@@ -96,28 +96,10 @@ func (renderer *Renderer) withInstance(
 	}
 }
 
-// GetPageCount opens the document and returns its page count without
-// rendering any page.
-func (renderer *Renderer) GetPageCount(ctx context.Context, pdfBytes []byte) (int, error) {
-	return renderer.withInstance(ctx, func(instance pdfium.Pdfium) (int, error) {
-		document, err := instance.OpenDocument(&requests.OpenDocument{File: &pdfBytes})
-		if err != nil {
-			return 0, fmt.Errorf("%w: %v", ErrInvalidPdf, err)
-		}
-		defer instance.FPDF_CloseDocument(&requests.FPDF_CloseDocument{Document: document.Document})
-
-		pageCountResponse, err := instance.FPDF_GetPageCount(&requests.FPDF_GetPageCount{
-			Document: document.Document,
-		})
-		if err != nil {
-			return 0, fmt.Errorf("%w: %v", ErrInvalidPdf, err)
-		}
-		return pageCountResponse.PageCount, nil
-	})
-}
-
 // RenderPages rasterizes every page as PNG and hands each to emit with a
-// 1-based page number. Returns the page count.
+// 1-based page number. Returns the page count — also alongside
+// ErrTooManyPages, so callers can report how many pages the rejected
+// document has.
 func (renderer *Renderer) RenderPages(
 	ctx context.Context,
 	pdfBytes []byte,
@@ -140,7 +122,7 @@ func (renderer *Renderer) RenderPages(
 		}
 		pageCount := pageCountResponse.PageCount
 		if pageCount > maxPages {
-			return 0, fmt.Errorf("%w: pdf has %d pages, max is %d", ErrTooManyPages, pageCount, maxPages)
+			return pageCount, fmt.Errorf("%w: pdf has %d pages, max is %d", ErrTooManyPages, pageCount, maxPages)
 		}
 
 		for pageIndex := 0; pageIndex < pageCount; pageIndex++ {

--- a/apps/pdf-converter/internal/render/render_test.go
+++ b/apps/pdf-converter/internal/render/render_test.go
@@ -80,11 +80,12 @@ func TestInterruptedRendersDoNotExhaustThePool(t *testing.T) {
 	}
 }
 
-func TestGetPageCountReturnsAbortedWhenContextAlreadyCancelled(t *testing.T) {
+func TestRenderPagesReturnsAbortedWhenContextAlreadyCancelled(t *testing.T) {
 	renderer := newTestRenderer(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := renderer.GetPageCount(ctx, pdftest.BuildPdfWithPages(3, 200))
+	_, err := renderer.RenderPages(ctx, pdftest.BuildPdfWithPages(3, 200), 20, 4_000_000,
+		func(pageNumber int, pngBytes []byte) error { return nil })
 	if !errors.Is(err, ErrAborted) {
 		t.Fatalf("expected ErrAborted, got %v", err)
 	}
@@ -122,10 +123,13 @@ func TestCapsPixelsPerPage(t *testing.T) {
 
 func TestRejectsTooManyPages(t *testing.T) {
 	renderer := newTestRenderer(t)
-	_, err := renderer.RenderPages(context.Background(), pdftest.BuildPdfWithPages(3, 200), 2, 4_000_000,
+	pageCount, err := renderer.RenderPages(context.Background(), pdftest.BuildPdfWithPages(3, 200), 2, 4_000_000,
 		func(pageNumber int, pngBytes []byte) error { return nil })
 	if !errors.Is(err, ErrTooManyPages) {
 		t.Fatalf("expected ErrTooManyPages, got %v", err)
+	}
+	if pageCount != 3 {
+		t.Fatalf("expected the rejected page count 3 alongside the error, got %d", pageCount)
 	}
 }
 
@@ -133,25 +137,6 @@ func TestRejectsInvalidPdf(t *testing.T) {
 	renderer := newTestRenderer(t)
 	_, err := renderer.RenderPages(context.Background(), []byte("not a pdf at all"), 20, 4_000_000,
 		func(pageNumber int, pngBytes []byte) error { return nil })
-	if !errors.Is(err, ErrInvalidPdf) {
-		t.Fatalf("expected ErrInvalidPdf, got %v", err)
-	}
-}
-
-func TestGetPageCount(t *testing.T) {
-	renderer := newTestRenderer(t)
-	pageCount, err := renderer.GetPageCount(context.Background(), pdftest.BuildPdfWithPages(3, 200))
-	if err != nil {
-		t.Fatalf("GetPageCount: %v", err)
-	}
-	if pageCount != 3 {
-		t.Fatalf("expected 3 pages, got %d", pageCount)
-	}
-}
-
-func TestGetPageCountRejectsInvalidPdf(t *testing.T) {
-	renderer := newTestRenderer(t)
-	_, err := renderer.GetPageCount(context.Background(), []byte("not a pdf at all"))
 	if !errors.Is(err, ErrInvalidPdf) {
 		t.Fatalf("expected ErrInvalidPdf, got %v", err)
 	}

--- a/apps/pdf-converter/server.go
+++ b/apps/pdf-converter/server.go
@@ -20,10 +20,6 @@ type renderDocumentRequest struct {
 	MaxPixelsPerPage int    `json:"maxPixelsPerPage"`
 }
 
-type pageCountRequest struct {
-	SourceObject string `json:"sourceObject"`
-}
-
 func writeJSON(response http.ResponseWriter, status int, payload any) {
 	response.Header().Set("Content-Type", "application/json")
 	response.WriteHeader(status)
@@ -118,7 +114,12 @@ func newServer(
 				return store.Upload(renderCtx, object, "image/png", pngBytes)
 			})
 		if errors.Is(err, render.ErrTooManyPages) {
-			writeError(response, http.StatusUnprocessableEntity, err.Error())
+			// pageCount rides along so the API can raise its typed, user-facing
+			// page-limit error without a separate page-count request.
+			writeJSON(response, http.StatusUnprocessableEntity, map[string]any{
+				"message":   err.Error(),
+				"pageCount": pageCount,
+			})
 			return
 		}
 		if errors.Is(err, render.ErrAborted) {
@@ -132,41 +133,6 @@ func newServer(
 		if err != nil {
 			log.Printf("render failed: %v", err)
 			writeError(response, http.StatusInternalServerError, "pdf rendering failed")
-			return
-		}
-		writeJSON(response, http.StatusOK, map[string]int{"pageCount": pageCount})
-	})
-
-	mux.HandleFunc("POST /page-count", func(response http.ResponseWriter, request *http.Request) {
-		var body pageCountRequest
-		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
-			writeError(response, http.StatusBadRequest, "invalid json body")
-			return
-		}
-		if !validObjectPath(body.SourceObject) {
-			writeError(response, http.StatusBadRequest, "sourceObject must be a relative object path")
-			return
-		}
-
-		pdfBytes, ok := fetchSourcePdf(response, request, store, body.SourceObject, maxSourceBytes)
-		if !ok {
-			return
-		}
-
-		countCtx, cancelCount := context.WithTimeout(request.Context(), renderTimeout)
-		defer cancelCount()
-		pageCount, err := renderer.GetPageCount(countCtx, pdfBytes)
-		if errors.Is(err, render.ErrInvalidPdf) {
-			writeError(response, http.StatusBadRequest, err.Error())
-			return
-		}
-		if errors.Is(err, render.ErrAborted) {
-			writeError(response, http.StatusGatewayTimeout, "pdf page count timed out or was cancelled")
-			return
-		}
-		if err != nil {
-			log.Printf("page count failed: %v", err)
-			writeError(response, http.StatusInternalServerError, "pdf page count failed")
 			return
 		}
 		writeJSON(response, http.StatusOK, map[string]int{"pageCount": pageCount})

--- a/apps/pdf-converter/server_test.go
+++ b/apps/pdf-converter/server_test.go
@@ -90,6 +90,19 @@ func TestRenderDocumentPageLimit(t *testing.T) {
 	if response.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", response.Code)
 	}
+	var parsed struct {
+		Message   string `json:"message"`
+		PageCount int    `json:"pageCount"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &parsed); err != nil || parsed.PageCount != 3 {
+		t.Fatalf("expected pageCount 3 in the 422 body, got %s", response.Body.String())
+	}
+	if parsed.Message == "" {
+		t.Fatalf("expected a message in the 422 body, got %s", response.Body.String())
+	}
+	if len(store.objects) != 1 {
+		t.Fatalf("expected no uploads, store has %d objects", len(store.objects))
+	}
 }
 
 func TestRenderDocumentSourceMissing(t *testing.T) {
@@ -192,62 +205,6 @@ func TestRenderDocumentTimesOutWhenRenderingStalls(t *testing.T) {
 	}
 	if !strings.Contains(response.Body.String(), "timed out") {
 		t.Fatalf("expected a timeout message, got %s", response.Body.String())
-	}
-}
-
-func postPageCount(handler http.Handler, body string) *httptest.ResponseRecorder {
-	request := httptest.NewRequest(http.MethodPost, "/page-count", strings.NewReader(body))
-	request.Header.Set("Content-Type", "application/json")
-	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, request)
-	return recorder
-}
-
-func TestPageCountHappyPath(t *testing.T) {
-	store := &fakeStore{objects: map[string][]byte{
-		"org1/proj1/doc1.pdf": pdftest.BuildPdfWithPages(3, 200),
-	}}
-	response := postPageCount(newTestServer(t, store), `{"sourceObject":"org1/proj1/doc1.pdf"}`)
-	if response.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", response.Code, response.Body.String())
-	}
-	var parsed struct {
-		PageCount int `json:"pageCount"`
-	}
-	if err := json.Unmarshal(response.Body.Bytes(), &parsed); err != nil || parsed.PageCount != 3 {
-		t.Fatalf("expected pageCount 3, got %s", response.Body.String())
-	}
-	if len(store.objects) != 1 {
-		t.Fatalf("expected no uploads, store has %d objects", len(store.objects))
-	}
-}
-
-func TestPageCountSourceMissing(t *testing.T) {
-	response := postPageCount(newTestServer(t, &fakeStore{objects: map[string][]byte{}}),
-		`{"sourceObject":"org1/proj1/nope.pdf"}`)
-	if response.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", response.Code)
-	}
-}
-
-func TestPageCountInvalidPdf(t *testing.T) {
-	store := &fakeStore{objects: map[string][]byte{"org1/proj1/doc1.pdf": []byte("not a pdf")}}
-	response := postPageCount(newTestServer(t, store), `{"sourceObject":"org1/proj1/doc1.pdf"}`)
-	if response.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", response.Code)
-	}
-}
-
-func TestPageCountValidation(t *testing.T) {
-	handler := newTestServer(t, &fakeStore{objects: map[string][]byte{}})
-	for _, body := range []string{
-		`{`,
-		`{"sourceObject":""}`,
-		`{"sourceObject":"../etc/x.pdf"}`,
-	} {
-		if response := postPageCount(handler, body); response.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400 for %q, got %d", body, response.Code)
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes the review finding in https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088739.

## Problem

- `generatePdfPageImages` called `POST /page-count` before `POST /render-document`, so every first render of a document cost **two** GCS downloads, **two** pdfium parses and **two** ID-token mints — while `/render-document` already fails fast on the page limit before rendering anything.
- The typed `PdfPageLimitExceededError` only existed via that client-side pre-flight comparison. If the render-time 422 fired instead, it surfaced as a generic `Error`, so extraction runs recorded `EXTRACTION_PROVIDER_ERROR` instead of `PDF_PAGE_LIMIT_EXCEEDED`.

## Fix

- `POST /render-document` now includes the document's `pageCount` in its 422 body (`RenderPages` returns the count alongside `ErrTooManyPages`).
- The API client maps a 422 with a numeric `pageCount` to `PdfPageLimitExceededError`, keeping the same typed, user-facing message in chat and extraction runs.
- The `/page-count` endpoint, the client's `getPageCount` and the renderer's `GetPageCount` are deleted (no other callers).

A 422 body without `pageCount` (deploy skew with an older converter) falls back to the previous generic error message.

## Verification

- `go vet ./...` and `go test ./...` in `apps/pdf-converter` ✅
- `npm run biome:check`, `npm run typecheck` ✅
- `npm run test:parallel` in `apps/api`: 2214 passed, 0 failed ✅
- `npm run check:boundaries` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)