### PR TITLE
fix(api): mark document failed and return 503 when the embeddings job cannot be enqueued

### DIFF
--- a/apps/api/src/domains/documents/embeddings/bull-mq-document-embeddings-batch.service.spec.ts
+++ b/apps/api/src/domains/documents/embeddings/bull-mq-document-embeddings-batch.service.spec.ts
@@ -1,7 +1,11 @@
+import { ServiceUnavailableException } from "@nestjs/common"
 import type { Queue } from "bullmq"
 import { BullMqDocumentEmbeddingsBatchService } from "./bull-mq-document-embeddings-batch.service"
 import type { DocumentEmbeddingQueueSyncService } from "./document-embedding-queue-sync.service"
-import { DOCUMENT_EMBEDDINGS_JOB_NAME } from "./document-embeddings.constants"
+import {
+  DOCUMENT_EMBEDDINGS_ENQUEUE_TIMEOUT_MS,
+  DOCUMENT_EMBEDDINGS_JOB_NAME,
+} from "./document-embeddings.constants"
 
 describe("BullMqDocumentEmbeddingsBatchService", () => {
   it("adds a create-embeddings job then marks document queued and notifies", async () => {
@@ -37,5 +41,65 @@ describe("BullMqDocumentEmbeddingsBatchService", () => {
     expect(addJob).toHaveBeenCalledWith(DOCUMENT_EMBEDDINGS_JOB_NAME, payload)
     expect(markDocumentAsQueuedAndNotify).toHaveBeenCalledWith(payload)
     expect(result).toBe(afterEnqueuePatch)
+  })
+
+  const payload = {
+    documentId: "document-id",
+    organizationId: "organization-id",
+    projectId: "project-id",
+    uploadedByUserId: "user-id",
+    origin: "document-upload" as const,
+    currentTraceId: "trace-id",
+  }
+
+  function buildService(addJob: jest.Mock) {
+    const queue = { add: addJob } as unknown as Queue
+    const markDocumentAsQueuedAndNotify = jest.fn().mockResolvedValue(undefined)
+    const markDocumentAsEnqueueFailedAndNotify = jest.fn().mockResolvedValue(undefined)
+    const service = new BullMqDocumentEmbeddingsBatchService(queue, {
+      markDocumentAsQueuedAndNotify,
+      markDocumentAsEnqueueFailedAndNotify,
+    } as unknown as DocumentEmbeddingQueueSyncService)
+    return { service, markDocumentAsQueuedAndNotify, markDocumentAsEnqueueFailedAndNotify }
+  }
+
+  it("marks the document failed and throws 503 when the queue rejects the job", async () => {
+    const { service, markDocumentAsQueuedAndNotify, markDocumentAsEnqueueFailedAndNotify } =
+      buildService(jest.fn().mockRejectedValue(new Error("Connection is closed.")))
+
+    await expect(service.enqueueCreateEmbeddingsForDocument(payload)).rejects.toThrow(
+      ServiceUnavailableException,
+    )
+    expect(markDocumentAsEnqueueFailedAndNotify).toHaveBeenCalledWith(payload)
+    expect(markDocumentAsQueuedAndNotify).not.toHaveBeenCalled()
+  })
+
+  it("marks the document failed and throws 503 when the queue never answers", async () => {
+    jest.useFakeTimers()
+    try {
+      const { service, markDocumentAsEnqueueFailedAndNotify } = buildService(
+        jest.fn().mockReturnValue(new Promise(() => {})),
+      )
+
+      const enqueuePromise = service.enqueueCreateEmbeddingsForDocument(payload)
+      const assertion = expect(enqueuePromise).rejects.toThrow(ServiceUnavailableException)
+      await jest.advanceTimersByTimeAsync(DOCUMENT_EMBEDDINGS_ENQUEUE_TIMEOUT_MS)
+      await assertion
+      expect(markDocumentAsEnqueueFailedAndNotify).toHaveBeenCalledWith(payload)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it("still throws 503 when marking the document failed also fails", async () => {
+    const queue = { add: jest.fn().mockRejectedValue(new Error("boom")) } as unknown as Queue
+    const service = new BullMqDocumentEmbeddingsBatchService(queue, {
+      markDocumentAsQueuedAndNotify: jest.fn(),
+      markDocumentAsEnqueueFailedAndNotify: jest.fn().mockRejectedValue(new Error("db down")),
+    } as unknown as DocumentEmbeddingQueueSyncService)
+
+    await expect(service.enqueueCreateEmbeddingsForDocument(payload)).rejects.toThrow(
+      ServiceUnavailableException,
+    )
   })
 })

--- a/apps/api/src/domains/documents/embeddings/bull-mq-document-embeddings-batch.service.ts
+++ b/apps/api/src/domains/documents/embeddings/bull-mq-document-embeddings-batch.service.ts
@@ -1,9 +1,11 @@
 import { InjectQueue } from "@nestjs/bullmq"
-import { Injectable, Logger } from "@nestjs/common"
+import { Injectable, Logger, ServiceUnavailableException } from "@nestjs/common"
 import type { Queue } from "bullmq"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DocumentEmbeddingQueueSyncService } from "./document-embedding-queue-sync.service"
 import {
+  DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE,
+  DOCUMENT_EMBEDDINGS_ENQUEUE_TIMEOUT_MS,
   DOCUMENT_EMBEDDINGS_JOB_NAME,
   DOCUMENT_EMBEDDINGS_QUEUE_NAME,
 } from "./document-embeddings.constants"
@@ -22,12 +24,66 @@ export class BullMqDocumentEmbeddingsBatchService {
     private readonly documentEmbeddingQueueSyncService: DocumentEmbeddingQueueSyncService,
   ) {}
 
+  /**
+   * Hands the job to BullMQ, then marks the document `queued`.
+   *
+   * If Redis is unreachable, `queue.add` would otherwise hang through ioredis' reconnect
+   * retries (well past any HTTP timeout) and leave the document `pending`, a state the stuck
+   * sweep does not cover and the reprocess action refuses. So the add is bounded, and on
+   * failure the document is marked `failed` before a 503 is thrown to the caller.
+   */
   async enqueueCreateEmbeddingsForDocument(
     payload: CreateDocumentEmbeddingsJobPayload,
   ): Promise<DocumentEmbeddingAfterEnqueuePatch> {
     this.logger.log(`Enqueuing document embeddings job ${JSON.stringify(payload)}`)
-    await this.documentEmbeddingsQueue.add(DOCUMENT_EMBEDDINGS_JOB_NAME, payload)
+    try {
+      await this.addJobWithTimeout(payload)
+    } catch (enqueueError) {
+      this.logger.error(
+        `Failed to enqueue document embeddings job for document ${payload.documentId}: ${
+          enqueueError instanceof Error ? enqueueError.message : String(enqueueError)
+        }`,
+      )
+      await this.markAsEnqueueFailedBestEffort(payload)
+      throw new ServiceUnavailableException(DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE)
+    }
 
     return await this.documentEmbeddingQueueSyncService.markDocumentAsQueuedAndNotify(payload)
+  }
+
+  private async addJobWithTimeout(payload: CreateDocumentEmbeddingsJobPayload): Promise<void> {
+    let timeoutHandle: NodeJS.Timeout | undefined
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(
+          new Error(
+            `Timed out after ${DOCUMENT_EMBEDDINGS_ENQUEUE_TIMEOUT_MS}ms waiting for the queue to accept the job`,
+          ),
+        )
+      }, DOCUMENT_EMBEDDINGS_ENQUEUE_TIMEOUT_MS)
+    })
+    try {
+      await Promise.race([
+        this.documentEmbeddingsQueue.add(DOCUMENT_EMBEDDINGS_JOB_NAME, payload),
+        timeoutPromise,
+      ])
+    } finally {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
+    }
+  }
+
+  /** The original enqueue error is what the caller must see, so a DB failure here is only logged. */
+  private async markAsEnqueueFailedBestEffort(
+    payload: CreateDocumentEmbeddingsJobPayload,
+  ): Promise<void> {
+    try {
+      await this.documentEmbeddingQueueSyncService.markDocumentAsEnqueueFailedAndNotify(payload)
+    } catch (markError) {
+      this.logger.error(
+        `Could not mark document ${payload.documentId} as failed after enqueue error: ${
+          markError instanceof Error ? markError.message : String(markError)
+        }`,
+      )
+    }
   }
 }

