### PR TITLE
test(mcp-servers): increase domain test coverage

### DIFF
--- a/apps/api/src/domains/mcp-servers/e2e-tests/agent-linking.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/agent-linking.spec.ts
@@ -89,6 +89,23 @@ describe("McpServers - agent linking", () => {
     expect(junction?.enabled).toBe(true)
   })
 
+  it("should be idempotent when enabling the same server twice", async () => {
+    await createContext()
+    const enable = () =>
+      request({
+        route: McpServersRoutes.enableForAgent,
+        pathParams: removeNullish({ organizationId, projectId, mcpServerId, agentId }),
+        token: accessToken,
+      })
+
+    expectResponse(await enable(), 201)
+    expectResponse(await enable(), 201)
+
+    expect(
+      await repositories.agentMcpServerRepository.count({ where: { agentId, mcpServerId } }),
+    ).toBe(1)
+  })
+
   it("should disable an MCP server for an agent", async () => {
     await createContext()
 

--- a/apps/api/src/domains/mcp-servers/e2e-tests/auth.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/auth.spec.ts
@@ -1,0 +1,341 @@
+import { randomUUID } from "node:crypto"
+import { McpServersRoutes } from "@caseai-connect/api-contracts"
+import { afterAll } from "@jest/globals"
+import type { INestApplication } from "@nestjs/common"
+import type { App } from "supertest/types"
+import { AUTH_ERRORS } from "@/common/errors/auth-errors"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { removeNullish } from "@/common/utils/remove-nullish"
+import { agentFactory } from "@/domains/agents/agent.factory"
+import { AgentsModule } from "@/domains/agents/agents.module"
+import type { Organization } from "@/domains/organizations/organization.entity"
+import { createOrganizationWithProject } from "@/domains/organizations/organization.factory"
+import { projectFactory } from "@/domains/projects/project.factory"
+import { mockForeignAuth0Id, setupUserGuardForTesting } from "../../../../test/e2e.helpers"
+import { expectResponse, type Requester, testRequester } from "../../../../test/request"
+import { mcpServerFactory } from "../mcp-server.factory"
+import { McpServersModule } from "../mcp-servers.module"
+
+type ProjectRole = "owner" | "admin" | "member"
+
+describe("McpServers - auth and scoping", () => {
+  let app: INestApplication<App>
+  let request: Requester
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+
+  let organizationId: string
+  let projectId: string
+  let mcpServerId: string
+  let agentId: string
+  let accessToken: string | null = "token"
+  let auth0Id = "auth0|123"
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [McpServersModule, AgentsModule],
+      applyOverrides: (moduleBuilder) => setupUserGuardForTesting(moduleBuilder, () => auth0Id),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+    request = testRequester(app)
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    accessToken = "token"
+    auth0Id = `auth0|${randomUUID()}`
+    mcpServerId = randomUUID()
+    agentId = randomUUID()
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await app.close()
+  })
+
+  const createContextForRole = async (role: ProjectRole = "owner") => {
+    const { organization, project } = await createOrganizationWithProject(repositories, {
+      user: { auth0Id },
+      organizationMembership: { role: "member" },
+      projectMembership: { role },
+    })
+    organizationId = organization.id
+    projectId = project.id
+
+    const mcpServer = mcpServerFactory.build({ name: "Scoped Server", projectId: project.id })
+    await repositories.mcpServerRepository.save(mcpServer)
+    mcpServerId = mcpServer.id
+
+    const agent = agentFactory.transient({ organization, project }).build()
+    await repositories.agentRepository.save(agent)
+    agentId = agent.id
+
+    return { organization, project, mcpServer, agent }
+  }
+
+  const createServerInOtherProject = async (organization: Organization) => {
+    const otherProject = projectFactory.transient({ organization }).build()
+    await repositories.projectRepository.save(otherProject)
+    const foreignServer = mcpServerFactory.build({
+      name: "Foreign Server",
+      projectId: otherProject.id,
+    })
+    await repositories.mcpServerRepository.save(foreignServer)
+    return { otherProject, foreignServer }
+  }
+
+  const pathParams = () => removeNullish({ organizationId, projectId, mcpServerId, agentId })
+
+  describe("createOne", () => {
+    const subject = () =>
+      request({
+        route: McpServersRoutes.createOne,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+        request: { payload: { name: "New Server", url: "https://new.example.com" } },
+      })
+
+    it("requires an authentication token", async () => {
+      await createContextForRole("owner")
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+    })
+
+    it.each<ProjectRole>(["owner", "admin"])("allows a project %s to create", async (role) => {
+      await createContextForRole(role)
+      expectResponse(await subject(), 201)
+    })
+
+    it("forbids a simple project member from creating", async () => {
+      await createContextForRole("member")
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+    })
+  })
+
+  describe("getAll", () => {
+    const subject = () =>
+      request({
+        route: McpServersRoutes.getAll,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+      })
+
+    it("requires an authentication token", async () => {
+      await createContextForRole("owner")
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("allows a simple project member to list", async () => {
+      const { mcpServer } = await createContextForRole("member")
+      // Factory config is not decryptable, replace with one created through the API as owner.
+      await repositories.mcpServerRepository.delete({ id: mcpServer.id })
+
+      const response = await subject()
+
+      expectResponse(response, 200)
+      expect(response.body.data).toEqual([])
+    })
+
+    it("returns the decrypted URL and never the API key", async () => {
+      const { mcpServer } = await createContextForRole("owner")
+      await repositories.mcpServerRepository.delete({ id: mcpServer.id })
+      await request({
+        route: McpServersRoutes.createOne,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+        request: {
+          payload: { name: "Secured", url: "https://secured.example.com", apiKey: "sk-top-secret" },
+        },
+      })
+
+      const response = await subject()
+
+      expectResponse(response, 200)
+      expect(response.body.data).toHaveLength(1)
+      expect(response.body.data[0]).toMatchObject({
+        name: "Secured",
+        url: "https://secured.example.com",
+        projectId,
+      })
+      expect(JSON.stringify(response.body)).not.toContain("sk-top-secret")
+    })
+
+    it("does not list servers from another project of the same organization", async () => {
+      const { organization, mcpServer } = await createContextForRole("owner")
+      await repositories.mcpServerRepository.delete({ id: mcpServer.id })
+      await createServerInOtherProject(organization)
+      await request({
+        route: McpServersRoutes.createOne,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+        request: { payload: { name: "Mine", url: "https://mine.example.com" } },
+      })
+
+      const response = await subject()
+
+      expectResponse(response, 200)
+      expect(response.body.data.map((server: { name: string }) => server.name)).toEqual(["Mine"])
+    })
+  })
+
+  describe("deleteOne", () => {
+    const subject = () =>
+      request({
+        route: McpServersRoutes.deleteOne,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+      })
+
+    it("requires an authentication token", async () => {
+      await createContextForRole("owner")
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it.each<ProjectRole>(["owner", "admin"])("allows a project %s to delete", async (role) => {
+      await createContextForRole(role)
+      expectResponse(await subject(), 200)
+    })
+
+    it("forbids a simple project member from deleting", async () => {
+      await createContextForRole("member")
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+
+      expect(
+        await repositories.mcpServerRepository.findOne({ where: { id: mcpServerId } }),
+      ).not.toBeNull()
+    })
+
+    it("returns 404 for an unknown server", async () => {
+      await createContextForRole("owner")
+      mcpServerId = randomUUID()
+      expectResponse(await subject(), 404)
+    })
+
+    it("returns 404 for a server of another project in the same organization", async () => {
+      const { organization } = await createContextForRole("owner")
+      const { foreignServer } = await createServerInOtherProject(organization)
+      mcpServerId = foreignServer.id
+
+      expectResponse(await subject(), 404)
+
+      expect(
+        await repositories.mcpServerRepository.findOne({ where: { id: foreignServer.id } }),
+      ).not.toBeNull()
+    })
+
+    it("returns 404 for a preset server", async () => {
+      await createContextForRole("owner")
+      const preset = mcpServerFactory.preset("auth-preset").build()
+      await repositories.mcpServerRepository.save(preset)
+      mcpServerId = preset.id
+
+      expectResponse(await subject(), 404)
+    })
+
+    it("also removes the agent links of the deleted server", async () => {
+      await createContextForRole("owner")
+      await repositories.agentMcpServerRepository.save(
+        repositories.agentMcpServerRepository.create({ agentId, mcpServerId, enabled: true }),
+      )
+
+      expectResponse(await subject(), 200)
+
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).toBeNull()
+    })
+  })
+
+  describe("enableForAgent", () => {
+    const subject = () =>
+      request({
+        route: McpServersRoutes.enableForAgent,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+      })
+
+    it("requires an authentication token", async () => {
+      await createContextForRole("owner")
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it.each<ProjectRole>(["owner", "admin"])("allows a project %s to enable", async (role) => {
+      await createContextForRole(role)
+      expectResponse(await subject(), 201)
+    })
+
+    it("forbids a simple project member from enabling", async () => {
+      await createContextForRole("member")
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).toBeNull()
+    })
+
+    it("returns 404 for a server of another project", async () => {
+      const { organization } = await createContextForRole("owner")
+      const { foreignServer } = await createServerInOtherProject(organization)
+      mcpServerId = foreignServer.id
+
+      expectResponse(await subject(), 404)
+    })
+  })
+
+  describe("disableForAgent", () => {
+    const subject = () =>
+      request({
+        route: McpServersRoutes.disableForAgent,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+      })
+
+    it("requires an authentication token", async () => {
+      await createContextForRole("owner")
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("forbids a simple project member from disabling", async () => {
+      await createContextForRole("member")
+      await repositories.agentMcpServerRepository.save(
+        repositories.agentMcpServerRepository.create({ agentId, mcpServerId, enabled: true }),
+      )
+
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).not.toBeNull()
+    })
+
+    it("returns 404 for a server of another project", async () => {
+      const { organization } = await createContextForRole("owner")
+      const { foreignServer } = await createServerInOtherProject(organization)
+      mcpServerId = foreignServer.id
+
+      expectResponse(await subject(), 404)
+    })
+
+    it("succeeds even when no link exists", async () => {
+      await createContextForRole("owner")
+      expectResponse(await subject(), 200)
+    })
+  })
+})

--- a/apps/api/src/domains/mcp-servers/encryption.service.spec.ts
+++ b/apps/api/src/domains/mcp-servers/encryption.service.spec.ts
@@ -1,0 +1,118 @@
+import { randomBytes } from "node:crypto"
+import type { ConfigService } from "@nestjs/config"
+import { EncryptionService } from "./encryption.service"
+
+const VALID_KEY_HEX = randomBytes(32).toString("hex")
+
+const buildConfigService = (key: string | undefined) =>
+  ({ get: () => key }) as unknown as ConfigService
+
+const buildService = (key: string | undefined = VALID_KEY_HEX) =>
+  new EncryptionService(buildConfigService(key))
+
+const splitEncrypted = (encrypted: string) => {
+  const [iv, authTag, ciphertext] = encrypted.split(":")
+  if (!iv || !authTag || !ciphertext) throw new Error(`Unexpected format: ${encrypted}`)
+  return { iv, authTag, ciphertext }
+}
+
+const flipFirstByte = (base64: string) => {
+  const bytes = Buffer.from(base64, "base64")
+  bytes[0] = (bytes[0] ?? 0) ^ 0xff
+  return bytes.toString("base64")
+}
+
+describe("EncryptionService", () => {
+  describe("constructor", () => {
+    it("should throw when MCP_ENCRYPTION_KEY is missing", () => {
+      expect(() => new EncryptionService(buildConfigService(undefined))).toThrow(
+        "MCP_ENCRYPTION_KEY env var is required",
+      )
+    })
+
+    it("should throw when MCP_ENCRYPTION_KEY is not 32 bytes", () => {
+      expect(() => buildService(randomBytes(16).toString("hex"))).toThrow(
+        "MCP_ENCRYPTION_KEY must be a 64-character hex string (32 bytes)",
+      )
+    })
+
+    it("should accept a 64-character hex key", () => {
+      expect(() => buildService()).not.toThrow()
+    })
+  })
+
+  describe("encrypt / decrypt", () => {
+    it("should round-trip a plaintext", () => {
+      const service = buildService()
+      const plaintext = JSON.stringify({ url: "https://example.com/mcp", apiKey: "sk-secret" })
+
+      expect(service.decrypt(service.encrypt(plaintext))).toBe(plaintext)
+    })
+
+    it("should round-trip an empty string", () => {
+      const service = buildService()
+
+      expect(service.decrypt(service.encrypt(""))).toBe("")
+    })
+
+    it("should round-trip multi-byte characters", () => {
+      const service = buildService()
+      const plaintext = "clé secrète – 秘密 🔐"
+
+      expect(service.decrypt(service.encrypt(plaintext))).toBe(plaintext)
+    })
+
+    it("should produce iv:authTag:ciphertext without leaking the plaintext", () => {
+      const service = buildService()
+      const encrypted = service.encrypt("sk-secret")
+
+      const { iv, authTag } = splitEncrypted(encrypted)
+      expect(encrypted.split(":")).toHaveLength(3)
+      expect(Buffer.from(iv, "base64")).toHaveLength(16)
+      expect(Buffer.from(authTag, "base64")).toHaveLength(16)
+      expect(encrypted).not.toContain("sk-secret")
+    })
+
+    it("should use a fresh IV so the same plaintext encrypts differently", () => {
+      const service = buildService()
+
+      expect(service.encrypt("same")).not.toBe(service.encrypt("same"))
+    })
+
+    it("should reject a ciphertext produced with another key", () => {
+      const encrypted = buildService().encrypt("secret")
+      const otherService = buildService(randomBytes(32).toString("hex"))
+
+      expect(() => otherService.decrypt(encrypted)).toThrow()
+    })
+
+    it("should reject a tampered ciphertext", () => {
+      const service = buildService()
+      const { iv, authTag, ciphertext } = splitEncrypted(service.encrypt("secret"))
+
+      expect(() => service.decrypt(`${iv}:${authTag}:${flipFirstByte(ciphertext)}`)).toThrow()
+    })
+
+    it("should reject a tampered auth tag", () => {
+      const service = buildService()
+      const { iv, authTag, ciphertext } = splitEncrypted(service.encrypt("secret"))
+
+      expect(() => service.decrypt(`${iv}:${flipFirstByte(authTag)}:${ciphertext}`)).toThrow()
+    })
+
+    it.each([
+      "",
+      "onlyone",
+      "two:parts",
+      "a::c",
+      ":b:c",
+      "a:b:c:d",
+    ])("should reject the malformed value %p", (malformed) => {
+      const service = buildService()
+
+      expect(() => service.decrypt(malformed)).toThrow(
+        "Invalid encrypted format — expected iv:authTag:ciphertext",
+      )
+    })
+  })
+})

--- a/apps/api/src/domains/mcp-servers/encryption.service.ts
+++ b/apps/api/src/domains/mcp-servers/encryption.service.ts
@@ -31,8 +31,9 @@ export class EncryptionService {
   }
 
   decrypt(encrypted: string): string {
-    const [ivB64, authTagB64, ciphertextB64] = encrypted.split(":")
-    if (!ivB64 || !authTagB64 || !ciphertextB64) {
+    const parts = encrypted.split(":")
+    const [ivB64, authTagB64, ciphertextB64] = parts
+    if (parts.length !== 3 || !ivB64 || !authTagB64 || ciphertextB64 === undefined) {
       throw new Error("Invalid encrypted format — expected iv:authTag:ciphertext")
     }
     const iv = Buffer.from(ivB64, "base64")

--- a/apps/api/src/domains/mcp-servers/mcp-server.policy.spec.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-server.policy.spec.ts
@@ -1,0 +1,127 @@
+import {
+  type ResourceState,
+  testPolicyScopedByProject,
+} from "@/common/test/test-project-scoped-policy.helpers"
+import { organizationMembershipFactory } from "@/domains/organizations/memberships/organization-membership.factory"
+import { organizationFactory } from "@/domains/organizations/organization.factory"
+import { projectMembershipFactory } from "@/domains/projects/memberships/project-membership.factory"
+import type { ProjectMembershipRole } from "@/domains/projects/memberships/project-membership.types"
+import { projectFactory } from "@/domains/projects/project.factory"
+import { userFactory } from "@/domains/users/user.factory"
+import { mcpServerFactory } from "./mcp-server.factory"
+import { McpServerPolicy } from "./mcp-server.policy"
+
+describe("McpServerPolicy", () => {
+  const { buildPolicy } = testPolicyScopedByProject({
+    buildResource: ({ project }) => mcpServerFactory.build({ projectId: project.id, project }),
+    ResourcePolicy: McpServerPolicy,
+  })
+
+  describe("canList", () => {
+    describe.each<[ProjectMembershipRole, ResourceState, boolean]>([
+      ["owner", "sameOrganization", true],
+      ["owner", "differentOrganization", false],
+      ["owner", "noResource", true],
+      ["admin", "sameOrganization", true],
+      ["admin", "differentOrganization", false],
+      ["admin", "noResource", true],
+      ["member", "sameOrganization", true],
+      ["member", "differentOrganization", false],
+      ["member", "noResource", true],
+    ])("when user is %s with %s MCP server", (projectRole, resourceState, expected) => {
+      it(`should return ${expected}`, () => {
+        const policy = buildPolicy({ resourceState, projectRole })
+
+        expect(policy.canList()).toBe(expected)
+      })
+    })
+
+    it("should return false when the user is not a member of the project", () => {
+      const policy = buildPolicy({ resourceState: "noResource" })
+
+      expect(policy.canList()).toBe(false)
+    })
+  })
+
+  describe("canCreate", () => {
+    describe.each<[ProjectMembershipRole, ResourceState, boolean]>([
+      ["owner", "sameOrganization", true],
+      ["owner", "differentOrganization", false],
+      ["owner", "noResource", true],
+      ["admin", "sameOrganization", true],
+      ["admin", "differentOrganization", false],
+      ["admin", "noResource", true],
+      ["member", "sameOrganization", false],
+      ["member", "differentOrganization", false],
+      ["member", "noResource", false],
+    ])("when user is %s with %s MCP server", (projectRole, resourceState, expected) => {
+      it(`should return ${expected}`, () => {
+        const policy = buildPolicy({ resourceState, projectRole })
+
+        expect(policy.canCreate()).toBe(expected)
+      })
+    })
+  })
+
+  describe("canDelete", () => {
+    describe.each<[ProjectMembershipRole, ResourceState, boolean]>([
+      ["owner", "sameOrganization", true],
+      ["owner", "differentOrganization", false],
+      ["owner", "noResource", false],
+      ["admin", "sameOrganization", true],
+      ["admin", "differentOrganization", false],
+      ["admin", "noResource", false],
+      ["member", "sameOrganization", false],
+      ["member", "differentOrganization", false],
+      ["member", "noResource", false],
+    ])("when user is %s with %s MCP server", (projectRole, resourceState, expected) => {
+      it(`should return ${expected}`, () => {
+        const policy = buildPolicy({ resourceState, projectRole })
+
+        expect(policy.canDelete()).toBe(expected)
+      })
+    })
+  })
+
+  describe("resource scoping", () => {
+    const organization = organizationFactory.build()
+    const user = userFactory.build()
+    const project = projectFactory.transient({ organization }).build()
+    const otherProject = projectFactory.transient({ organization }).build()
+    const context = {
+      organizationMembership: organizationMembershipFactory
+        .transient({ user, organization })
+        .params({ role: "member" })
+        .build(),
+      projectMembership: projectMembershipFactory
+        .transient({ user, project })
+        .params({ role: "owner" })
+        .build(),
+      project,
+    }
+
+    it("should allow deleting a server of the current project", () => {
+      const server = mcpServerFactory.build({ projectId: project.id })
+
+      expect(new McpServerPolicy(context, server).canDelete()).toBe(true)
+    })
+
+    it("should deny deleting a server of another project in the same organization", () => {
+      const server = mcpServerFactory.build({ projectId: otherProject.id })
+
+      expect(new McpServerPolicy(context, server).canDelete()).toBe(false)
+    })
+
+    it("should deny deleting a preset server that belongs to no project", () => {
+      const server = mcpServerFactory.preset("preset").build()
+
+      expect(new McpServerPolicy(context, server).canDelete()).toBe(false)
+    })
+
+    it("should deny deleting when the resource is not an entity", () => {
+      const policy = new McpServerPolicy(context, "not-an-entity" as never)
+
+      expect(policy.canDelete()).toBe(false)
+    })
+  })
+})

--- a/apps/api/src/domains/mcp-servers/mcp-servers.service.spec.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "@/common/test/test-transaction-manager"
 import { agentFactory } from "@/domains/agents/agent.factory"
 import { createOrganizationWithProject } from "@/domains/organizations/organization.factory"
+import { projectFactory } from "@/domains/projects/project.factory"
 import { McpServersModule } from "./mcp-servers.module"
 import { McpServersService } from "./mcp-servers.service"
 
@@ -52,6 +53,245 @@ describe("McpServersService", () => {
     })
   })
 
+  describe("createMcpServer", () => {
+    it("should create a project-scoped server with encrypted config", async () => {
+      const { project } = await createOrganizationWithProject(repositories)
+
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Project Server",
+        config: { url: "https://example.com/mcp", apiKey: "sk-project-key" },
+      })
+
+      expect(server.id).toBeDefined()
+      expect(server.name).toBe("Project Server")
+      expect(server.presetSlug).toBeNull()
+      expect(server.projectId).toBe(project.id)
+      expect(server.encryptedConfig).not.toContain("sk-project-key")
+      expect(server.encryptedConfig).not.toContain("example.com")
+
+      const saved = await repositories.mcpServerRepository.findOne({ where: { id: server.id } })
+      expect(saved?.projectId).toBe(project.id)
+      expect(saved?.encryptedConfig).toBe(server.encryptedConfig)
+    })
+  })
+
+  describe("listMcpServers", () => {
+    it("should return the project's servers sorted by name", async () => {
+      const { project } = await createOrganizationWithProject(repositories)
+      await service.createMcpServer({
+        projectId: project.id,
+        name: "Zeta",
+        config: { url: "https://zeta.example.com" },
+      })
+      await service.createMcpServer({
+        projectId: project.id,
+        name: "Alpha",
+        config: { url: "https://alpha.example.com" },
+      })
+      await service.createMcpServer({
+        projectId: project.id,
+        name: "Mid",
+        config: { url: "https://mid.example.com" },
+      })
+
+      const servers = await service.listMcpServers(project.id)
+
+      expect(servers.map((server) => server.name)).toEqual(["Alpha", "Mid", "Zeta"])
+    })
+
+    it("should not return servers of other projects nor presets", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const otherProject = projectFactory.transient({ organization }).build()
+      await repositories.projectRepository.save(otherProject)
+
+      await service.createMcpServer({
+        projectId: project.id,
+        name: "Mine",
+        config: { url: "https://mine.example.com" },
+      })
+      await service.createMcpServer({
+        projectId: otherProject.id,
+        name: "Theirs",
+        config: { url: "https://theirs.example.com" },
+      })
+      await service.createPreset("list-preset", "Preset", { url: "https://preset.example.com" })
+
+      const servers = await service.listMcpServers(project.id)
+
+      expect(servers.map((server) => server.name)).toEqual(["Mine"])
+    })
+
+    it("should not return soft-deleted servers", async () => {
+      const { project } = await createOrganizationWithProject(repositories)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Gone",
+        config: { url: "https://gone.example.com" },
+      })
+      await service.deleteMcpServer(server.id)
+
+      expect(await service.listMcpServers(project.id)).toEqual([])
+    })
+  })
+
+  describe("findMcpServerById", () => {
+    it("should return the server when it belongs to the project", async () => {
+      const { project } = await createOrganizationWithProject(repositories)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Found",
+        config: { url: "https://found.example.com" },
+      })
+
+      const found = await service.findMcpServerById(server.id, project.id)
+
+      expect(found?.id).toBe(server.id)
+    })
+
+    it("should return null when the server belongs to another project", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const otherProject = projectFactory.transient({ organization }).build()
+      await repositories.projectRepository.save(otherProject)
+      const server = await service.createMcpServer({
+        projectId: otherProject.id,
+        name: "Elsewhere",
+        config: { url: "https://elsewhere.example.com" },
+      })
+
+      expect(await service.findMcpServerById(server.id, project.id)).toBeNull()
+    })
+
+    it("should return null for a preset server", async () => {
+      const { project } = await createOrganizationWithProject(repositories)
+      const preset = await service.createPreset("find-preset", "Preset", {
+        url: "https://preset.example.com",
+      })
+
+      expect(await service.findMcpServerById(preset.id, project.id)).toBeNull()
+    })
+
+    it("should return null for a soft-deleted server", async () => {
+      const { project } = await createOrganizationWithProject(repositories)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Deleted",
+        config: { url: "https://deleted.example.com" },
+      })
+      await service.deleteMcpServer(server.id)
+
+      expect(await service.findMcpServerById(server.id, project.id)).toBeNull()
+    })
+  })
+
+  describe("deleteMcpServer", () => {
+    it("should soft-delete the server and its agent links", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "To Delete",
+        config: { url: "https://delete.example.com" },
+      })
+      const junction = await service.enableForAgent(agent.id, server.id)
+
+      await service.deleteMcpServer(server.id)
+
+      const deletedServer = await repositories.mcpServerRepository.findOne({
+        where: { id: server.id },
+        withDeleted: true,
+      })
+      expect(deletedServer?.deletedAt).not.toBeNull()
+
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { id: junction.id } }),
+      ).toBeNull()
+      const deletedJunction = await repositories.agentMcpServerRepository.findOne({
+        where: { id: junction.id },
+        withDeleted: true,
+      })
+      expect(deletedJunction?.deletedAt).not.toBeNull()
+
+      expect(await service.getEnabledServersForAgent(agent.id)).toEqual([])
+    })
+
+    it("should leave other servers and their links untouched", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      const doomed = await service.createMcpServer({
+        projectId: project.id,
+        name: "Doomed",
+        config: { url: "https://doomed.example.com" },
+      })
+      const survivor = await service.createMcpServer({
+        projectId: project.id,
+        name: "Survivor",
+        config: { url: "https://survivor.example.com" },
+      })
+      await service.enableForAgent(agent.id, doomed.id)
+      await service.enableForAgent(agent.id, survivor.id)
+
+      await service.deleteMcpServer(doomed.id)
+
+      expect(await service.listMcpServers(project.id)).toHaveLength(1)
+      expect(await service.getEnabledServersForAgent(agent.id)).toEqual([
+        { id: survivor.id, url: "https://survivor.example.com" },
+      ])
+    })
+  })
+
+  describe("disableForAgent", () => {
+    it("should remove the link for that agent only", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      const otherAgent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save([agent, otherAgent])
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Shared",
+        config: { url: "https://shared.example.com" },
+      })
+      await service.enableForAgent(agent.id, server.id)
+      await service.enableForAgent(otherAgent.id, server.id)
+
+      await service.disableForAgent(agent.id, server.id)
+
+      expect(await service.getEnabledServersForAgent(agent.id)).toEqual([])
+      expect(await service.getEnabledServersForAgent(otherAgent.id)).toHaveLength(1)
+      expect(
+        await repositories.agentMcpServerRepository.count({ where: { mcpServerId: server.id } }),
+      ).toBe(1)
+    })
+
+    it("should be a no-op when no link exists", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Unlinked",
+        config: { url: "https://unlinked.example.com" },
+      })
+
+      await expect(service.disableForAgent(agent.id, server.id)).resolves.toBeUndefined()
+    })
+  })
+
+  describe("decryptUrl", () => {
+    it("should return the URL stored in the encrypted config", async () => {
+      const { project } = await createOrganizationWithProject(repositories)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Decrypt",
+        config: { url: "https://decrypt.example.com/mcp", apiKey: "sk-hidden" },
+      })
+
+      expect(service.decryptUrl(server)).toBe("https://decrypt.example.com/mcp")
+    })
+  })
+
   describe("enableForAgent", () => {
     it("should create an agent-mcp-server junction", async () => {
       const { organization, project } = await createOrganizationWithProject(repositories)
@@ -68,6 +308,48 @@ describe("McpServersService", () => {
       expect(result.agentId).toBe(agent.id)
       expect(result.mcpServerId).toBe(server.id)
       expect(result.enabled).toBe(true)
+    })
+  })
+
+  describe("enableForAgent idempotence", () => {
+    it("should return the existing link when enabling twice", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Twice",
+        config: { url: "https://twice.example.com" },
+      })
+
+      const first = await service.enableForAgent(agent.id, server.id)
+      const second = await service.enableForAgent(agent.id, server.id)
+
+      expect(second.id).toBe(first.id)
+      expect(
+        await repositories.agentMcpServerRepository.count({
+          where: { agentId: agent.id, mcpServerId: server.id },
+        }),
+      ).toBe(1)
+    })
+
+    it("should re-enable a link that was disabled in place", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Re-enabled",
+        config: { url: "https://reenabled.example.com" },
+      })
+      const junction = await service.enableForAgent(agent.id, server.id)
+      await repositories.agentMcpServerRepository.update(junction.id, { enabled: false })
+
+      const result = await service.enableForAgent(agent.id, server.id)
+
+      expect(result.id).toBe(junction.id)
+      expect(result.enabled).toBe(true)
+      expect(await service.getEnabledServersForAgent(agent.id)).toHaveLength(1)
     })
   })
 
