### PR TITLE
fix(llm): delegate pdf page count caching to the connect repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - PDF documents sent to Gemma and MedGemma agents are now converted to images by a dedicated service, so heavy PDF processing no longer slows down the platform.
 
 ### Fixed
+- (beta) PDF extraction now reports an error when caching a document's page count fails, instead of silently re-rendering.
 - The chat widget hint no longer blocks clicks on the page underneath.
 - (beta) The MCP Servers tab on the agent editor shows translated labels and each server's saved state.
 - Chat shows an error message instead of an empty reply when the model fails.

--- a/apps/api/src/domains/documents/documents.service.ts
+++ b/apps/api/src/domains/documents/documents.service.ts
@@ -222,14 +222,14 @@ export class DocumentsService {
     documentId: string
     pdfPageCount: number
   }): Promise<void> {
-    await this.documentRepository.update(
-      {
-        id: documentId,
-        organizationId: connectScope.organizationId,
-        projectId: connectScope.projectId,
-      },
-      { pdfPageCount },
-    )
+    const { success } = await this.documentConnectRepository.updateOneById({
+      connectScope,
+      id: documentId,
+      fields: { pdfPageCount },
+    })
+    if (!success) {
+      throw new NotFoundException(`Document with id ${documentId} not found`)
+    }
   }
 
   async updateEmbeddingStatus({

--- a/apps/api/src/domains/documents/service-tests/update-pdf-page-count.spec.ts
+++ b/apps/api/src/domains/documents/service-tests/update-pdf-page-count.spec.ts
@@ -1,0 +1,73 @@
+import { NotFoundException } from "@nestjs/common"
+import { createOrganizationWithProject } from "@/domains/organizations/organization.factory"
+import { documentFactory } from "../document.factory"
+import { documentsServiceTestSetup } from "./test-setup"
+
+const getTestContext = documentsServiceTestSetup()
+
+describe("updatePdfPageCount", () => {
+  it("should persist the rendered page count on the document", async () => {
+    const { service, repositories } = getTestContext()
+
+    const { organization, project } = await createOrganizationWithProject(repositories)
+
+    const document = documentFactory.transient({ organization, project }).build({
+      title: "PDF document",
+      fileName: "file.pdf",
+    })
+    await repositories.documentRepository.save(document)
+
+    await service.updatePdfPageCount({
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      documentId: document.id,
+      pdfPageCount: 3,
+    })
+
+    const updatedDocument = await repositories.documentRepository.findOne({
+      where: { id: document.id },
+    })
+    expect(updatedDocument?.pdfPageCount).toBe(3)
+  })
+
+  it("should throw NotFoundException when document does not exist", async () => {
+    const { service, repositories } = getTestContext()
+
+    const { organization, project } = await createOrganizationWithProject(repositories)
+
+    await expect(
+      service.updatePdfPageCount({
+        connectScope: { organizationId: organization.id, projectId: project.id },
+        documentId: "00000000-0000-0000-0000-000000000000",
+        pdfPageCount: 3,
+      }),
+    ).rejects.toThrow(NotFoundException)
+  })
+
+  it("should throw NotFoundException when document belongs to another project", async () => {
+    const { service, repositories } = getTestContext()
+
+    const firstContext = await createOrganizationWithProject(repositories)
+    const secondContext = await createOrganizationWithProject(repositories)
+
+    const document = documentFactory
+      .transient({ organization: firstContext.organization, project: firstContext.project })
+      .build({ title: "PDF document", fileName: "file.pdf" })
+    await repositories.documentRepository.save(document)
+
+    await expect(
+      service.updatePdfPageCount({
+        connectScope: {
+          organizationId: secondContext.organization.id,
+          projectId: secondContext.project.id,
+        },
+        documentId: document.id,
+        pdfPageCount: 3,
+      }),
+    ).rejects.toThrow(NotFoundException)
+
+    const unchangedDocument = await repositories.documentRepository.findOne({
+      where: { id: document.id },
+    })
+    expect(unchangedDocument?.pdfPageCount).toBeNull()
+  })
+})


### PR DESCRIPTION
## Context

Follow-up to the review discussion on #675: https://github.com/bayesimpact/bayes-platform/pull/675#discussion_r3880088749

`DocumentsService.updatePdfPageCount` re-implemented connect scoping in a raw `documentRepository.update` criteria (against the rule in `apps/api/CLAUDE.md`) and, unlike its neighbors (`updateContent`, `updateEmbeddingStatus`, `resetForRecrawl`), never checked whether the update matched a row — a scope mismatch was a silent no-op, so the page count was never cached and the pdf-converter re-rendered on every run with no surfaced error.

## Fix

- Route the update through `documentConnectRepository.updateOneById` (same pattern as `AgentMessageAttachmentDocumentsService.updatePdfPageCount` from #675) and throw `NotFoundException` when nothing matches.
- Note: the `deleted_at` concern from the review comment is moot — `Document` has no soft-delete column — but the scoping delegation and the silent no-op were real.

## Tests

New `service-tests/update-pdf-page-count.spec.ts` (written first, red on the old code):
- persists the rendered page count
- throws `NotFoundException` for an unknown document id
- throws `NotFoundException` and leaves the row untouched when the document belongs to another project

`biome:check`, `typecheck`, `check:boundaries`, and the full `test:parallel` suite (2228 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)