### PR TITLE
fix(llm): treat zero-page pdfs as an error instead of caching a silent empty render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - PDF documents sent to Gemma and MedGemma agents are now converted to images by a dedicated service, so heavy PDF processing no longer slows down the platform.
 
 ### Fixed
+- (beta) Sending an empty PDF to Gemma or MedGemma now shows a clear error instead of an invented answer.
 - The chat widget hint no longer blocks clicks on the page underneath.
 - (beta) The MCP Servers tab on the agent editor shows translated labels and each server's saved state.
 - Chat shows an error message instead of an empty reply when the model fails.

--- a/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-converter.client.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common"
 import { GoogleAuth, type IdTokenClient } from "google-auth-library"
+import { PdfHasNoPagesError } from "./pdf-has-no-pages.error"
 import { PdfPageLimitExceededError } from "./pdf-page-limit-exceeded.error"
 
 // Guards against oversized vision requests: each page becomes one image sent
@@ -48,9 +49,10 @@ export class PdfConverterClient {
   }
 
   // Renders a PDF document into individual page images.
-  // Returns the number of pages rendered. Throws PdfPageLimitExceededError
-  // (user-facing message) without rendering anything when the document has
-  // more pages than image-only models accept.
+  // Returns the number of pages rendered. Throws PdfHasNoPagesError or
+  // PdfPageLimitExceededError (user-facing messages) without rendering
+  // anything when the document has no pages or more pages than image-only
+  // models accept.
   async generatePdfPageImages({
     sourceObject,
     outputPrefix,
@@ -59,6 +61,9 @@ export class PdfConverterClient {
     outputPrefix: string
   }): Promise<number> {
     const pageCount = await this.getPageCount({ sourceObject })
+    if (pageCount === 0) {
+      throw new PdfHasNoPagesError()
+    }
     if (pageCount > MAX_PDF_PAGES_FOR_IMAGE_CONVERSION) {
       throw new PdfPageLimitExceededError(pageCount, MAX_PDF_PAGES_FOR_IMAGE_CONVERSION)
     }

--- a/apps/api/src/domains/documents/pdf-pages/pdf-has-no-pages.error.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-has-no-pages.error.ts
@@ -1,0 +1,11 @@
+// Thrown before rendering when a pdf reports zero pages (empty or corrupt
+// document): a zero count must fail loudly, otherwise the model would be
+// called with no page images and hallucinate from the bare prompt. The
+// message is user-facing: it is shown verbatim in the chat error bubble and
+// in extraction run error details.
+export class PdfHasNoPagesError extends Error {
+  constructor() {
+    super("This PDF has no pages that can be rendered.")
+    this.name = "PdfHasNoPagesError"
+  }
+}

--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
@@ -1,5 +1,6 @@
 import type { IFileStorage } from "../storage/file-storage.interface"
 import { PdfConverterClient } from "./pdf-converter.client"
+import { PdfHasNoPagesError } from "./pdf-has-no-pages.error"
 import { PdfPageLimitExceededError } from "./pdf-page-limit-exceeded.error"
 import { PdfPagesService } from "./pdf-pages.service"
 
@@ -101,6 +102,45 @@ describe("PdfPagesService", () => {
     await expect(imageUrlsPromise).rejects.toThrow(
       "This PDF has 25 pages; the maximum is 20 pages.",
     )
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe("http://pdf-converter.test/page-count")
+    expect(onPageCountUpdate).not.toHaveBeenCalled()
+  })
+
+  it("throws a user-facing error without rendering or caching when the pdf has no pages", async () => {
+    process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
+    const fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ pageCount: 0 }), { status: 200 }))
+    const onPageCountUpdate = jest.fn()
+
+    const imageUrlsPromise = buildService().getImageUrls({
+      document: { storageRelativePath: "org1/proj1/doc1.pdf", pdfPageCount: null },
+      onPageCountUpdate,
+      fileStorageService: buildFileStorageService(),
+    })
+
+    await expect(imageUrlsPromise).rejects.toBeInstanceOf(PdfHasNoPagesError)
+    await expect(imageUrlsPromise).rejects.toThrow("This PDF has no pages that can be rendered.")
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe("http://pdf-converter.test/page-count")
+    expect(onPageCountUpdate).not.toHaveBeenCalled()
+  })
+
+  it("re-checks the converter instead of trusting a cached zero page count", async () => {
+    process.env.PDF_CONVERTER_URL = "http://pdf-converter.test"
+    const fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ pageCount: 0 }), { status: 200 }))
+    const onPageCountUpdate = jest.fn()
+
+    const imageUrlsPromise = buildService().getImageUrls({
+      document: { storageRelativePath: "org1/proj1/doc1.pdf", pdfPageCount: 0 },
+      onPageCountUpdate,
+      fileStorageService: buildFileStorageService(),
+    })
+
+    await expect(imageUrlsPromise).rejects.toBeInstanceOf(PdfHasNoPagesError)
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     expect(String(fetchSpy.mock.calls[0]![0])).toBe("http://pdf-converter.test/page-count")
     expect(onPageCountUpdate).not.toHaveBeenCalled()

--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.ts
@@ -34,7 +34,10 @@ export class PdfPagesService {
     onPageCountUpdate: (pdfPageCount: number) => Promise<void>
     fileStorageService: IFileStorage
   }): Promise<string[]> {
-    if (pdfPageCount === null) {
+    // A zero count is never trusted: the converter client throws on zero-page
+    // pdfs before anything is persisted, so a cached 0 predates that guard
+    // and must be re-checked instead of silently producing zero image parts.
+    if (pdfPageCount === null || pdfPageCount === 0) {
       // If the PDF page count is not known, render the document to determine it.
       pdfPageCount = await this.pdfConverterClient.generatePdfPageImages({
         sourceObject: storageRelativePath,


### PR DESCRIPTION
Fixes the issue raised in https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088768.

## Problem

The pdf-converter returns `{ pageCount: 0 }` with HTTP 200 for a zero-page PDF: the page-limit check passes, the render loop never runs, and 0 is persisted to `pdf_page_count`. From then on every run on that document "succeeds" with zero image parts — the model answers from the bare prompt alone, and retries hit the cached 0 forever.

## Fix

- `PdfConverterClient.generatePdfPageImages` now throws a user-facing `PdfHasNoPagesError` ("This PDF has no pages that can be rendered.") when the page count is 0 — before rendering and before anything is persisted, mirroring the existing `PdfPageLimitExceededError` guard.
- `PdfPagesService.getImageUrls` no longer trusts a cached `pdfPageCount` of 0 (rows persisted before this guard existed): it re-checks the converter, which fails loudly instead of silently producing zero image parts.

## Tests

- New spec: converter reports 0 pages → rejects with the user-facing error, no render call, no `onPageCountUpdate`.
- New spec: cached `pdfPageCount: 0` → re-checks the converter instead of resolving to `[]` (the old silent-success behavior).
- Full API suite (`test:parallel`): 292 suites / 2227 tests passing; biome, typecheck and boundary checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)