@@ -108,6 +390,67 @@ describe("McpServersService", () => {
       const configs = await service.getEnabledServersForAgent(agent.id)
 
       expect(configs).toHaveLength(0)
+    })
+
+    it("should return an empty list for an agent with no servers", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+
+      expect(await service.getEnabledServersForAgent(agent.id)).toEqual([])
+    })
+
+    it("should pass static headers through from the config", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "With Headers",
+        config: {
+          url: "https://headers.example.com/mcp",
+          headers: { "X-Api-Version": "2", "X-Tenant": "acme" },
+        },
+      })
+      await service.enableForAgent(agent.id, server.id)
+
+      expect(await service.getEnabledServersForAgent(agent.id)).toEqual([
+        {
+          id: server.id,
+          url: "https://headers.example.com/mcp",
+          headers: { "X-Api-Version": "2", "X-Tenant": "acme" },
+        },
+      ])
+    })
+
+    it("should skip a link whose server was soft-deleted directly", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Orphaned",
+        config: { url: "https://orphaned.example.com" },
+      })
+      await service.enableForAgent(agent.id, server.id)
+      await repositories.mcpServerRepository.softDelete({ id: server.id })
+
+      expect(await service.getEnabledServersForAgent(agent.id)).toEqual([])
+    })
+
+    it("should not return servers enabled for another agent", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      const otherAgent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save([agent, otherAgent])
+      const server = await service.createMcpServer({
+        projectId: project.id,
+        name: "Other's",
+        config: { url: "https://other.example.com" },
+      })
+      await service.enableForAgent(otherAgent.id, server.id)
+
+      expect(await service.getEnabledServersForAgent(agent.id)).toEqual([])
     })
 
     it("should return multiple servers", async () => {

--- a/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
@@ -97,6 +97,14 @@ export class McpServersService {
   }
 
   async enableForAgent(agentId: string, mcpServerId: string): Promise<AgentMcpServer> {
+    const existing = await this.agentMcpServerRepository.findOne({
+      where: { agentId, mcpServerId },
+    })
+    if (existing) {
+      if (existing.enabled) return existing
+      existing.enabled = true
+      return this.agentMcpServerRepository.save(existing)
+    }
     return this.agentMcpServerRepository.save(
       this.agentMcpServerRepository.create({
         agentId,


### PR DESCRIPTION
Closes #579

## What

Brings the MCP servers domain from 13 to 108 tests.

- `encryption.service.spec.ts` (new): key validation, round-trips, fresh IV per call, wrong key, tampered ciphertext and auth tag, malformed formats.
- `mcp-server.policy.spec.ts` (new): role matrix for list, create and delete, plus scoping to another project, preset servers and non-entity resources.
- `mcp-servers.service.spec.ts`: covers create, list ordering and isolation, find by id, delete cascading to agent links, disable, decryptUrl, static headers, soft-deleted servers.
- `e2e-tests/auth.spec.ts` (new): for every route, no token, foreign user, owner and admin allowed, member forbidden, 404 on other-project or preset servers, API key never returned.

## Two small production changes surfaced by the tests

- `enableForAgent` returned a 500 when called twice for the same agent and server because of the unique constraint on the junction table. It now returns the existing link, and re-enables it if it had been disabled in place.
- `decrypt` rejected its own output for an empty plaintext. The format check now counts segments instead of testing for emptiness.

## Checks

biome, typecheck, boundaries and the full MCP domain suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