--- a/apps/api/src/domains/documents/embeddings/document-embedding-queue-sync.service.spec.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embedding-queue-sync.service.spec.ts
@@ -3,6 +3,7 @@ import type { Repository } from "typeorm"
 import type { Document } from "../document.entity"
 import { DocumentEmbeddingQueueSyncService } from "./document-embedding-queue-sync.service"
 import type { DocumentEmbeddingStatusNotifierService } from "./document-embedding-status-notifier.service"
+import { DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE } from "./document-embeddings.constants"
 
 describe("DocumentEmbeddingQueueSyncService", () => {
   const payload = {
@@ -87,6 +88,50 @@ describe("DocumentEmbeddingQueueSyncService", () => {
     expect(result).toEqual({
       embeddingStatus: "queued",
       embeddingError: null,
+      updatedAt: document.updatedAt,
+    })
+  })
+
+  it("marks the document failed with the enqueue error, saves, and notifies", async () => {
+    const document = {
+      id: payload.documentId,
+      organizationId: payload.organizationId,
+      projectId: payload.projectId,
+      embeddingStatus: "pending",
+      embeddingError: null,
+      updatedAt: new Date("2026-05-04T12:00:00.000Z"),
+    } as Document
+
+    const queryBuilder = {
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(document),
+    }
+    const save = jest.fn().mockImplementation((entity: Document) => Promise.resolve(entity))
+    const documentRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      save,
+    } as unknown as Repository<Document>
+
+    const notifyEmbeddingStatusChanged = jest.fn().mockResolvedValue(undefined)
+    const service = new DocumentEmbeddingQueueSyncService(documentRepository, {
+      notifyEmbeddingStatusChanged,
+    } as unknown as DocumentEmbeddingStatusNotifierService)
+
+    const result = await service.markDocumentAsEnqueueFailedAndNotify(payload)
+
+    expect(document.embeddingStatus).toBe("failed")
+    expect(document.embeddingError).toBe(DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE)
+    expect(save).toHaveBeenCalledWith(document)
+    expect(notifyEmbeddingStatusChanged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: payload.documentId,
+        embeddingStatus: "failed",
+        embeddingError: DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE,
+      }),
+    )
+    expect(result).toEqual({
+      embeddingStatus: "failed",
+      embeddingError: DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE,
       updatedAt: document.updatedAt,
     })
   })

