### PR TITLE
fix(documents): delete stored files and rendered page images on document deletion and purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Security
 - Security updates of dependencies and base images across all services.
+- Deleting a document or purging a conversation now also removes its file and rendered page images from storage.
 
 ## [26.09.1] - 2026-09-02
 

--- a/apps/api/.dependency-cruiser-known-violations.json
+++ b/apps/api/.dependency-cruiser-known-violations.json
@@ -3897,6 +3897,15 @@
   },
   {
     "type": "dependency",
+    "from": "src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.ts",
+    "to": "src/domains/documents/pdf-pages/pdf-pages.service.ts",
+    "rule": {
+      "severity": "warn",
+      "name": "no-cross-domain-service-reach"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "src/domains/agents/csv-extraction-runs/agent-csv-extraction-run-csv-export.service.ts",
     "to": "src/domains/documents/documents.service.ts",
     "rule": {

--- a/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.spec.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.spec.ts
@@ -7,8 +7,12 @@ import {
 import { agentFactory } from "@/domains/agents/agent.factory"
 import type { ConversationAgentSession } from "@/domains/agents/conversation-agent-sessions/conversation-agent-session.entity"
 import { agentSettingsFactory } from "@/domains/agents/settings/agent.settings.factory"
+import { agentMessageAttachmentDocumentFactory } from "@/domains/agents/shared/agent-session-messages/agent-message-attachment-document.factory"
 import { agentMessageFactory } from "@/domains/agents/shared/agent-session-messages/agent-messages.factory"
 import { agentMessageFeedbackFactory } from "@/domains/agents/shared/agent-session-messages/feedback/agent-message-feedback.factory"
+import { documentFactory } from "@/domains/documents/document.factory"
+import { PdfConverterClient } from "@/domains/documents/pdf-pages/pdf-converter.client"
+import { PdfPagesService } from "@/domains/documents/pdf-pages/pdf-pages.service"
 import type { IFileStorage } from "@/domains/documents/storage/file-storage.interface"
 import {
   createOrganizationWithAgentMessage,
@@ -32,7 +36,11 @@ describe("ConversationAgentSessionPurgeService", () => {
         deletedStoragePaths.push(storageRelativePath)
       },
     } as unknown as IFileStorage
-    service = new ConversationAgentSessionPurgeService(setup.dataSource, fileStorageFake)
+    service = new ConversationAgentSessionPurgeService(
+      setup.dataSource,
+      fileStorageFake,
+      new PdfPagesService(new PdfConverterClient()),
+    )
   })
 
   beforeEach(async () => {
@@ -109,6 +117,66 @@ describe("ConversationAgentSessionPurgeService", () => {
       id: feedback.id,
     })
     expect(savedFeedback.content).toBe("")
+  })
+
+  it("removes attachment files and their rendered pages from storage", async () => {
+    const { organization, project, agentSession, agentSettings } = await createPurgeableSession()
+    const attachment = agentMessageAttachmentDocumentFactory
+      .transient({ organization, project })
+      .build({
+        storageRelativePath: `${organization.id}/${project.id}/attachment1.pdf`,
+        pdfPageCount: 2,
+      })
+    await repositories.agentMessageAttachmentDocumentRepository.save(attachment)
+    const messageWithAttachment = agentMessageFactory
+      .user()
+      .transient({ organization, project, session: agentSession, agentSettings })
+      .build({ content: "See attached", attachmentDocumentId: attachment.id })
+    await repositories.agentMessageRepository.save(messageWithAttachment)
+
+    const { purged } = await service.purgeSessionContent(agentSession.id)
+    expect(purged).toBe(true)
+
+    expect(deletedStoragePaths.sort()).toEqual(
+      [
+        `${organization.id}/${project.id}/attachment1.pdf`,
+        `${organization.id}/${project.id}/derived/attachment1/page-1.png`,
+        `${organization.id}/${project.id}/derived/attachment1/page-2.png`,
+      ].sort(),
+    )
+    const deletedAttachment = await repositories.agentMessageAttachmentDocumentRepository.findOne({
+      where: { id: attachment.id },
+    })
+    expect(deletedAttachment).toBeNull()
+  })
+
+  it("removes the files of documents generated in the session from storage", async () => {
+    const { organization, project, agentSession, agentSettings } = await createPurgeableSession()
+    const generatedDocument = documentFactory.transient({ organization, project }).build({
+      sourceType: "agentSessionMessage",
+      storageRelativePath: `${organization.id}/${project.id}/generated1.pdf`,
+      pdfPageCount: 1,
+    })
+    await repositories.documentRepository.save(generatedDocument)
+    const messageWithDocument = agentMessageFactory
+      .assistant()
+      .transient({ organization, project, session: agentSession, agentSettings })
+      .build({ content: "Here is your file", documentId: generatedDocument.id })
+    await repositories.agentMessageRepository.save(messageWithDocument)
+
+    const { purged } = await service.purgeSessionContent(agentSession.id)
+    expect(purged).toBe(true)
+
+    expect(deletedStoragePaths.sort()).toEqual(
+      [
+        `${organization.id}/${project.id}/generated1.pdf`,
+        `${organization.id}/${project.id}/derived/generated1/page-1.png`,
+      ].sort(),
+    )
+    const deletedDocument = await repositories.documentRepository.findOne({
+      where: { id: generatedDocument.id },
+    })
+    expect(deletedDocument).toBeNull()
   })
 
   it("is idempotent: a second run does nothing", async () => {

--- a/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-agent-session-purge.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable, Logger } from "@nestjs/common"
 import { InjectDataSource } from "@nestjs/typeorm"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DataSource, type EntityManager, In } from "typeorm"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { PdfPagesService } from "@/domains/documents/pdf-pages/pdf-pages.service"
 import {
   FILE_STORAGE_SERVICE,
   type IFileStorage,
@@ -10,6 +12,9 @@ import { AgentMessage } from "../../shared/agent-session-messages/agent-message.
 import { AgentMessageAttachmentDocument } from "../../shared/agent-session-messages/agent-message-attachment-document.entity"
 import { AgentMessageFeedback } from "../../shared/agent-session-messages/feedback/agent-message-feedback.entity"
 import { ConversationAgentSession } from "../conversation-agent-session.entity"
+
+/** What is needed to remove a deleted document's source object and rendered pages from storage. */
+type StoredDocumentFiles = { storageRelativePath: string; pdfPageCount: number | null }
 
 /**
  * GDPR content purge: empties everything user-generated in a conversation
@@ -23,10 +28,11 @@ export class ConversationAgentSessionPurgeService {
   constructor(
     @InjectDataSource() private readonly dataSource: DataSource,
     @Inject(FILE_STORAGE_SERVICE) private readonly fileStorage: IFileStorage,
+    private readonly pdfPagesService: PdfPagesService,
   ) {}
 
   async purgeSessionContent(sessionId: string): Promise<{ purged: boolean }> {
-    const attachmentStoragePaths: string[] = []
+    const deletedDocumentFiles: StoredDocumentFiles[] = []
 
     const purged = await this.dataSource.transaction(async (entityManager) => {
       const session = await entityManager.findOne(ConversationAgentSession, {
@@ -34,7 +40,7 @@ export class ConversationAgentSessionPurgeService {
       })
       if (!session || session.purgedAt) return false
 
-      attachmentStoragePaths.push(...(await this.purgeSessionMessages(entityManager, sessionId)))
+      deletedDocumentFiles.push(...(await this.purgeSessionMessages(entityManager, sessionId)))
 
       await entityManager.update(
         ConversationAgentSession,
@@ -44,7 +50,7 @@ export class ConversationAgentSessionPurgeService {
       return true
     })
 
-    await this.deleteAttachmentFiles(attachmentStoragePaths, sessionId)
+    await this.deleteStoredFiles(deletedDocumentFiles, sessionId)
     return { purged }
   }
 
@@ -54,7 +60,7 @@ export class ConversationAgentSessionPurgeService {
    * the purged session no longer links to a person.
    */
   async purgePublicSessionContent(sessionId: string): Promise<{ purged: boolean }> {
-    const attachmentStoragePaths: string[] = []
+    const deletedDocumentFiles: StoredDocumentFiles[] = []
 
     const purged = await this.dataSource.transaction(async (entityManager) => {
       // Loaded by entity name: importing the PublicAgentSession entity here
@@ -64,7 +70,7 @@ export class ConversationAgentSessionPurgeService {
       })) as { id: string; purgedAt: Date | null } | null
       if (!session || session.purgedAt) return false
 
-      attachmentStoragePaths.push(...(await this.purgeSessionMessages(entityManager, sessionId)))
+      deletedDocumentFiles.push(...(await this.purgeSessionMessages(entityManager, sessionId)))
 
       await entityManager.update(
         "PublicAgentSession",
@@ -74,16 +80,16 @@ export class ConversationAgentSessionPurgeService {
       return true
     })
 
-    await this.deleteAttachmentFiles(attachmentStoragePaths, sessionId)
+    await this.deleteStoredFiles(deletedDocumentFiles, sessionId)
     return { purged }
   }
 
-  /** Empties the messages of a session; returns the storage paths of deleted attachments. */
+  /** Empties the messages of a session; returns the stored files of the deleted documents. */
   private async purgeSessionMessages(
     entityManager: EntityManager,
     sessionId: string,
-  ): Promise<string[]> {
-    const attachmentStoragePaths: string[] = []
+  ): Promise<StoredDocumentFiles[]> {
+    const deletedDocumentFiles: StoredDocumentFiles[] = []
 
     const messages = await entityManager.find(AgentMessage, {
       where: { sessionId },
@@ -107,9 +113,7 @@ export class ConversationAgentSessionPurgeService {
       const attachments = await entityManager.find(AgentMessageAttachmentDocument, {
         where: { id: In(attachmentDocumentIds) },
       })
-      attachmentStoragePaths.push(
-        ...attachments.map((attachment) => attachment.storageRelativePath),
-      )
+      deletedDocumentFiles.push(...attachments)
       await entityManager.delete(AgentMessageAttachmentDocument, {
         id: In(attachmentDocumentIds),
       })
@@ -119,27 +123,43 @@ export class ConversationAgentSessionPurgeService {
       .map((message) => message.documentId)
       .filter((id): id is string => Boolean(id))
     if (generatedDocumentIds.length > 0) {
-      // Deleted by entity name: importing the Document entity here would be a
-      // cross-domain entity import (no-cross-domain-entity-import).
+      // Loaded and deleted by entity name: importing the Document entity here
+      // would be a cross-domain entity import (no-cross-domain-entity-import).
+      const generatedDocuments = await entityManager.find<StoredDocumentFiles & { id: string }>(
+        "Document",
+        {
+          where: { id: In(generatedDocumentIds) },
+          select: { storageRelativePath: true, pdfPageCount: true },
+        },
+      )
+      deletedDocumentFiles.push(...generatedDocuments)
       await entityManager.delete("Document", { id: In(generatedDocumentIds) })
     }
 
     await entityManager.update(AgentMessage, { sessionId }, { content: "", toolCalls: null })
-    return attachmentStoragePaths
+    return deletedDocumentFiles
   }
 
   // Storage cleanup happens after commit: a storage hiccup must not resurrect
   // the DB content, and a missing file is not an error.
-  private async deleteAttachmentFiles(
-    attachmentStoragePaths: string[],
+  private async deleteStoredFiles(
+    deletedDocumentFiles: StoredDocumentFiles[],
     sessionId: string,
   ): Promise<void> {
-    for (const storageRelativePath of attachmentStoragePaths) {
+    for (const document of deletedDocumentFiles) {
+      // Generated documents may have no stored file (content lives in the row only).
+      if (!document.storageRelativePath) continue
       try {
-        await this.fileStorage.deleteFile(storageRelativePath)
+        await Promise.all([
+          this.fileStorage.deleteFile(document.storageRelativePath),
+          this.pdfPagesService.deleteRenderedPages({
+            document,
+            fileStorageService: this.fileStorage,
+          }),
+        ])
       } catch (error) {
         this.logger.warn(
-          `Could not delete attachment file ${storageRelativePath} for purged session ${sessionId}: ${(error as Error).message}`,
+          `Could not delete stored files ${document.storageRelativePath} for purged session ${sessionId}: ${(error as Error).message}`,
         )
       }
     }

--- a/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-retention-sweep-workers.module.ts
+++ b/apps/api/src/domains/agents/conversation-agent-sessions/retention/conversation-retention-sweep-workers.module.ts
@@ -2,6 +2,7 @@ import { BullModule } from "@nestjs/bullmq"
 import { Module } from "@nestjs/common"
 import { TypeOrmModule } from "@nestjs/typeorm"
 import { ALL_ENTITIES } from "@/common/all-entities"
+import { PdfPagesModule } from "@/domains/documents/pdf-pages/pdf-pages.module"
 import { StorageModule } from "@/domains/documents/storage/storage.module"
 import { ConversationAgentSessionPurgeService } from "./conversation-agent-session-purge.service"
 import { CONVERSATION_RETENTION_SWEEP_QUEUE_NAME } from "./conversation-retention.constants"
@@ -16,6 +17,7 @@ import { ConversationRetentionSweepSchedulerService } from "./conversation-reten
     }),
     TypeOrmModule.forFeature(ALL_ENTITIES),
     StorageModule,
+    PdfPagesModule,
   ],
   providers: [
     ConversationRetentionSweepWorker,

--- a/apps/api/src/domains/documents/crawling/url-crawling-workers.module.ts
+++ b/apps/api/src/domains/documents/crawling/url-crawling-workers.module.ts
@@ -7,6 +7,8 @@ import { ALL_ENTITIES } from "@/common/all-entities"
 import { SpiderClientService } from "@/external/spider/spider-client.service"
 import { DocumentsService } from "../documents.service"
 import { DocumentEmbeddingStatusNotifierService } from "../embeddings/document-embedding-status-notifier.service"
+import { PdfPagesModule } from "../pdf-pages/pdf-pages.module"
+import { StorageModule } from "../storage/storage.module"
 import { DocumentTagsService } from "../tags/document-tags.service"
 import { DocumentCrawlProgressNotifierService } from "./document-crawl-progress-notifier.service"
 import { URL_CRAWLING_QUEUE_NAME } from "./url-crawling.constants"
@@ -28,6 +30,8 @@ import { WebSourceEmbeddingsBatchModule } from "./web-source-embeddings-batch.mo
     }),
     TypeOrmModule.forFeature(ALL_ENTITIES),
     WebSourceEmbeddingsBatchModule,
+    StorageModule,
+    PdfPagesModule,
   ],
   providers: [
     UrlCrawlingWorker,

--- a/apps/api/src/domains/documents/crawling/web-source-embeddings-workers.module.ts
+++ b/apps/api/src/domains/documents/crawling/web-source-embeddings-workers.module.ts
@@ -7,6 +7,8 @@ import { ALL_ENTITIES } from "@/common/all-entities"
 import { DocumentsService } from "../documents.service"
 import { DocumentEmbeddingStatusNotifierService } from "../embeddings/document-embedding-status-notifier.service"
 import { DocumentEmbeddingsSharedService } from "../embeddings/document-embeddings-shared.service"
+import { PdfPagesModule } from "../pdf-pages/pdf-pages.module"
+import { StorageModule } from "../storage/storage.module"
 import { DocumentTagsService } from "../tags/document-tags.service"
 import { WebPageEmbeddingsProcessorService } from "./web-page-embeddings-processor.service"
 import { WEB_SOURCE_EMBEDDINGS_QUEUE_NAME } from "./web-source-embeddings.constants"
@@ -25,6 +27,8 @@ import { WebSourceEmbeddingsQueueMetricsService } from "./web-source-embeddings-
       name: WEB_SOURCE_EMBEDDINGS_QUEUE_NAME,
     }),
     TypeOrmModule.forFeature(ALL_ENTITIES),
+    StorageModule,
+    PdfPagesModule,
   ],
   providers: [
     WebSourceEmbeddingsWorker,

--- a/apps/api/src/domains/documents/documents.service.ts
+++ b/apps/api/src/domains/documents/documents.service.ts
@@ -1,18 +1,25 @@
-import { Injectable, NotFoundException } from "@nestjs/common"
+import { Inject, Injectable, Logger, NotFoundException } from "@nestjs/common"
 import { InjectRepository } from "@nestjs/typeorm"
 import type { Repository, UpdateResult } from "typeorm"
 import { ConnectRepository } from "@/common/entities/connect-repository"
 import type { RequiredConnectScope } from "@/common/entities/connect-required-fields"
 import { Document } from "./document.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
+import { PdfPagesService } from "./pdf-pages/pdf-pages.service"
+import { FILE_STORAGE_SERVICE, type IFileStorage } from "./storage/file-storage.interface"
+// biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DocumentTagsService } from "./tags/document-tags.service"
 import type { DocumentTagsUpdateFields } from "./tags/document-tags.types"
 
 @Injectable()
 export class DocumentsService {
+  private readonly logger = new Logger(DocumentsService.name)
+
   constructor(
     @InjectRepository(Document) private readonly documentRepository: Repository<Document>,
     private readonly documentTagsService: DocumentTagsService,
+    @Inject(FILE_STORAGE_SERVICE) private readonly fileStorageService: IFileStorage,
+    private readonly pdfPagesService: PdfPagesService,
   ) {
     this.documentConnectRepository = new ConnectRepository(documentRepository, "documents")
   }
@@ -281,6 +288,10 @@ export class DocumentsService {
     connectScope: RequiredConnectScope
     documentId: string
   }): Promise<true> {
+    const document = await this.documentConnectRepository.getOneById(connectScope, documentId)
+    if (!document) {
+      throw new NotFoundException(`Document with id ${documentId} not found`)
+    }
     const isDeleted = await this.documentConnectRepository.deleteOneById({
       connectScope,
       id: documentId,
@@ -288,6 +299,30 @@ export class DocumentsService {
     if (!isDeleted) {
       throw new NotFoundException(`Document with id ${documentId} not found`)
     }
+
+    // Storage cleanup happens after the row is gone: a storage hiccup must not
+    // resurrect the document, and a missing object is not an error.
+    await this.deleteStoredFiles(document)
     return true
+  }
+
+  /** Removes the source object and every rendered page image of a document from storage. */
+  private async deleteStoredFiles(document: Document): Promise<void> {
+    // Crawled documents have no stored file: their content lives in the row only.
+    if (!document.storageRelativePath) return
+
+    try {
+      await Promise.all([
+        this.fileStorageService.deleteFile(document.storageRelativePath),
+        this.pdfPagesService.deleteRenderedPages({
+          document,
+          fileStorageService: this.fileStorageService,
+        }),
+      ])
+    } catch (error) {
+      this.logger.warn(
+        `Could not delete stored files of document ${document.id} (${document.storageRelativePath}): ${(error as Error).message}`,
+      )
+    }
   }
 }

--- a/apps/api/src/domains/documents/embeddings/document-embeddings-stuck-sweep-workers.module.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings-stuck-sweep-workers.module.ts
@@ -3,6 +3,8 @@ import { Module } from "@nestjs/common"
 import { TypeOrmModule } from "@nestjs/typeorm"
 import { ALL_ENTITIES } from "@/common/all-entities"
 import { DocumentsService } from "../documents.service"
+import { PdfPagesModule } from "../pdf-pages/pdf-pages.module"
+import { StorageModule } from "../storage/storage.module"
 import { DocumentTagsService } from "../tags/document-tags.service"
 import { DocumentEmbeddingStatusNotifierService } from "./document-embedding-status-notifier.service"
 import { DOCUMENT_EMBEDDINGS_STUCK_SWEEP_QUEUE_NAME } from "./document-embeddings-stuck.constants"
@@ -16,6 +18,8 @@ import { DocumentEmbeddingsStuckSweepSchedulerService } from "./document-embeddi
       name: DOCUMENT_EMBEDDINGS_STUCK_SWEEP_QUEUE_NAME,
     }),
     TypeOrmModule.forFeature(ALL_ENTITIES),
+    StorageModule,
+    PdfPagesModule,
   ],
   providers: [
     DocumentEmbeddingsStuckSweepWorker,

--- a/apps/api/src/domains/documents/embeddings/document-embeddings-workers.module.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings-workers.module.ts
@@ -3,6 +3,7 @@ import { Module } from "@nestjs/common"
 import { TypeOrmModule } from "@nestjs/typeorm"
 import { ALL_ENTITIES } from "@/common/all-entities"
 import { DocumentsService } from "../documents.service"
+import { PdfPagesModule } from "../pdf-pages/pdf-pages.module"
 import { StorageModule } from "../storage/storage.module"
 import { DocumentTagsService } from "../tags/document-tags.service"
 import { DocumentEmbeddingStatusNotifierService } from "./document-embedding-status-notifier.service"
@@ -20,6 +21,7 @@ import { QueueMetricsService } from "./queue-metrics.service"
     }),
     TypeOrmModule.forFeature(ALL_ENTITIES),
     StorageModule,
+    PdfPagesModule,
   ],
   providers: [
     DocumentEmbeddingsWorker,

--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.spec.ts
@@ -12,6 +12,7 @@ describe("PdfPagesService", () => {
       getTemporaryUrl: jest.fn((storageRelativePath: string) =>
         Promise.resolve(`https://storage.example.test/${storageRelativePath}?signature=abc`),
       ),
+      deleteFile: jest.fn(() => Promise.resolve()),
     }) as unknown as IFileStorage
 
   afterEach(() => {
@@ -33,6 +34,34 @@ describe("PdfPagesService", () => {
     expect(buildService().pageObjectPath("org1/proj1/doc1.pdf", 3)).toBe(
       "org1/proj1/derived/doc1/page-3.png",
     )
+  })
+
+  it("deletes every rendered page when the page count is cached", async () => {
+    const fileStorageService = buildFileStorageService()
+
+    await buildService().deleteRenderedPages({
+      document: { storageRelativePath: "org1/proj1/doc1.pdf", pdfPageCount: 3 },
+      fileStorageService,
+    })
+
+    expect(fileStorageService.deleteFile).toHaveBeenCalledTimes(3)
+    expect(fileStorageService.deleteFile).toHaveBeenCalledWith("org1/proj1/derived/doc1/page-1.png")
+    expect(fileStorageService.deleteFile).toHaveBeenCalledWith("org1/proj1/derived/doc1/page-2.png")
+    expect(fileStorageService.deleteFile).toHaveBeenCalledWith("org1/proj1/derived/doc1/page-3.png")
+  })
+
+  it.each([
+    null,
+    0,
+  ])("deletes nothing when the page count is %s because no page was rendered", async (pdfPageCount) => {
+    const fileStorageService = buildFileStorageService()
+
+    await buildService().deleteRenderedPages({
+      document: { storageRelativePath: "org1/proj1/doc1.pdf", pdfPageCount },
+      fileStorageService,
+    })
+
+    expect(fileStorageService.deleteFile).not.toHaveBeenCalled()
   })
 
   it("returns one signed url per page without calling the converter when the count is cached", async () => {

--- a/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.ts
+++ b/apps/api/src/domains/documents/pdf-pages/pdf-pages.service.ts
@@ -27,6 +27,27 @@ export class PdfPagesService {
     return `${this.derivedPagesPrefix(storageRelativePath)}page-${pageNumber}.png`
   }
 
+  /**
+   * Removes the rendered page images of a document from storage. The cached
+   * page count is the record of which pages exist: a null or zero count means
+   * nothing was ever rendered (or persisted), so there is nothing to delete.
+   */
+  async deleteRenderedPages({
+    document: { storageRelativePath, pdfPageCount },
+    fileStorageService,
+  }: {
+    document: { storageRelativePath: string; pdfPageCount: number | null }
+    fileStorageService: IFileStorage
+  }): Promise<void> {
+    if (!pdfPageCount) return
+
+    await Promise.all(
+      Array.from({ length: pdfPageCount }, (_, index) =>
+        fileStorageService.deleteFile(this.pageObjectPath(storageRelativePath, index + 1)),
+      ),
+    )
+  }
+
   async getImageUrls({
     document: { storageRelativePath, pdfPageCount },
     onPageCountUpdate,

--- a/apps/api/src/domains/documents/service-tests/delete-document.spec.ts
+++ b/apps/api/src/domains/documents/service-tests/delete-document.spec.ts
@@ -6,6 +6,10 @@ import { documentsServiceTestSetup } from "./test-setup"
 const getTestContext = documentsServiceTestSetup()
 
 describe("deleteDocument", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it("should delete a document for a project", async () => {
     const { service, repositories } = getTestContext()
 
@@ -28,6 +32,104 @@ describe("deleteDocument", () => {
     expect(deletedDocument).toBeNull()
   })
 
+  it("should remove the source file and every rendered page from storage", async () => {
+    const { service, repositories, fileStorageService } = getTestContext()
+    const deleteFileSpy = jest.spyOn(fileStorageService, "deleteFile").mockResolvedValue()
+
+    const { organization, project } = await createOrganizationWithProject(repositories)
+    const document = documentFactory.transient({ organization, project }).build({
+      fileName: "file.pdf",
+      storageRelativePath: `${organization.id}/${project.id}/doc1.pdf`,
+      pdfPageCount: 2,
+    })
+    await repositories.documentRepository.save(document)
+
+    await service.deleteDocument({
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      documentId: document.id,
+    })
+
+    const deletedPaths = deleteFileSpy.mock.calls.map(
+      ([storageRelativePath]) => storageRelativePath,
+    )
+    expect(deletedPaths.sort()).toEqual(
+      [
+        `${organization.id}/${project.id}/doc1.pdf`,
+        `${organization.id}/${project.id}/derived/doc1/page-1.png`,
+        `${organization.id}/${project.id}/derived/doc1/page-2.png`,
+      ].sort(),
+    )
+  })
+
+  it("should only remove the source file when no page was rendered", async () => {
+    const { service, repositories, fileStorageService } = getTestContext()
+    const deleteFileSpy = jest.spyOn(fileStorageService, "deleteFile").mockResolvedValue()
+
+    const { organization, project } = await createOrganizationWithProject(repositories)
+    const document = documentFactory.transient({ organization, project }).build({
+      fileName: "file.pdf",
+      storageRelativePath: `${organization.id}/${project.id}/doc1.pdf`,
+      pdfPageCount: null,
+    })
+    await repositories.documentRepository.save(document)
+
+    await service.deleteDocument({
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      documentId: document.id,
+    })
+
+    expect(deleteFileSpy).toHaveBeenCalledTimes(1)
+    expect(deleteFileSpy).toHaveBeenCalledWith(`${organization.id}/${project.id}/doc1.pdf`)
+  })
+
+  it("should not touch storage for a crawled document without a stored file", async () => {
+    const { service, repositories, fileStorageService } = getTestContext()
+    const deleteFileSpy = jest.spyOn(fileStorageService, "deleteFile").mockResolvedValue()
+
+    const { organization, project } = await createOrganizationWithProject(repositories)
+    const document = documentFactory.transient({ organization, project }).build({
+      sourceType: "webCrawl",
+      storageRelativePath: null as unknown as string,
+    })
+    await repositories.documentRepository.save(document)
+
+    await service.deleteDocument({
+      connectScope: { organizationId: organization.id, projectId: project.id },
+      documentId: document.id,
+    })
+
+    expect(deleteFileSpy).not.toHaveBeenCalled()
+    const deletedDocument = await repositories.documentRepository.findOne({
+      where: { id: document.id },
+    })
+    expect(deletedDocument).toBeNull()
+  })
+
+  it("should still delete the document when storage cleanup fails", async () => {
+    const { service, repositories, fileStorageService } = getTestContext()
+    jest.spyOn(fileStorageService, "deleteFile").mockRejectedValue(new Error("storage down"))
+
+    const { organization, project } = await createOrganizationWithProject(repositories)
+    const document = documentFactory.transient({ organization, project }).build({
+      fileName: "file.pdf",
+      storageRelativePath: `${organization.id}/${project.id}/doc1.pdf`,
+      pdfPageCount: 2,
+    })
+    await repositories.documentRepository.save(document)
+
+    await expect(
+      service.deleteDocument({
+        connectScope: { organizationId: organization.id, projectId: project.id },
+        documentId: document.id,
+      }),
+    ).resolves.toBe(true)
+
+    const deletedDocument = await repositories.documentRepository.findOne({
+      where: { id: document.id },
+    })
+    expect(deletedDocument).toBeNull()
+  })
+
   it("should throw NotFoundException when document does not exist", async () => {
     const { service, repositories } = getTestContext()
 
@@ -41,5 +143,33 @@ describe("deleteDocument", () => {
         documentId: nonExistentDocumentId,
       }),
     ).rejects.toThrow(NotFoundException)
+  })
+
+  it("should throw NotFoundException when document belongs to another project", async () => {
+    const { service, repositories, fileStorageService } = getTestContext()
+    const deleteFileSpy = jest.spyOn(fileStorageService, "deleteFile").mockResolvedValue()
+
+    const firstContext = await createOrganizationWithProject(repositories)
+    const secondContext = await createOrganizationWithProject(repositories)
+    const document = documentFactory
+      .transient({ organization: firstContext.organization, project: firstContext.project })
+      .build({ fileName: "file.pdf" })
+    await repositories.documentRepository.save(document)
+
+    await expect(
+      service.deleteDocument({
+        connectScope: {
+          organizationId: secondContext.organization.id,
+          projectId: secondContext.project.id,
+        },
+        documentId: document.id,
+      }),
+    ).rejects.toThrow(NotFoundException)
+
+    expect(deleteFileSpy).not.toHaveBeenCalled()
+    const untouchedDocument = await repositories.documentRepository.findOne({
+      where: { id: document.id },
+    })
+    expect(untouchedDocument).not.toBeNull()
   })
 })

--- a/apps/api/src/domains/documents/service-tests/test-setup.ts
+++ b/apps/api/src/domains/documents/service-tests/test-setup.ts
@@ -6,11 +6,13 @@ import {
 } from "@/common/test/test-database"
 import { DocumentsModule } from "../documents.module"
 import { DocumentsService } from "../documents.service"
+import { FILE_STORAGE_SERVICE, type IFileStorage } from "../storage/file-storage.interface"
 import { withDocumentEmbeddingsBatchServiceMock } from "../test-overrides"
 
 export function documentsServiceTestSetup() {
   let service: DocumentsService
   let repositories: AllRepositories
+  let fileStorageService: IFileStorage
   let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
 
   beforeAll(async () => {
@@ -19,6 +21,7 @@ export function documentsServiceTestSetup() {
       applyOverrides: withDocumentEmbeddingsBatchServiceMock,
     })
     service = setup.module.get<DocumentsService>(DocumentsService)
+    fileStorageService = setup.module.get<IFileStorage>(FILE_STORAGE_SERVICE)
     repositories = setup.getAllRepositories()
   })
 
@@ -31,6 +34,6 @@ export function documentsServiceTestSetup() {
   })
 
   return () => {
-    return { repositories, service }
+    return { repositories, service, fileStorageService }
   }
 }


### PR DESCRIPTION
## Summary

Closes #689.

Deleting a document only soft-deleted the row. The source object and every rendered page image under the `derived/` prefix stayed in the bucket indefinitely. The conversation purge flow removed attachment source files but never their rendered pages, and left the files of generated documents behind.

### Changes

- **Rendered page cleanup**: `PdfPagesService.deleteRenderedPages` removes `page-1..N` using the cached page count as the record of which images exist. A null or zero count means nothing was rendered, so nothing is deleted.
- **Document deletion**: `DocumentsService.deleteDocument` loads the row, soft-deletes it, then removes the source object and all rendered pages. Storage cleanup runs after the row is gone and failures are logged as warnings instead of resurrecting the document. Crawled documents with no stored file are skipped.
- **Conversation purge**: attachments now lose their rendered pages too, and generated documents lose their stored files.
- **Module wiring**: the worker modules that provide `DocumentsService` directly, plus the retention workers module, import `StorageModule` and `PdfPagesModule`.
- **Dependency-cruiser baseline**: one warn-level cross-domain entry, matching the existing entries for the agents domain reaching `PdfPagesService`.
- Changelog entry under Security.

Note: the issue says `IFileStorage` has no delete method, but a per-object `deleteFile` already exists and this PR builds on it. No prefix-listing delete was added since the page count enumerates the objects exactly.

### Tests

- Unit tests for `deleteRenderedPages` (count set, null, zero).
- Service tests for `deleteDocument`: source plus pages removed, source only when no pages, no storage calls for crawled documents, storage failure still deletes the row, no cleanup when the scope does not match.
- Purge tests for attachments with rendered pages and for generated documents.

### Verification

- `npx tsc --noEmit` (api): pass
- `npx biome check .` (root): pass
- `npm run check:boundaries` (api): pass
- `npm run test:parallel` (api): 2293 passed, 12 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)