### PR TITLE
fix(workers): cpu-workers pool starts again; smoke and tests boot every queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
-- Background jobs (evaluations, CSV extraction, crawling, extraction sessions) start again after a worker startup failure.
 - Refreshing the page during a reply no longer loses the answer.
 - An interrupted reply can be sent again.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Background jobs (evaluations, CSV extraction, crawling, extraction sessions) start again after a worker startup failure.
 - Refreshing the page during a reply no longer loses the answer.
 - An interrupted reply can be sent again.
 

--- a/apps/api/jest.setup-early.ts
+++ b/apps/api/jest.setup-early.ts
@@ -4,8 +4,7 @@
  */
 delete process.env.BULL_BOARD_ENABLED
 
-// Worker queue selection fails fast when unset (see worker-pools.ts). Provide
-// defaults so specs importing worker constants/modules don't throw at import.
-process.env.WORKER_QUEUE_NAMES ??=
-  "evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,extraction-agent-session-queue,url-crawling,document-embeddings,document-embeddings-stuck-sweep,web-source-embeddings"
+// Worker queue selection fails fast when unset (see worker-pools.ts). `all`
+// enables every known queue, so this file never carries a copy of the list.
+process.env.WORKER_QUEUE_NAMES ??= "all"
 process.env.WORKERS_HEALTH_QUEUE_NAME ??= "document-embeddings"

--- a/apps/api/src/domains/agents/extraction-agent-sessions/extraction-agent-session-run-llm.service.ts
+++ b/apps/api/src/domains/agents/extraction-agent-sessions/extraction-agent-session-run-llm.service.ts
@@ -24,7 +24,7 @@ import {
   type IFileStorage,
 } from "@/domains/documents/storage/file-storage.interface"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
-import { ProjectsService } from "@/domains/projects/projects.service"
+import { ProjectRepository } from "@/domains/projects/project.repository"
 import { LlmServiceBase } from "@/external/llm"
 import { modelRequiresPdfAsImages } from "@/external/llm/agent-provider"
 import type { Agent } from "../agent.entity"
@@ -49,7 +49,7 @@ export class ExtractionAgentSessionRunLlmService extends LlmServiceBase {
     @Inject(FILE_STORAGE_SERVICE)
     private readonly fileStorageService: IFileStorage,
     private readonly statusNotifierService: ExtractionAgentSessionStatusNotifierService,
-    private readonly projectsService: ProjectsService,
+    private readonly projectRepository: ProjectRepository,
     private readonly pdfPagesService: PdfPagesService,
     private readonly documentsService: DocumentsService,
     @Inject("_MockLLMProvider")
@@ -130,7 +130,7 @@ export class ExtractionAgentSessionRunLlmService extends LlmServiceBase {
         connectScope,
       })
 