--- a/apps/api/src/domains/documents/embeddings/document-embedding-queue-sync.service.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embedding-queue-sync.service.ts
@@ -6,6 +6,7 @@ import type { RequiredConnectScope } from "@/common/entities/connect-required-fi
 import { Document } from "../document.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DocumentEmbeddingStatusNotifierService } from "./document-embedding-status-notifier.service"
+import { DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE } from "./document-embeddings.constants"
 import type {
   CreateDocumentEmbeddingsJobPayload,
   DocumentEmbeddingAfterEnqueuePatch,
@@ -25,6 +26,26 @@ export class DocumentEmbeddingQueueSyncService {
   async markDocumentAsQueuedAndNotify(
     payload: CreateDocumentEmbeddingsJobPayload,
   ): Promise<DocumentEmbeddingAfterEnqueuePatch> {
+    return await this.markDocumentStatusAndNotify(payload, {
+      embeddingStatus: "queued",
+      embeddingError: null,
+    })
+  }
+
+  /** Called when the job never reached the queue, so the document does not stay `pending` forever. */
+  async markDocumentAsEnqueueFailedAndNotify(
+    payload: CreateDocumentEmbeddingsJobPayload,
+  ): Promise<DocumentEmbeddingAfterEnqueuePatch> {
+    return await this.markDocumentStatusAndNotify(payload, {
+      embeddingStatus: "failed",
+      embeddingError: DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE,
+    })
+  }
+
+  private async markDocumentStatusAndNotify(
+    payload: CreateDocumentEmbeddingsJobPayload,
+    patch: Pick<Document, "embeddingStatus" | "embeddingError">,
+  ): Promise<DocumentEmbeddingAfterEnqueuePatch> {
     const connectScope: RequiredConnectScope = {
       organizationId: payload.organizationId,
       projectId: payload.projectId,
@@ -36,8 +57,8 @@ export class DocumentEmbeddingQueueSyncService {
     if (!document) {
       throw new NotFoundException(`Document with id ${payload.documentId} not found`)
     }
-    document.embeddingStatus = "queued"
-    document.embeddingError = null
+    document.embeddingStatus = patch.embeddingStatus
+    document.embeddingError = patch.embeddingError
     const savedDocument = await this.documentConnectRepository.saveOne(document)
     await this.embeddingStatusNotifierService.notifyEmbeddingStatusChanged({
       documentId: savedDocument.id,

--- a/apps/api/src/domains/documents/embeddings/document-embeddings-stuck-sweep.service.spec.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings-stuck-sweep.service.spec.ts
@@ -2,6 +2,7 @@ import type { Repository } from "typeorm"
 import type { Document } from "../document.entity"
 import type { DocumentsService } from "../documents.service"
 import type { DocumentEmbeddingStatusNotifierService } from "./document-embedding-status-notifier.service"
+import { DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE } from "./document-embeddings.constants"
 import { DOCUMENT_EMBEDDINGS_STUCK_TIMEOUT_ERROR_MESSAGE } from "./document-embeddings-stuck.constants"
 import { DocumentEmbeddingsStuckSweepService } from "./document-embeddings-stuck-sweep.service"
 
@@ -116,5 +117,47 @@ describe("DocumentEmbeddingsStuckSweepService", () => {
 
     expect(result).toEqual({ timedOutCount: 0 })
     expect(documentsService.saveOne).not.toHaveBeenCalled()
+  })
+
+  it("marks uploaded project documents left pending as failed with the enqueue error", async () => {
+    const pendingDocument = {
+      id: "doc-2",
+      organizationId: "org-1",
+      projectId: "proj-1",
+      sourceType: "project",
+      uploadStatus: "uploaded",
+      embeddingStatus: "pending",
+      embeddingError: null,
+      updatedAt: new Date("2020-01-01T00:00:00.000Z"),
+    } as Document
+
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([pendingDocument]),
+    }
+    const documentRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    } as unknown as Repository<Document>
+
+    const saveOne = jest.fn().mockImplementation((entity: Document) => Promise.resolve(entity))
+    const notifyEmbeddingStatusChanged = jest.fn().mockResolvedValue(undefined)
+
+    const service = new DocumentEmbeddingsStuckSweepService(
+      documentRepository,
+      { saveOne } as unknown as DocumentsService,
+      { notifyEmbeddingStatusChanged } as unknown as DocumentEmbeddingStatusNotifierService,
+    )
+
+    const result = await service.sweepStuckDocuments()
+
+    expect(pendingDocument.embeddingStatus).toBe("failed")
+    expect(pendingDocument.embeddingError).toBe(DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE)
+    expect(notifyEmbeddingStatusChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: "doc-2", embeddingStatus: "failed" }),
+    )
+    expect(result).toEqual({ timedOutCount: 1 })
   })
 })

--- a/apps/api/src/domains/documents/embeddings/document-embeddings-stuck-sweep.service.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings-stuck-sweep.service.ts
@@ -1,11 +1,12 @@
 import { Injectable, Logger } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
-import type { Repository } from "typeorm"
+import { Brackets, type Repository } from "typeorm"
 import { Document } from "../document.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DocumentsService } from "../documents.service"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DocumentEmbeddingStatusNotifierService } from "./document-embedding-status-notifier.service"
+import { DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE } from "./document-embeddings.constants"
 import { getDocumentEmbeddingStuckThresholdSeconds } from "./document-embeddings-stuck.config"
 import {
   DOCUMENT_EMBEDDINGS_STUCK_SWEEP_BATCH_LIMIT,
@@ -26,19 +27,37 @@ export class DocumentEmbeddingsStuckSweepService {
     const thresholdSeconds = getDocumentEmbeddingStuckThresholdSeconds()
     const cutoff = new Date(Date.now() - thresholdSeconds * 1000)
 
+    // `pending` + uploaded project documents are those whose enqueue never happened
+    // (for example the API crashed between the upload confirm and the queue add).
     const stuckDocuments = await this.documentRepository
       .createQueryBuilder("document")
-      .where("document.embedding_status IN (:...statuses)", {
-        statuses: ["queued", "processing"],
-      })
+      .where(
+        new Brackets((statusWhere) => {
+          statusWhere
+            .where("document.embedding_status IN (:...statuses)", {
+              statuses: ["queued", "processing"],
+            })
+            .orWhere(
+              "document.embedding_status = :pendingStatus AND document.upload_status = :uploadedStatus AND document.source_type = :projectSourceType",
+              {
+                pendingStatus: "pending",
+                uploadedStatus: "uploaded",
+                projectSourceType: "project",
+              },
+            )
+        }),
+      )
       .andWhere("document.updated_at < :cutoff", { cutoff })
       .orderBy("document.updated_at", "ASC")
       .limit(DOCUMENT_EMBEDDINGS_STUCK_SWEEP_BATCH_LIMIT)
       .getMany()
 
     for (const document of stuckDocuments) {
+      const wasNeverEnqueued = document.embeddingStatus === "pending"
       document.embeddingStatus = "failed"
-      document.embeddingError = DOCUMENT_EMBEDDINGS_STUCK_TIMEOUT_ERROR_MESSAGE
+      document.embeddingError = wasNeverEnqueued
+        ? DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE
+        : DOCUMENT_EMBEDDINGS_STUCK_TIMEOUT_ERROR_MESSAGE
       const savedDocument = await this.documentsService.saveOne(document)
       await this.embeddingStatusNotifierService.notifyEmbeddingStatusChanged({
         documentId: savedDocument.id,

--- a/apps/api/src/domains/documents/embeddings/document-embeddings.constants.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings.constants.ts
@@ -3,3 +3,10 @@ const DEFAULT_DOCUMENT_EMBEDDINGS_QUEUE_NAME = "document-embeddings"
 export const DOCUMENT_EMBEDDINGS_QUEUE_NAME =
   process.env.DOCUMENT_EMBEDDINGS_QUEUE_NAME ?? DEFAULT_DOCUMENT_EMBEDDINGS_QUEUE_NAME
 export const DOCUMENT_EMBEDDINGS_JOB_NAME = "create-embeddings"
+
+/** Max time to wait for BullMQ to accept a create-embeddings job before failing the document. */
+export const DOCUMENT_EMBEDDINGS_ENQUEUE_TIMEOUT_MS = 10_000
+
+/** User-visible reason when the job could not be handed to the queue (Redis down, timeout). */
+export const DOCUMENT_EMBEDDINGS_ENQUEUE_FAILED_ERROR_MESSAGE =
+  "Document could not be scheduled for processing. Please retry."


### PR DESCRIPTION
Closes #174

## Problem

When Redis is not reachable, `queue.add` in the document embeddings batch service waits through the ioredis reconnect retries. The confirm endpoint does not answer before the HTTP timeout. The document stays in `pending`. The stuck sweep does not cover `pending`. The reprocess action accepts only `failed`. The user cannot recover the document.

## Changes

- Bound `queue.add` with a 10 second timeout.
- If the enqueue fails or times out, set the document to `failed` with a user-visible message. Then throw a 503.
- If the database write also fails, log it and still throw the 503.
- Add `markDocumentAsEnqueueFailedAndNotify` to the queue sync service. Share the code with the `queued` path.
- Extend the stuck sweep to `pending` documents that are uploaded and have the `project` source type. This recovers documents that are already stuck in production.

`reprocessOne` uses the same method, so it gets the same behavior.

## Not in this PR

- The crawling batch services have the same pattern. They run in the workers, not in an HTTP request. They are unchanged.
- No changelog entry.

## Tests

- 5 new unit tests: queue rejects, queue never answers, database write fails after enqueue error, failed marking, sweep of pending documents.
- `confirm-many` e2e and the full API suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
