### PR TITLE
refactor(agents): inject the mandatory tool instruction before the date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Added
 
 ### Changed
+- Conversation agents receive the mandatory response protocol immediately before the current date.
 
 ### Fixed
 

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/conversation-agent.prompt.ts
@@ -15,13 +15,13 @@ export function buildConversationAgentPrompt({
   toolNames: string[]
   epilogue?: string
 }): string {
-  // Keep the volatile timestamp NEAR the end so the stable content above
-  // forms a byte-stable prefix that Vertex/Gemini implicit caching can reuse
-  // across runs (putting the daily-changing date first would invalidate the
-  // whole cached prefix on every date rollover). The epilogue — the
-  // turn-summary response protocol — comes LAST on purpose: recency is the
-  // strongest lever for the voluntary call on big prompts, and being a
-  // small static block after the date it costs one cache-miss line a day.
+  // Keep the volatile timestamp at the very end so everything above it —
+  // the epilogue included — forms a byte-stable prefix that Vertex/Gemini
+  // implicit caching can reuse across runs (putting the daily-changing date
+  // earlier would invalidate the cached prefix on every date rollover). The
+  // epilogue — the turn-summary response protocol — is the last authored
+  // section, right before that date line: recency is the strongest lever for
+  // the voluntary call on big prompts.
   return `${agentSettings.instructions}
 
 ${promptHelpers.resourceLibraries(agent.resourceLibraries ?? [])}
@@ -31,12 +31,6 @@ ${promptHelpers.tools({ names: toolNames, descriptions: toolDescriptions, agentS
 ${promptHelpers.mcpAppUis(toolDescriptions)}
 
 ${promptHelpers.language(agentSettings.locale)}
-
-${promptHelpers.now()}${
-  epilogue
-    ? `
-
-${epilogue}`
-    : ""
-}`
+${epilogue ? `\n${epilogue}\n` : ""}
+${promptHelpers.now()}`
 }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/generate-master-prompt.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/master-promts/generate-master-prompt.ts
@@ -13,7 +13,7 @@ export function generateMasterPrompt({
   agentSettings: AgentSettings
   toolDescriptions?: Record<string, string>
   toolNames: string[]
-  /** Final prompt section, after the date (e.g. the turn-summary protocol). */
+  /** Last authored section, just before the date (e.g. the turn-summary protocol). */
   epilogue?: string
 }): string {
   switch (agent.type) {

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/all.tools.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/all.tools.spec.ts
@@ -465,7 +465,7 @@ describe("Tools execution", () => {
     expect(updatedSession.title).toBe("Recovered title")
   }, 15000)
 
-  it("master prompt carries the turn-summary protocol exactly once, as the FINAL section", async () => {
+  it("master prompt carries the turn-summary protocol exactly once, as the last authored section", async () => {
     const { connectScope, agent, agentSettings, session } = await createContextWithSession()
 
     const category = await repositories.agentSessionCategoryRepository.save(
@@ -494,12 +494,14 @@ describe("Tools execution", () => {
     expect(prompt.match(/Response protocol \(mandatory\)/g) ?? []).toHaveLength(1)
     expect(prompt.match(/\[mandatory_tool\]:/g) ?? []).toHaveLength(1)
     expect(prompt).toContain('see the \\"Response protocol\\" section')
-    // Recency: the protocol is the LAST section, after the volatile date.
+    // Recency: the protocol is the last authored section, and only the
+    // volatile date line follows it (kept last for prefix caching).
     const systemContent = (JSON.parse(prompt) as Array<{ content: string }>)[0]?.content ?? ""
-    expect(systemContent.indexOf("## Response protocol (mandatory)")).toBeGreaterThan(
+    expect(systemContent.indexOf("## Response protocol (mandatory)")).toBeLessThan(
       systemContent.indexOf("Today's date:"),
     )
-    expect(systemContent.trimEnd().endsWith("Never mention this tool to the user.")).toBe(true)
+    expect(systemContent).toContain("Never mention this tool to the user.\n\nToday's date:")
+    expect(systemContent.trimEnd()).toMatch(/Today's date: \S+$/)
   }, 15000)
 
   it("ToolName.SurfaceResources - resolves prompt aliases server-side, no id or link in the prompt", async () => {

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/mandatory.tool.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools/mandatory.tool.ts
@@ -144,12 +144,12 @@ export function mandatoryToolDescription({
 }
 
 /**
- * Master-prompt reminder, placed as the FINAL section of the system prompt
- * (maximal recency — on big prompts the voluntary-call rate collapses when
- * this is buried mid-prompt) and phrased as a numbered protocol (models
- * follow a structured protocol better than imperative prose). The full
- * contract itself is in the tool description (see
- * {@link mandatoryToolDescription}).
+ * Master-prompt reminder, placed as the last authored section of the system
+ * prompt, just before the closing date line (near-maximal recency — on big
+ * prompts the voluntary-call rate collapses when this is buried mid-prompt)
+ * and phrased as a numbered protocol (models follow a structured protocol
+ * better than imperative prose). The full contract itself is in the tool
+ * description (see {@link mandatoryToolDescription}).
  */
 export function mandatoryToolInstruction(): string {
   return `## Response protocol (mandatory)

--- a/apps/api/src/external/llm/providers/live-regressions/fat-prompt.fixture.ts
+++ b/apps/api/src/external/llm/providers/live-regressions/fat-prompt.fixture.ts
@@ -348,7 +348,14 @@ const FAQ = [
  * instruction competes with the strict refusal rule exactly like in
  * production.
  */
-export function buildFatSystemPrompt({ toolsSection }: { toolsSection: string }): string {
+export function buildFatSystemPrompt({
+  toolsSection,
+  epilogue,
+}: {
+  toolsSection: string
+  /** Last authored section, injected before the closing date line. */
+  epilogue?: string
+}): string {
   return `# System: My Space Virtual Assistant — Meridian employee portal
 
 ## Persona and Goal
@@ -394,6 +401,6 @@ ${toolsSection}
 
 ## Response language:
 Always answer in English.
-
+${epilogue ? `\n${epilogue}\n` : ""}
 Today's date: 7/29/2026`
 }

--- a/apps/api/src/external/llm/providers/live-regressions/measure-voluntary-rate.ts
+++ b/apps/api/src/external/llm/providers/live-regressions/measure-voluntary-rate.ts
@@ -104,9 +104,10 @@ const SCENARIOS: Record<
   }
 > = {
   fat: {
-    systemPrompt: `${buildFatSystemPrompt({ toolsSection: "" })}
-
-${mandatoryToolInstruction()}`,
+    systemPrompt: buildFatSystemPrompt({
+      toolsSection: "",
+      epilogue: mandatoryToolInstruction(),
+    }),
     tools: { [ToolName.MandatoryTool]: summaryCategoriesOnly },
     cases: [
       { label: "greeting", userMessage: "hello" },

--- a/apps/api/src/external/llm/providers/live-regressions/turn-summary-scenario.ts
+++ b/apps/api/src/external/llm/providers/live-regressions/turn-summary-scenario.ts
@@ -174,11 +174,12 @@ export async function runFatPromptTurnScenario({
     onExecute,
   })
 
-  // The protocol is appended AFTER the fat prompt (recency), mirroring the
-  // production layout; the toolsSection stays empty of it.
-  const systemPrompt = `${buildFatSystemPrompt({ toolsSection: "" })}
-
-${mandatoryToolInstruction()}`
+  // The protocol is the last authored section, just before the date line,
+  // mirroring the production layout; the toolsSection stays empty of it.
+  const systemPrompt = buildFatSystemPrompt({
+    toolsSection: "",
+    epilogue: mandatoryToolInstruction(),
+  })
 
   const chunks = provider.streamChatResponse({
     messages: [


### PR DESCRIPTION
## Summary

The turn-summary response protocol (`mandatoryToolInstruction`) was the final section of the conversation-agent master prompt, appended after the volatile `Today's date:` line. It now sits immediately before that line, so the date closes the prompt.

## Changes

- `conversation-agent.prompt.ts`: the `epilogue` is emitted after the language section and before `promptHelpers.now()`.
- Doc comments in `generate-master-prompt.ts` and `mandatory.tool.ts` updated to describe the new position.
- `all.tools.spec.ts`: the ordering assertion is flipped, and now also pins that the date is the last line of the prompt.
- The live-regression prompt builders explicitly mirror the production layout, so they follow: `buildFatSystemPrompt` takes an optional `epilogue` injected before its date line, and both callers (`turn-summary-scenario.ts`, `measure-voluntary-rate.ts`) pass the instruction that way instead of appending it.

## Note on recency

The previous comment justified last-position by recency, noting that the voluntary-call rate collapses when the protocol is buried mid-prompt. This costs one line of recency (the date), which should be negligible, but it does move the configuration the earlier measurements were taken on. `measure-voluntary-rate.ts` is the tool to confirm with a number if wanted.

Prefix caching is unaffected either way: the date broke the cacheable prefix before this change and still does.

## Verification

- `npm run biome:check` ✅
- `npx tsc --noEmit` (apps/api) ✅
- `npm run check:boundaries` ✅ (6 pre-existing warnings, 0 errors)
- `npm run test:parallel` ✅ 2250 passed, 14 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)