-      const llmFeatures = await this.projectsService.getLlmFeatures(connectScope)
+      const llmFeatures = await this.projectRepository.getLlmFeatures(connectScope)
       const result = await this.getProviderForModel(agentSettings.model).generateStructuredOutput({
         message: llmMessage,
         schema: agentSettings.outputJsonSchema,

--- a/apps/api/src/worker-pools.spec.ts
+++ b/apps/api/src/worker-pools.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ALL_WORKER_QUEUES_SENTINEL,
   KNOWN_WORKER_QUEUE_NAMES,
   parseEnabledWorkerQueueNames,
   WORKER_QUEUE_NAMES_ENV,
@@ -34,6 +35,17 @@ describe("parseEnabledWorkerQueueNames", () => {
     const [first, second] = KNOWN_WORKER_QUEUE_NAMES
     process.env[WORKER_QUEUE_NAMES_ENV] = `  ${first} , ${second} ,`
     expect(parseEnabledWorkerQueueNames()).toEqual([first, second])
+  })
+
+  it("returns every known queue for the `all` sentinel", () => {
+    process.env[WORKER_QUEUE_NAMES_ENV] = ` ${ALL_WORKER_QUEUES_SENTINEL} `
+    expect(parseEnabledWorkerQueueNames()).toEqual([...KNOWN_WORKER_QUEUE_NAMES])
+  })
+
+  it("does not accept the `all` sentinel mixed with queue names", () => {
+    process.env[WORKER_QUEUE_NAMES_ENV] =
+      `${ALL_WORKER_QUEUES_SENTINEL},${KNOWN_WORKER_QUEUE_NAMES[0]}`
+    expect(() => parseEnabledWorkerQueueNames()).toThrow(ALL_WORKER_QUEUES_SENTINEL)
   })
 
   it("returns every known queue when all are listed", () => {

--- a/apps/api/src/worker-pools.ts
+++ b/apps/api/src/worker-pools.ts
@@ -40,15 +40,27 @@ export const KNOWN_WORKER_QUEUE_NAMES: readonly string[] = [
 export const WORKER_QUEUE_NAMES_ENV = "WORKER_QUEUE_NAMES"
 
 /**
+ * Sentinel value: consume every known queue. Meant for the CI smoke check and
+ * the test setup, so they never carry a copy of the queue list that can drift
+ * from the code (see #732). Production pools list their queues explicitly.
+ */
+export const ALL_WORKER_QUEUES_SENTINEL = "all"
+
+/**
  * Parse the comma-separated list of queue names this instance should consume,
  * supplied via the `WORKER_QUEUE_NAMES` env var. Production runs two instance
  * types (GPU / CPU); each sets this var to the subset of queues it owns.
+ *
+ * The value `all` (ALL_WORKER_QUEUES_SENTINEL) enables every known queue.
  *
  * Fails fast (throws) when the var is missing/empty or names an unknown queue,
  * so a misconfigured instance never silently consumes the wrong queues.
  */
 export function parseEnabledWorkerQueueNames(): string[] {
   const rawValue = process.env[WORKER_QUEUE_NAMES_ENV]
+  if (rawValue?.trim() === ALL_WORKER_QUEUES_SENTINEL) {
+    return [...KNOWN_WORKER_QUEUE_NAMES]
+  }
   const queueNames = (rawValue ?? "")
     .split(",")
     .map((queueName) => queueName.trim())

--- a/apps/api/src/workers-app.module.spec.ts
+++ b/apps/api/src/workers-app.module.spec.ts
@@ -1,0 +1,19 @@
+import { KNOWN_WORKER_QUEUE_NAMES } from "./worker-pools"
+import { WORKER_MODULE_REGISTRY } from "./workers-app.module"
+
+/**
+ * `WORKER_QUEUE_NAMES=all` (smoke check, test setup) expands to
+ * KNOWN_WORKER_QUEUE_NAMES. A queue registered in one list but not the other
+ * would either never boot in CI or be rejected as unknown at startup (#732).
+ */
+describe("WORKER_MODULE_REGISTRY", () => {
+  const registryQueues = WORKER_MODULE_REGISTRY.flatMap((entry) => entry.queues)
+
+  it("covers exactly the known worker queues", () => {
+    expect([...registryQueues].sort()).toEqual([...KNOWN_WORKER_QUEUE_NAMES].sort())
+  })
+
+  it("maps each queue to a single module", () => {
+    expect(new Set(registryQueues).size).toBe(registryQueues.length)
+  })
+})

--- a/apps/api/src/workers-app.module.ts
+++ b/apps/api/src/workers-app.module.ts
@@ -42,7 +42,7 @@ import { parseEnabledWorkerQueueNames } from "./worker-pools"
  * a module is loaded when any of its queues is in the enabled set. Queues listed
  * together always travel together (they belong to the same module).
  */
-const WORKER_MODULE_REGISTRY: { module: Type<unknown>; queues: string[] }[] = [
+export const WORKER_MODULE_REGISTRY: { module: Type<unknown>; queues: string[] }[] = [
   {
     module: EvaluationExtractionRunWorkersModule,
     queues: [EVALUATION_EXTRACTION_RUN_QUEUE_NAME, EVALUATION_EXTRACTION_RUN_EXECUTE_QUEUE_NAME],

--- a/infra/docker-compose.api-workers-smoke.yaml
+++ b/infra/docker-compose.api-workers-smoke.yaml
@@ -60,7 +60,7 @@ services:
       - "3003:3000"
     restart: "no"
 
-  # CPU pool: no Docling, consumes the LLM/extraction/crawling queues.
+  # CPU pool: no Docling, consumes the LLM/extraction/crawling/sweep queues.
   cpu-workers:
     image: ${CPU_WORKERS_IMAGE:-agentstudio-cpu-workers-smoke:latest}
     build:
@@ -91,7 +91,8 @@ services:
       DOCUMENT_EXTRACTOR_DOCLING_ENABLED: "false"
       LOCAL_STORAGE_SERVER_BASE_URL: http://api:3000
       MCP_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
-      WORKER_QUEUE_NAMES: "evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,evaluation-conversation-run-queue,evaluation-conversation-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,url-crawling"
+      # Same list as the production cpu-workers pool (infra repo, platform/terraform/envs/connect), so every CPU worker module boots in CI.
+      WORKER_QUEUE_NAMES: "evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,evaluation-conversation-run-queue,evaluation-conversation-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,url-crawling,web-source-embeddings,document-embeddings-stuck-sweep,extraction-agent-session-queue,conversation-retention-sweep"
       WORKERS_HEALTH_QUEUE_NAME: evaluation-extraction-run-queue
     restart: "no"
 
@@ -126,6 +127,7 @@ services:
       DOCUMENT_EXTRACTOR_DOCLING_ENABLED: "true"
       LOCAL_STORAGE_SERVER_BASE_URL: http://api:3000
       MCP_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
-      WORKER_QUEUE_NAMES: "document-embeddings,document-embeddings-stuck-sweep,web-source-embeddings"
+      # Same list as the production gpu-workers pool.
+      WORKER_QUEUE_NAMES: "document-embeddings"
       WORKERS_HEALTH_QUEUE_NAME: document-embeddings
     restart: "no"

--- a/infra/docker-compose.api-workers-smoke.yaml
+++ b/infra/docker-compose.api-workers-smoke.yaml
@@ -60,7 +60,7 @@ services:
       - "3003:3000"
     restart: "no"
 
-  # CPU pool: no Docling, consumes the LLM/extraction/crawling/sweep queues.
+  # CPU pool: no Docling. Boots every queue so each worker module is exercised without Docling.
   cpu-workers:
     image: ${CPU_WORKERS_IMAGE:-agentstudio-cpu-workers-smoke:latest}
     build:
@@ -91,12 +91,12 @@ services:
       DOCUMENT_EXTRACTOR_DOCLING_ENABLED: "false"
       LOCAL_STORAGE_SERVER_BASE_URL: http://api:3000
       MCP_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
-      # Same list as the production cpu-workers pool (infra repo, platform/terraform/envs/connect), so every CPU worker module boots in CI.
-      WORKER_QUEUE_NAMES: "evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,evaluation-conversation-run-queue,evaluation-conversation-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,url-crawling,web-source-embeddings,document-embeddings-stuck-sweep,extraction-agent-session-queue,conversation-retention-sweep"
+      # `all` boots every worker module (see worker-pools.ts), so the smoke check never carries a queue list that can drift from the code.
+      WORKER_QUEUE_NAMES: all
       WORKERS_HEALTH_QUEUE_NAME: evaluation-extraction-run-queue
     restart: "no"
 
-  # GPU pool: ships Docling, consumes the embedding queues.
+  # GPU pool: ships Docling. Boots every queue so each worker module is exercised with Docling.
   gpu-workers:
     image: ${GPU_WORKERS_IMAGE:-agentstudio-gpu-workers-smoke:latest}
     build:
@@ -127,7 +127,6 @@ services:
       DOCUMENT_EXTRACTOR_DOCLING_ENABLED: "true"
       LOCAL_STORAGE_SERVER_BASE_URL: http://api:3000
       MCP_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
-      # Same list as the production gpu-workers pool.
-      WORKER_QUEUE_NAMES: "document-embeddings"
+      WORKER_QUEUE_NAMES: all
       WORKERS_HEALTH_QUEUE_NAME: document-embeddings
     restart: "no"


### PR DESCRIPTION
Closes #732

## Problem

Since 2026-09-04 06:13 UTC the `cpu-workers` pool exits at startup and Cloud Run restarts it. PR #726 added `ProjectsService` to `ExtractionAgentSessionRunLlmService`, but `ExtractionAgentSessionWorkersModule` does not provide it. All CPU queues were stopped.

## Fix

- `ExtractionAgentSessionRunLlmService` injects `ProjectRepository` and calls `getLlmFeatures` on it. `ProjectsService.getLlmFeatures` is a passthrough to this method, and the other worker services already use the repository.

## Why CI did not stop it, and what changes

- The smoke compose and the jest setup carried their own copies of the queue list. The smoke CPU list had 7 of 11 production queues, so the broken module never loaded in CI.
- `WORKER_QUEUE_NAMES=all` now enables every known queue. The smoke compose and the jest setup use it, so they carry no queue list.
- A spec checks that `WORKER_MODULE_REGISTRY` and `KNOWN_WORKER_QUEUE_NAMES` cover the same queues.

## Checks

- `tsc`, `biome ci`, worker pool specs and extraction agent session specs pass.
- `make docker-workers-check` boots both images with every worker module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
