### PR TITLE
fix(llm): handle directory-less source paths in the derived pdf pages prefix

### DIFF
--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
@@ -24,6 +24,10 @@ describe("PdfPagesService", () => {
     )
   })
 
+  it("derives a root-level pages prefix when the source path has no directory", () => {
+    expect(buildService().derivedPagesPrefix("doc1.pdf")).toBe("derived/doc1/")
+  })
+
   it("builds the page object path", () => {
     expect(buildService().pageObjectPath("org1/proj1/doc1.pdf", 3)).toBe(
       "org1/proj1/derived/doc1/page-3.png",

--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.ts
@@ -16,9 +16,11 @@ export class PdfPagesService {
 
   derivedPagesPrefix(storageRelativePath: string): string {
     const lastSlashIndex = storageRelativePath.lastIndexOf("/")
-    const directory = storageRelativePath.slice(0, lastSlashIndex)
+    // lastIndexOf returns -1 for a bare filename: keep the derived tree at the root then.
+    const directoryPrefix =
+      lastSlashIndex === -1 ? "" : `${storageRelativePath.slice(0, lastSlashIndex)}/`
     const baseName = storageRelativePath.slice(lastSlashIndex + 1).replace(/\.[^.]+$/, "")
-    return `${directory}/derived/${baseName}/`
+    return `${directoryPrefix}derived/${baseName}/`
   }
 
   pageObjectPath(storageRelativePath: string, pageNumber: number): string {


### PR DESCRIPTION
## Summary

Fixes the truncation flagged in https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088763.

`derivedPagesPrefix` computed the directory with `slice(0, lastIndexOf("/"))`. For a slash-less `storageRelativePath`, `lastIndexOf` returns `-1`, so `slice(0, -1)` chopped the last character of the filename: `"doc1.pdf"` produced the corrupt prefix `"doc1.pd/derived/doc1/"`. Latent today (all production paths are `{org}/{proj}/{id}.{ext}`), but writes and reads share this function, so a future bare-name caller would plant derived trees at corrupt top-level prefixes without ever failing loudly.

The `-1` case is now handled explicitly: a bare filename maps to a root-level `derived/{name}/` prefix.

## Test plan

- [x] New regression test: `derivedPagesPrefix("doc1.pdf")` → `"derived/doc1/"` (verified failing before the fix, passing after)
- [x] `npm run biome:check`, `npm run typecheck`, and the full API suite (`npm run test:parallel`, 292 suites) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)