### PR TITLE
feat(embed): optional banner and public page link for public agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 - (beta) Priority calls: agents on Gemini 3.x models can now enable the priority tier from the Model tab.
 - Agents can run on gemini-3.7-flash and gemini-3.8-flash.
+- Public agent banner: an optional notice pinned above the conversation on the public page and in the widget.
+- Public page link: the Embed tab shows the shareable URL that serves an agent without a host website.
 
 ### Changed
 

--- a/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-config.entity.ts
+++ b/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-config.entity.ts
@@ -25,6 +25,10 @@ export class AgentEmbedConfig extends ConnectEntityBase {
   @Column({ type: "varchar", name: "primary_color", length: 20, nullable: true, default: null })
   primaryColor!: string | null
 
+  /** Optional notice pinned above the conversation (e.g. "Test version, staff only"). */
+  @Column({ type: "text", name: "banner_text", nullable: true, default: null })
+  bannerText!: string | null
+
   @ManyToOne(() => Agent, { onDelete: "CASCADE" })
   @JoinColumn({ name: "agent_id" })
   agent!: Agent

--- a/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-config.factory.ts
+++ b/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-config.factory.ts
@@ -28,6 +28,7 @@ export const agentEmbedConfigFactory = AgentEmbedConfigFactory.define(
       title: params.title ?? null,
       logoUrl: params.logoUrl ?? null,
       primaryColor: params.primaryColor ?? null,
+      bannerText: params.bannerText ?? null,
       createdAt: params.createdAt ?? now,
       updatedAt: params.updatedAt ?? now,
       deletedAt: params.deletedAt ?? null,

--- a/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-configs-management.controller.ts
+++ b/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-configs-management.controller.ts
@@ -40,13 +40,14 @@ export class AgentEmbedConfigsManagementController {
     @Req() request: EndpointRequestWithAgent,
     @Body() { payload }: typeof AgentEmbedConfigsRoutes.updateOne.request,
   ): Promise<typeof AgentEmbedConfigsRoutes.updateOne.response> {
-    const { isEnabled, allowedOrigins, title, logoUrl, primaryColor } = payload ?? {}
+    const { isEnabled, allowedOrigins, title, logoUrl, primaryColor, bannerText } = payload ?? {}
     await this.agentEmbedConfigsService.update(request.agent.id, {
       isEnabled,
       allowedOrigins,
       title,
       logoUrl,
       primaryColor,
+      bannerText,
     })
     return { data: { success: true } }
   }
@@ -62,6 +63,7 @@ function toAgentEmbedConfigDto(entity: AgentEmbedConfig): AgentEmbedConfigDto {
     title: entity.title,
     logoUrl: entity.logoUrl,
     primaryColor: entity.primaryColor,
+    bannerText: entity.bannerText,
     createdAt: entity.createdAt.getTime(),
     updatedAt: entity.updatedAt.getTime(),
   }

--- a/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-configs.service.ts
+++ b/apps/api/src/domains/public-chat/agent-embed-configs/agent-embed-configs.service.ts
@@ -47,7 +47,10 @@ export class AgentEmbedConfigsService {
   async update(
     agentId: string,
     fields: Partial<
-      Pick<AgentEmbedConfig, "isEnabled" | "allowedOrigins" | "title" | "logoUrl" | "primaryColor">
+      Pick<
+        AgentEmbedConfig,
+        "isEnabled" | "allowedOrigins" | "title" | "logoUrl" | "primaryColor" | "bannerText"
+      >
     >,
   ): Promise<AgentEmbedConfig> {
     const config = await this.findByAgentIdOrFail(agentId)

--- a/apps/api/src/domains/public-chat/agent-embed-configs/e2e-tests/update-one.spec.ts
+++ b/apps/api/src/domains/public-chat/agent-embed-configs/e2e-tests/update-one.spec.ts
@@ -102,6 +102,32 @@ describe("AgentEmbedConfigs Management - PATCH one", () => {
     expect(updated.allowedOrigins).toEqual(origins)
   })
 
+  it("updates bannerText and clears it with null", async () => {
+    const response = await request({
+      route: AgentEmbedConfigsRoutes.updateOne,
+      pathParams: { organizationId, projectId, agentId },
+      token: "token",
+      request: { payload: { bannerText: "Test version, healthcare staff only" } },
+    })
+
+    expectResponse(response, 200)
+    const updated = await setup
+      .getRepository(AgentEmbedConfig)
+      .findOneOrFail({ where: { agentId } })
+    expect(updated.bannerText).toBe("Test version, healthcare staff only")
+
+    await request({
+      route: AgentEmbedConfigsRoutes.updateOne,
+      pathParams: { organizationId, projectId, agentId },
+      token: "token",
+      request: { payload: { bannerText: null } },
+    })
+    const cleared = await setup
+      .getRepository(AgentEmbedConfig)
+      .findOneOrFail({ where: { agentId } })
+    expect(cleared.bannerText).toBeNull()
+  })
+
   it("only updates specified fields (partial update)", async () => {
     await request({
       route: AgentEmbedConfigsRoutes.updateOne,

--- a/apps/api/src/domains/public-chat/e2e-tests/get-config.spec.ts
+++ b/apps/api/src/domains/public-chat/e2e-tests/get-config.spec.ts
@@ -44,7 +44,7 @@ describe("PublicChat - getConfig", () => {
       await createOrganizationWithAgent(repositories)
     const embedConfig = agentEmbedConfigFactory
       .transient({ organization, project, agent })
-      .build({ isEnabled: true })
+      .build({ isEnabled: true, bannerText: "Test version, healthcare staff only" })
     await repositories.agentEmbedConfigRepository.save(embedConfig)
     embedToken = embedConfig.embedToken
     return { organization, project, agent, agentSettings, embedConfig }
@@ -64,5 +64,6 @@ describe("PublicChat - getConfig", () => {
     expect(response.body.data.title).toBe(embedConfig.title)
     expect(response.body.data.logoUrl).toBe(embedConfig.logoUrl)
     expect(response.body.data.primaryColor).toBe(embedConfig.primaryColor)
+    expect(response.body.data.bannerText).toBe("Test version, healthcare staff only")
   })
 })

--- a/apps/api/src/domains/public-chat/public-chat.controller.ts
+++ b/apps/api/src/domains/public-chat/public-chat.controller.ts
@@ -33,6 +33,7 @@ export class PublicChatController {
         title: embedConfig.title,
         logoUrl: embedConfig.logoUrl,
         primaryColor: embedConfig.primaryColor,
+        bannerText: embedConfig.bannerText,
       } satisfies EmbedPublicConfigDto,
     }
   }

--- a/apps/api/src/domains/public-chat/public-chat.service.ts
+++ b/apps/api/src/domains/public-chat/public-chat.service.ts
@@ -111,6 +111,7 @@ export class PublicChatService {
       title: embedConfig.title,
       logoUrl: embedConfig.logoUrl,
       primaryColor: embedConfig.primaryColor,
+      bannerText: embedConfig.bannerText,
       createdAt: embedConfig.createdAt.getTime(),
       updatedAt: embedConfig.updatedAt.getTime(),
     }

--- a/apps/api/src/migrations/1788785187296-add-embed-config-banner-text.ts
+++ b/apps/api/src/migrations/1788785187296-add-embed-config-banner-text.ts
@@ -1,0 +1,13 @@
+import type { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddEmbedConfigBannerText1788785187296 implements MigrationInterface {
+  name = "AddEmbedConfigBannerText1788785187296"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agent_embed_config" ADD "banner_text" text`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agent_embed_config" DROP COLUMN "banner_text"`)
+  }
+}

--- a/apps/help/src/components/EmbedWalkthrough.astro
+++ b/apps/help/src/components/EmbedWalkthrough.astro
@@ -5,13 +5,15 @@
  * blind): AgentEditor.tsx (tab gating: conversation-only, flag `agent-embed`, last
  * tab after Orchestration) and AgentEmbedTab.tsx (Enable embed switch, read-only
  * Embed snippet + Copy, snippet hint, Allowed origins, Widget title, Logo URL,
- * Brand color, Update). Labels verbatim from the agent / actions locales (EN + FR).
- * Uses the PRODUCT (coral) palette, pinned locally. Derived 2026-07-16.
+ * Brand color, Banner text, Update) plus the read-only Public page link under the
+ * snippet. Labels verbatim from the agent / actions locales (EN + FR).
+ * Uses the PRODUCT (coral) palette, pinned locally. Derived 2026-07-16, updated 2026-09-07.
  */
 type Lang = "en" | "fr"
 const { lang = "en" } = Astro.props as { lang?: Lang }
 
 const SNIPPET = '<script src="https://app.example.com/launcher.js" data-token="emb_1a2b3c4d"></script>'
+const PUBLIC_PAGE_URL = "https://app.example.com/index.html?embedToken=emb_1a2b3c4d&displayMode=drawer"
 
 const STRINGS = {
   en: {
@@ -31,6 +33,9 @@ const STRINGS = {
     snippetDescription: "Paste this <script> tag before the closing </body> tag on any page where you want the chat widget to appear.",
     snippetValue: SNIPPET,
     snippetHint: "Optional attributes: data-color, data-locale, data-display-mode, data-hint.",
+    publicPageLabel: "Public page link",
+    publicPageDescription: "Share this link, or a QR code of it, to make Helpful Assistant available without a host website.",
+    publicPageValue: PUBLIC_PAGE_URL,
     allowedOriginsLabel: "Allowed origins",
     allowedOriginsDescription: "Comma-separated list of allowed origins (e.g. https://app.example.com). Leave empty to allow all origins.",
     allowedOriginsPlaceholder: "https://app.example.com, https://staging.example.com",
@@ -42,15 +47,18 @@ const STRINGS = {
     primaryColorLabel: "Brand color",
     primaryColorDescription: "Primary color used in the chat widget header. Enter a hex value (e.g. #2563eb).",
     colorValue: "#2563eb",
+    bannerTextLabel: "Banner text",
+    bannerTextDescription: "Optional notice pinned above the conversation, on the public page and in the widget.",
+    bannerTextPlaceholder: "Test version, for the pilot team only",
     update: "Update",
     prev: "Prev", next: "Next", step: "Step",
     steps: [
       "In Studio, open a conversation agent to edit it.",
       "Open the Embed tab — it appears only for conversation agents.",
       "Turn on Enable embed to allow the agent on external sites.",
-      "Copy the Embed snippet and paste it before </body> on your site.",
+      "Copy the Embed snippet for your site, or the Public page link to share the agent without a website.",
       "Set Allowed origins to control which sites may embed the widget.",
-      "Customize the Widget title, Logo URL and Brand color.",
+      "Customize the Widget title, Logo URL, Brand color and Banner text.",
       "Click Update to save the embed configuration.",
     ],
   },
@@ -71,6 +79,9 @@ const STRINGS = {
     snippetDescription: "Collez cette balise <script> avant la balise </body> fermante sur chaque page où vous souhaitez afficher le widget de chat.",
     snippetValue: SNIPPET,
     snippetHint: "Attributs optionnels : data-color, data-locale, data-display-mode, data-hint.",
+    publicPageLabel: "Lien de la page publique",
+    publicPageDescription: "Partagez ce lien, ou un QR code de ce lien, pour rendre Helpful Assistant accessible sans site hôte.",
+    publicPageValue: PUBLIC_PAGE_URL,
     allowedOriginsLabel: "Origines autorisées",
     allowedOriginsDescription: "Liste d'origines autorisées séparées par des virgules (ex. https://app.example.com). Laissez vide pour autoriser toutes les origines.",
     allowedOriginsPlaceholder: "https://app.example.com, https://staging.example.com",
@@ -82,15 +93,18 @@ const STRINGS = {
     primaryColorLabel: "Couleur principale",
     primaryColorDescription: "Couleur principale utilisée dans l'en-tête du widget de chat. Saisissez une valeur hexadécimale (ex. #2563eb).",
     colorValue: "#2563eb",
+    bannerTextLabel: "Texte du bandeau",
+    bannerTextDescription: "Message optionnel affiché en permanence au-dessus de la conversation, sur la page publique et dans le widget.",
+    bannerTextPlaceholder: "Version de test, réservée à l'équipe pilote",
     update: "Mettre à jour",
     prev: "Précédent", next: "Suivant", step: "Étape",
     steps: [
       "Dans Studio, ouvrez un agent conversationnel pour le modifier.",
       "Ouvrez l'onglet Intégration — il n'apparaît que pour les agents conversationnels.",
       "Activez « Activer l'intégration » pour autoriser l'agent sur des sites externes.",
-      "Copiez l'extrait d'intégration et collez-le avant </body> sur votre site.",
+      "Copiez l'extrait d'intégration pour votre site, ou le Lien de la page publique pour partager l'agent sans site web.",
       "Définissez les Origines autorisées pour contrôler quels sites peuvent intégrer le widget.",
-      "Personnalisez le Titre du widget, l'URL du logo et la Couleur principale.",
+      "Personnalisez le Titre du widget, l'URL du logo, la Couleur principale et le Texte du bandeau.",
       "Cliquez sur Mettre à jour pour enregistrer la configuration d'intégration.",
     ],
   },
@@ -115,7 +129,7 @@ const steps = [
   { page: "overview", spot: "navAgent1", observe: [] },
   { page: "embed", spot: "tab-embed", observe: [] },
   { page: "embed", spot: "", observe: ["obsEnable"] },
-  { page: "embed", spot: "", observe: ["obsSnippet"] },
+  { page: "embed", spot: "", observe: ["obsSnippet", "obsPublicPage"] },
   { page: "embed", spot: "", observe: ["obsOrigins"] },
   { page: "embed", spot: "", observe: ["obsBranding"] },
   { page: "embed", spot: "btnUpdate", observe: [] },
@@ -197,6 +211,15 @@ const labels = { prev: s.prev, next: s.next, step: s.step }
                 <p class="hint">{s.snippetHint}</p>
               </div>
 
+              <div class="fld" id="obsPublicPage">
+                <p class="lbl">{s.publicPageLabel}</p>
+                <p class="hint">{s.publicPageDescription}</p>
+                <div class="snippet-row">
+                  <span class="input block mono">{s.publicPageValue}</span>
+                  <span class="iconbtn"><svg viewBox="0 0 24 24"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg></span>
+                </div>
+              </div>
+
               <div class="fld" id="obsOrigins">
                 <p class="lbl">{s.allowedOriginsLabel}</p>
                 <p class="hint">{s.allowedOriginsDescription}</p>
@@ -218,6 +241,11 @@ const labels = { prev: s.prev, next: s.next, step: s.step }
                   <p class="lbl">{s.primaryColorLabel}</p>
                   <p class="hint">{s.primaryColorDescription}</p>
                   <span class="colorrow"><i class="swatch"></i><span class="input block mono">{s.colorValue}</span></span>
+                </div>
+                <div class="fld">
+                  <p class="lbl">{s.bannerTextLabel}</p>
+                  <p class="hint">{s.bannerTextDescription}</p>
+                  <span class="textarea muted-txt">{s.bannerTextPlaceholder}</span>
                 </div>
               </div>
             </div>

--- a/apps/help/src/content/docs/en/agent-embed.mdx
+++ b/apps/help/src/content/docs/en/agent-embed.mdx
@@ -1,18 +1,23 @@
 ---
 title: Embed
 highlight: Embed
-description: Put a conversation agent on your own website as a chat widget — enable embedding, copy the script snippet, restrict which sites can load it, and match your branding.
+description: Make a conversation agent available outside the platform — as a chat widget on your own website or as a standalone public page shared by link or QR code — with your branding and an optional banner.
 category: guides-agents
 order: 6
-updated: 2026-07-22
+updated: 2026-09-07
 ---
 
 import EmbedWalkthrough from "@/components/EmbedWalkthrough.astro"
 
-**Embed** lets you place a **conversation agent** on your own website as a **chat
-widget**. You turn embedding on, copy a small `<script>` **snippet** into your site,
-and the agent appears as a chat bubble (or a side panel) that your visitors can talk
-to.
+**Embed** lets you make a **conversation agent** available to people outside the
+platform, in two ways:
+
+- as a **chat widget** on your own website: you turn embedding on, copy a small
+  `<script>` **snippet** into your site, and the agent appears as a chat bubble (or a
+  side panel) that your visitors can talk to;
+- as a **standalone public page**: the platform serves the same chat, full screen, at
+  a **public page link** you can share directly or print as a **QR code**. No website
+  is needed, which suits a pilot, an event or a test access.
 
 Embedding is configured on the **Embed** tab of a **conversation agent's** editor, in
 **Studio**. It's an optional feature: the tab only appears when your workspace has
@@ -30,11 +35,17 @@ enabled, which sits after it.
 - Each conversation agent has its own **embed snippet** — a `<script>` tag carrying a
   unique token. Adding that snippet to a web page loads the chat widget for that
   agent.
-- The snippet exists whether or not embedding is on, but the widget only loads once
-  **Enable embed** is turned on.
+- The same token gives the agent a **public page link**. Anyone who opens it gets
+  the full chat, without any host website.
+- The snippet and the link exist whether or not embedding is on, but the widget and
+  the public page only work once **Enable embed** is turned on. Turning it off takes
+  them offline immediately, which is how you end a temporary access.
 - You control **which sites** may load the widget with **Allowed origins**, and you
   can **customize its appearance** (title, logo, brand color) plus a few optional
   `data-` attributes on the script tag.
+- An optional **banner text** stays pinned above the conversation, on the public page
+  and in the widget, so visitors always see the context (for example *Test version,
+  for the pilot team only*) even if the link is forwarded.
 - Changes are saved with **Update** (this tab uses **Update**, not Save).
 
 ## The full flow at a glance
@@ -79,16 +90,21 @@ The hint lists **optional attributes** you can add to the tag to tweak the widge
 - **`data-display-mode`** — set to `drawer` for a side panel instead of a bubble.
 - **`data-hint`** — a tooltip shown on load and on hover (e.g. `Need help?`).
 
+Below the snippet, **Public page link** is the URL of the standalone page. Copy it with
+the **copy** button and share it as a link or a QR code when you have no website to
+host the widget. Append `&locale=fr` to force the language of the page.
+
 ### 5. Restrict the allowed origins
 
 In **Allowed origins**, enter a **comma-separated list** of the sites permitted to
 load the widget (for example `https://app.example.com, https://staging.example.com`).
 As the description notes, **leave it empty to allow all origins** — but for production
-it's safer to list only your own domains.
+it's safer to list only your own domains. If you use the **public page link**, keep
+the list empty: the page has no host website to allow.
 
 ### 6. Customize the widget's appearance
 
-Three optional fields control how the widget looks:
+Four optional fields control how the widget looks:
 
 - **Widget title** — the title shown in the chat header. Left empty, it **defaults to
   the agent's name**.
@@ -96,11 +112,15 @@ Three optional fields control how the widget looks:
   `https://example.com/logo.png`).
 - **Brand color** — the primary color of the chat header. Pick it with the color
   swatch or type a **hex value** (e.g. `#2563eb`).
+- **Banner text** — an optional notice pinned above the conversation, on the public
+  page and in the widget. State the context there: a test version, the intended
+  audience, a validity period. Leave it empty to show no banner.
 
 ### 7. Update
 
 Click **Update** to save the configuration. Your changes — enabled state, allowed
-origins, title, logo and color — take effect for the embedded widget.
+origins, title, logo, color and banner — take effect for the widget and the public
+page.
 
 ## Tips
 
@@ -112,6 +132,8 @@ origins, title, logo and color — take effect for the embedded widget.
   bubble, and `data-locale` to force the widget's language.
 - The **Widget title** falls back to the agent's name — set it explicitly if you want
   a different heading for visitors.
+- For a temporary access shared by link or QR code, set a **Banner text** that says
+  who the agent is for, then turn **Enable embed** off when the access ends.
 
 ## Troubleshooting
 
@@ -125,5 +147,9 @@ origins, title, logo and color — take effect for the embedded widget.
   every origin; add your specific domains to restrict it.
 - **The header shows the agent's name, not my title** — **Widget title** is empty, so
   it defaults to the agent's name; enter a title and **Update**.
+- **The public page shows "not available"** — **Enable embed** is off, or **Allowed
+  origins** is not empty. Turn embedding on and clear the origins list.
+- **The banner doesn't show** — **Banner text** is empty or you didn't click
+  **Update**; the banner only appears when the text is set.
 - **Related:** the embedded widget is a conversation agent — see
   [Add a conversation agent](/en/add-a-conversation-agent) to configure what it says.

--- a/apps/help/src/content/docs/fr/agent-embed.mdx
+++ b/apps/help/src/content/docs/fr/agent-embed.mdx
@@ -1,18 +1,24 @@
 ---
 title: Intégration
 highlight: Intégration
-description: Placez un agent conversationnel sur votre propre site comme widget de chat — activez l'intégration, copiez l'extrait de script, restreignez les sites autorisés, et adaptez la marque.
+description: Rendez un agent conversationnel accessible hors de la plateforme — comme widget de chat sur votre site ou comme page publique autonome partagée par lien ou QR code — avec votre marque et un bandeau optionnel.
 category: guides-agents
 order: 6
-updated: 2026-07-22
+updated: 2026-09-07
 ---
 
 import EmbedWalkthrough from "@/components/EmbedWalkthrough.astro"
 
-L'**intégration** vous permet de placer un **agent conversationnel** sur votre propre
-site web comme **widget de chat**. Vous activez l'intégration, copiez un petit extrait
-`<script>` dans votre site, et l'agent apparaît sous forme de bulle de chat (ou de
-panneau latéral) avec laquelle vos visiteurs peuvent discuter.
+L'**intégration** vous permet de rendre un **agent conversationnel** accessible à des
+personnes extérieures à la plateforme, de deux façons :
+
+- comme **widget de chat** sur votre propre site web : vous activez l'intégration,
+  copiez un petit extrait `<script>` dans votre site, et l'agent apparaît sous forme de
+  bulle de chat (ou de panneau latéral) avec laquelle vos visiteurs peuvent discuter ;
+- comme **page publique autonome** : la plateforme sert le même chat, en plein écran,
+  à un **lien de page publique** que vous partagez directement ou imprimez en **QR
+  code**. Aucun site web n'est nécessaire, ce qui convient à un pilote, un événement
+  ou un accès de test.
 
 L'intégration se configure sur l'onglet **Intégration** de l'éditeur d'un **agent
 conversationnel**, dans **Studio**. C'est une fonctionnalité optionnelle : l'onglet
@@ -32,11 +38,19 @@ activé, qui se place après lui.
 - Chaque agent conversationnel possède son propre **extrait d'intégration** — une
   balise `<script>` portant un jeton unique. Ajouter cet extrait à une page web y
   charge le widget de chat de cet agent.
-- L'extrait existe que l'intégration soit activée ou non, mais le widget ne se charge
-  qu'une fois **Activer l'intégration** activé.
+- Le même jeton donne à l'agent un **lien de page publique**. Toute personne qui
+  l'ouvre accède au chat complet, sans aucun site hôte.
+- L'extrait et le lien existent que l'intégration soit activée ou non, mais le widget
+  et la page publique ne fonctionnent qu'une fois **Activer l'intégration** activé. Le
+  désactiver les met hors ligne immédiatement : c'est ainsi que vous terminez un accès
+  temporaire.
 - Vous contrôlez **quels sites** peuvent charger le widget avec les **Origines
   autorisées**, et vous pouvez **personnaliser son apparence** (titre, logo, couleur
   principale) ainsi que quelques attributs `data-` optionnels sur la balise de script.
+- Un **texte de bandeau** optionnel reste affiché au-dessus de la conversation, sur la
+  page publique et dans le widget, pour que les visiteurs voient toujours le contexte
+  (par exemple *Version de test, réservée à l'équipe pilote*) même si le lien est
+  transféré.
 - Les modifications sont enregistrées avec **Mettre à jour** (cet onglet utilise
   **Mettre à jour**, pas Enregistrer).
 
@@ -88,17 +102,23 @@ widget :
 - **`data-hint`** — une infobulle affichée au chargement et au survol (ex. `Besoin
   d'aide ?`).
 
+Sous l'extrait, **Lien de la page publique** est l'URL de la page autonome. Copiez-la
+avec le bouton **copier** et partagez-la sous forme de lien ou de QR code quand vous
+n'avez pas de site pour héberger le widget. Ajoutez `&locale=fr` pour forcer la langue
+de la page.
+
 ### 5. Restreindre les origines autorisées
 
 Dans **Origines autorisées**, saisissez une **liste séparée par des virgules** des
 sites autorisés à charger le widget (par exemple `https://app.example.com,
 https://staging.example.com`). Comme le précise la description, **laissez vide pour
 autoriser toutes les origines** — mais en production, il est plus sûr de ne lister que
-vos propres domaines.
+vos propres domaines. Si vous utilisez le **lien de la page publique**, laissez la
+liste vide : la page n'a pas de site hôte à autoriser.
 
 ### 6. Personnaliser l'apparence du widget
 
-Trois champs optionnels contrôlent l'aspect du widget :
+Quatre champs optionnels contrôlent l'aspect du widget :
 
 - **Titre du widget** — le titre affiché dans l'en-tête du chat. Laissé vide, il
   **correspond au nom de l'agent**.
@@ -107,12 +127,16 @@ Trois champs optionnels contrôlent l'aspect du widget :
 - **Couleur principale** — la couleur principale de l'en-tête du chat. Choisissez-la
   avec le sélecteur de couleur ou saisissez une **valeur hexadécimale** (ex.
   `#2563eb`).
+- **Texte du bandeau** — un message optionnel affiché en permanence au-dessus de la
+  conversation, sur la page publique et dans le widget. Précisez-y le contexte : une
+  version de test, le public visé, une période de validité. Laissez-le vide pour
+  n'afficher aucun bandeau.
 
 ### 7. Mettre à jour
 
 Cliquez sur **Mettre à jour** pour enregistrer la configuration. Vos modifications —
-état d'activation, origines autorisées, titre, logo et couleur — prennent effet pour
-le widget intégré.
+état d'activation, origines autorisées, titre, logo, couleur et bandeau — prennent
+effet pour le widget et la page publique.
 
 ## Conseils
 
@@ -125,6 +149,9 @@ le widget intégré.
   flottante, et `data-locale` pour forcer la langue du widget.
 - Le **Titre du widget** reprend le nom de l'agent — définissez-le explicitement si
   vous voulez un autre en-tête pour les visiteurs.
+- Pour un accès temporaire partagé par lien ou QR code, définissez un **Texte du
+  bandeau** qui indique à qui l'agent s'adresse, puis désactivez **Activer
+  l'intégration** quand l'accès prend fin.
 
 ## Dépannage
 
@@ -140,6 +167,12 @@ le widget intégré.
   restreindre.
 - **L'en-tête affiche le nom de l'agent, pas mon titre** — le **Titre du widget** est
   vide, il reprend donc le nom de l'agent ; saisissez un titre et **Mettez à jour**.
+- **La page publique indique « non disponible »** — **Activer l'intégration** est
+  désactivé, ou les **Origines autorisées** ne sont pas vides. Activez l'intégration et
+  videz la liste des origines.
+- **Le bandeau ne s'affiche pas** — le **Texte du bandeau** est vide ou vous n'avez pas
+  cliqué sur **Mettre à jour** ; le bandeau n'apparaît que lorsque le texte est
+  renseigné.
 - **En lien :** le widget intégré est un agent conversationnel — voir
   [Ajouter un agent conversationnel](/fr/add-a-conversation-agent) pour configurer ce
   qu'il dit.

--- a/apps/web-embed/src/App.tsx
+++ b/apps/web-embed/src/App.tsx
@@ -144,6 +144,7 @@ function LiveChat({
   return (
     <EmbedChat
       agentName={remoteConfig?.title ?? remoteConfig?.agentName}
+      bannerText={remoteConfig?.bannerText ?? undefined}
       theme={theme}
       locale={locale}
       displayMode={displayMode}
@@ -218,6 +219,7 @@ function SimulatedChat({
   return (
     <EmbedChat
       agentName="Helpful Assistant"
+      bannerText={readParam("bannerText")}
       locale={locale}
       displayMode={displayMode}
       hideHeader={hideHeader}

--- a/apps/web-embed/src/chat/EmbedChat.stories.tsx
+++ b/apps/web-embed/src/chat/EmbedChat.stories.tsx
@@ -48,6 +48,22 @@ export const ShortConversation: Story = {
   },
 }
 
+export const WithBanner: Story = {
+  args: {
+    messages: shortConversation,
+    bannerText: "Test version, for the pilot team only. Answers may be incomplete.",
+  },
+}
+
+export const WithBannerNoHeader: Story = {
+  name: "With banner — header hidden",
+  args: {
+    messages: shortConversation,
+    hideHeader: true,
+    bannerText: "Test version, for the pilot team only.",
+  },
+}
+
 export const LongConversation: Story = {
   args: {
     messages: longConversation,

--- a/apps/web-embed/src/chat/EmbedChat.tsx
+++ b/apps/web-embed/src/chat/EmbedChat.tsx
@@ -6,6 +6,7 @@ import { createEmbedI18n } from "../i18n"
 import {
   Chat,
   ChatActions,
+  ChatBanner,
   ChatContent,
   ChatFooter,
   ChatHeader,
@@ -43,6 +44,8 @@ export type EmbedChatProps = {
   onClose?: () => void
   /** Hide the branded header (agent name, logo, close). Useful when the host already has chrome. */
   hideHeader?: boolean
+  /** Optional notice pinned above the conversation (e.g. "Test version, staff only"). */
+  bannerText?: string
 }
 
 export function EmbedChat(props: EmbedChatProps) {
@@ -73,6 +76,7 @@ function EmbedChatInner({
   placeholder,
   onClose,
   hideHeader = false,
+  bannerText,
 }: EmbedChatProps) {
   const { t } = useTranslation("chat")
   const chatEndRef = useRef<HTMLDivElement>(null)
@@ -101,6 +105,8 @@ function EmbedChatInner({
       {!hideHeader && (
         <ChatHeader agentName={agentName} logoUrl={theme?.logoUrl} onClose={onClose} />
       )}
+
+      {bannerText && <ChatBanner text={bannerText} />}
 
       <ChatContent>
         {messages.map((message) => (

--- a/apps/web-embed/src/chat/components/ChatBanner.tsx
+++ b/apps/web-embed/src/chat/components/ChatBanner.tsx
@@ -1,0 +1,28 @@
+import { InfoIcon } from "lucide-react"
+import type * as React from "react"
+import { cn } from "../lib/cn"
+
+/**
+ * Organization-configured notice pinned above the conversation.
+ * Stays visible while the messages scroll, in both the standalone public page and the widget.
+ */
+export function ChatBanner({
+  text,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { text: string }) {
+  return (
+    <div
+      data-slot="chat-banner"
+      role="note"
+      className={cn(
+        "flex shrink-0 items-start gap-2 border-b border-amber-200 bg-amber-50 px-5 py-2.5 text-sm text-amber-900",
+        className,
+      )}
+      {...props}
+    >
+      <InfoIcon aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+      <p className="flex-1 whitespace-pre-line break-words">{text}</p>
+    </div>
+  )
+}

--- a/apps/web-embed/src/chat/components/index.ts
+++ b/apps/web-embed/src/chat/components/index.ts
@@ -1,5 +1,6 @@
 export { Chat } from "./Chat"
 export { ChatActions } from "./ChatActions"
+export { ChatBanner } from "./ChatBanner"
 export { ChatBotMessage } from "./ChatBotMessage"
 export { ChatContent } from "./ChatContent"
 export { ChatFooter } from "./ChatFooter"

--- a/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.en.json
+++ b/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.en.json
@@ -186,6 +186,9 @@
       "snippetLabel": "Embed snippet",
       "snippetDescription": "Paste this <script> tag before the closing </body> tag on any page where you want the chat widget to appear.",
       "snippetHint": "Optional attributes: data-color=\"#2563eb\" (button color), data-locale=\"fr\" (widget language), data-display-mode=\"drawer\" (side panel instead of bubble), data-hint=\"Need help?\" (tooltip shown on load and hover).",
+      "publicPageLabel": "Public page link",
+      "publicPageDescription": "Share this link, or a QR code of it, to make {{name}} available without a host website.",
+      "publicPageHint": "The page only works while embedding is enabled. Add &locale=fr to force the language.",
       "allowedOriginsLabel": "Allowed origins",
       "allowedOriginsDescription": "Comma-separated list of allowed origins (e.g. https://app.example.com). Leave empty to allow all origins.",
       "allowedOriginsPlaceholder": "https://app.example.com, https://staging.example.com",
@@ -195,7 +198,10 @@
       "logoUrlDescription": "URL of the logo image shown in the chat header.",
       "logoUrlPlaceholder": "https://example.com/logo.png",
       "primaryColorLabel": "Brand color",
-      "primaryColorDescription": "Primary color used in the chat widget header. Enter a hex value (e.g. #2563eb)."
+      "primaryColorDescription": "Primary color used in the chat widget header. Enter a hex value (e.g. #2563eb).",
+      "bannerTextLabel": "Banner text",
+      "bannerTextDescription": "Optional notice pinned above the conversation, on the public page and in the widget. Use it to state the context, such as a test version or the intended audience.",
+      "bannerTextPlaceholder": "Test version, for the pilot team only"
     },
     "source_one": "{{count}} source",
     "source_other": "{{count}} sources",

--- a/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.fr.json
+++ b/apps/web/src/common/features/agents/agent-settings/locales/agent-settings.fr.json
@@ -186,6 +186,9 @@
       "snippetLabel": "Extrait d'intégration",
       "snippetDescription": "Collez cette balise <script> avant la balise </body> fermante sur chaque page où vous souhaitez afficher le widget de chat.",
       "snippetHint": "Attributs optionnels : data-color=\"#2563eb\" (couleur du bouton), data-locale=\"fr\" (langue du widget), data-display-mode=\"drawer\" (panneau latéral au lieu d'une bulle), data-hint=\"Besoin d'aide ?\" (infobulle affichée au chargement et au survol).",
+      "publicPageLabel": "Lien de la page publique",
+      "publicPageDescription": "Partagez ce lien, ou un QR code de ce lien, pour rendre {{name}} accessible sans site hôte.",
+      "publicPageHint": "La page ne fonctionne que lorsque l'intégration est activée. Ajoutez &locale=fr pour forcer la langue.",
       "allowedOriginsLabel": "Origines autorisées",
       "allowedOriginsDescription": "Liste d'origines autorisées séparées par des virgules (ex. https://app.example.com). Laissez vide pour autoriser toutes les origines.",
       "allowedOriginsPlaceholder": "https://app.example.com, https://staging.example.com",
@@ -195,7 +198,10 @@
       "logoUrlDescription": "URL de l'image du logo affichée dans l'en-tête du chat.",
       "logoUrlPlaceholder": "https://example.com/logo.png",
       "primaryColorLabel": "Couleur principale",
-      "primaryColorDescription": "Couleur principale utilisée dans l'en-tête du widget de chat. Saisissez une valeur hexadécimale (ex. #2563eb)."
+      "primaryColorDescription": "Couleur principale utilisée dans l'en-tête du widget de chat. Saisissez une valeur hexadécimale (ex. #2563eb).",
+      "bannerTextLabel": "Texte du bandeau",
+      "bannerTextDescription": "Message optionnel affiché en permanence au-dessus de la conversation, sur la page publique et dans le widget. Utilisez-le pour préciser le contexte, par exemple une version de test ou le public visé.",
+      "bannerTextPlaceholder": "Version de test, réservée à l'équipe pilote"
     },
     "source_one": "{{count}} source",
     "source_other": "{{count}} sources",

--- a/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.factory.ts
+++ b/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.factory.ts
@@ -25,6 +25,7 @@ export const agentEmbedConfigFactory = AgentEmbedConfigFactory.define(
       title: params.title ?? null,
       logoUrl: params.logoUrl ?? null,
       primaryColor: params.primaryColor ?? null,
+      bannerText: params.bannerText ?? null,
       createdAt: params.createdAt ?? faker.date.past().getTime(),
       updatedAt: params.updatedAt ?? faker.date.recent().getTime(),
     }

--- a/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.models.ts
+++ b/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.models.ts
@@ -9,6 +9,7 @@ export type AgentEmbedConfig = {
   title: string | null
   logoUrl: string | null
   primaryColor: string | null
+  bannerText: string | null
   createdAt: TimeType
   updatedAt: TimeType
 }

--- a/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.spi.ts
+++ b/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.spi.ts
@@ -14,6 +14,7 @@ export interface IAgentEmbedConfigsSpi {
       title?: string | null
       logoUrl?: string | null
       primaryColor?: string | null
+      bannerText?: string | null
     },
   ) => Promise<void>
 }

--- a/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.thunks.ts
+++ b/apps/web/src/studio/features/agent-embed-configs/agent-embed-configs.thunks.ts
@@ -22,12 +22,13 @@ type UpdateConfigPayload = {
   title?: string | null
   logoUrl?: string | null
   primaryColor?: string | null
+  bannerText?: string | null
 }
 
 const updateConfig = createAsyncThunk<void, UpdateConfigPayload, ThunkConfig>(
   "agentEmbedConfigs/updateConfig",
   async (
-    { isEnabled, allowedOrigins, title, logoUrl, primaryColor },
+    { isEnabled, allowedOrigins, title, logoUrl, primaryColor, bannerText },
     { extra: { services }, getState },
   ) => {
     const state = getState()
@@ -36,7 +37,7 @@ const updateConfig = createAsyncThunk<void, UpdateConfigPayload, ThunkConfig>(
     const agentId = getCurrentId({ state, name: "agentId" })
     await services.agentEmbedConfigs.updateOne(
       { organizationId, projectId, agentId },
-      { isEnabled, allowedOrigins, title, logoUrl, primaryColor },
+      { isEnabled, allowedOrigins, title, logoUrl, primaryColor, bannerText },
     )
   },
 )

--- a/apps/web/src/studio/features/agent-embed-configs/external/agent-embed-configs.api.ts
+++ b/apps/web/src/studio/features/agent-embed-configs/external/agent-embed-configs.api.ts
@@ -29,6 +29,7 @@ const fromDto = (dto: AgentEmbedConfigDto): AgentEmbedConfig => ({
   title: dto.title,
   logoUrl: dto.logoUrl,
   primaryColor: dto.primaryColor,
+  bannerText: dto.bannerText,
   createdAt: dto.createdAt,
   updatedAt: dto.updatedAt,
 })

--- a/apps/web/src/studio/features/agents/agent-settings/components/tabs/EmbedTab.tsx
+++ b/apps/web/src/studio/features/agents/agent-settings/components/tabs/EmbedTab.tsx
@@ -25,6 +25,7 @@ type EmbedFormState = {
   title: string
   logoUrl: string
   primaryColor: string
+  bannerText: string
 }
 
 function toFormState(config: AgentEmbedConfig): EmbedFormState {
@@ -34,6 +35,7 @@ function toFormState(config: AgentEmbedConfig): EmbedFormState {
     title: config.title ?? "",
     logoUrl: config.logoUrl ?? "",
     primaryColor: config.primaryColor ?? "",
+    bannerText: config.bannerText ?? "",
   }
 }
 
@@ -43,7 +45,10 @@ const emptyFormState: EmbedFormState = {
   title: "",
   logoUrl: "",
   primaryColor: "",
+  bannerText: "",
 }
+
+type CopyTarget = "snippet" | "publicPage"
 
 export function EmbedTab({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
   const agentId = useCurrentId(selectCurrentAgentId)
@@ -64,7 +69,7 @@ function WithData({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }
   const agent = useValue(selectCurrentAgentData)
   const config = useValue(selectAgentEmbedConfig)
 
-  const [copied, setCopied] = useState(false)
+  const [copied, setCopied] = useState<CopyTarget | null>(null)
   const [form, setForm] = useState<EmbedFormState>(emptyFormState)
 
   useEffect(() => {
@@ -79,12 +84,17 @@ function WithData({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }
   const embedSnippet = config
     ? `<script src="${embedBaseUrl}/launcher.js" data-token="${config.embedToken}"></script>`
     : ""
+  // Standalone hosted page: the same chat, served full-screen at a shareable URL (link or QR code).
+  const publicPageUrl = config
+    ? `${embedBaseUrl}/index.html?embedToken=${config.embedToken}&displayMode=drawer`
+    : ""
 
-  const handleCopy = async () => {
-    if (!embedSnippet) return
-    await navigator.clipboard.writeText(embedSnippet)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+  const handleCopy = async (target: CopyTarget) => {
+    const text = target === "snippet" ? embedSnippet : publicPageUrl
+    if (!text) return
+    await navigator.clipboard.writeText(text)
+    setCopied(target)
+    setTimeout(() => setCopied(null), 2000)
   }
 
   const handleUpdate = () => {
@@ -99,6 +109,7 @@ function WithData({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }
         title: form.title.trim() || null,
         logoUrl: form.logoUrl.trim() || null,
         primaryColor: form.primaryColor.trim() || null,
+        bannerText: form.bannerText.trim() || null,
       }),
     )
   }
@@ -130,12 +141,55 @@ function WithData({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }
               rows={2}
               className="font-mono text-xs resize-none"
             />
-            <Button type="button" variant="outline" size="icon" onClick={handleCopy}>
-              {copied ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => handleCopy("snippet")}
+            >
+              {copied === "snippet" ? (
+                <CheckIcon className="size-4" />
+              ) : (
+                <CopyIcon className="size-4" />
+              )}
             </Button>
           </div>
           <p className="text-xs text-muted-foreground mt-1">
             {t("agentSettings:embed.snippetHint")}
+          </p>
+        </Field>
+      )}
+
+      {config && (
+        <Field>
+          <FieldLabel htmlFor="embed-public-page-url">
+            {t("agentSettings:embed.publicPageLabel")}
+          </FieldLabel>
+          <FieldDescription>
+            {t("agentSettings:embed.publicPageDescription", { name: agent.name })}
+          </FieldDescription>
+          <div className="flex gap-2 items-start">
+            <Input
+              id="embed-public-page-url"
+              readOnly
+              value={publicPageUrl}
+              className="font-mono text-xs"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => handleCopy("publicPage")}
+            >
+              {copied === "publicPage" ? (
+                <CheckIcon className="size-4" />
+              ) : (
+                <CopyIcon className="size-4" />
+              )}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {t("agentSettings:embed.publicPageHint")}
           </p>
         </Field>
       )}
@@ -199,6 +253,21 @@ function WithData({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }
             className="font-mono"
           />
         </div>
+      </Field>
+
+      <Field>
+        <FieldLabel htmlFor="embed-banner-text">
+          {t("agentSettings:embed.bannerTextLabel")}
+        </FieldLabel>
+        <FieldDescription>{t("agentSettings:embed.bannerTextDescription")}</FieldDescription>
+        <Textarea
+          id="embed-banner-text"
+          value={form.bannerText}
+          onChange={(e) => setForm((prev) => ({ ...prev, bannerText: e.target.value }))}
+          placeholder={t("agentSettings:embed.bannerTextPlaceholder")}
+          rows={2}
+          maxLength={300}
+        />
       </Field>
 
       <Field orientation="horizontal" className="justify-end">

--- a/docs/public-chat-api.md
+++ b/docs/public-chat-api.md
@@ -11,7 +11,7 @@ Base URL: `https://<your-api-host>`
 
 | Step | Endpoint | Description |
 |------|----------|-------------|
-| 1 | `GET /public/agents/:embedToken/config` | Fetch branding (title, logo, color) |
+| 1 | `GET /public/agents/:embedToken/config` | Fetch branding (title, logo, color) and the banner text |
 | 2 | `POST /public/agents/:embedToken/sessions` | Create (or resume) a chat session |
 | 3 | `GET /public/agents/:embedToken/sessions/:sessionId` | Restore session history |
 | 4 | `GET /public/agents/:embedToken/sessions/:sessionId/messages/stream` | Stream an assistant reply (SSE) |
@@ -34,13 +34,13 @@ GET /public/agents/:embedToken/config
     "title": "Help Center",
     "logoUrl": "https://example.com/logo.png",
     "primaryColor": "#2563eb",
-    "displayMode": "modal"
+    "bannerText": "Test version, for the pilot team only"
   }
 }
 ```
 
-`title`, `logoUrl`, and `primaryColor` are `null` when not configured — fall back to your own defaults.  
-`displayMode` is `"modal"` (floating bubble, default) or `"drawer"` (side panel) — use it to adapt how your custom UI presents the chat window.
+`title`, `logoUrl`, `primaryColor`, and `bannerText` are `null` when not configured — fall back to your own defaults.  
+`bannerText` is a notice the organization wants every visitor to see (test version, intended audience, and so on). Pin it above the conversation so it stays visible while messages scroll.
 
 ---
 

--- a/packages/api-contracts/src/agent-embed-configs/agent-embed-configs.dto.ts
+++ b/packages/api-contracts/src/agent-embed-configs/agent-embed-configs.dto.ts
@@ -12,6 +12,8 @@ export type AgentEmbedConfigDto = {
   title: string | null
   logoUrl: string | null
   primaryColor: string | null
+  /** Optional notice pinned above the conversation in the public page and widget. */
+  bannerText: string | null
   createdAt: TimeType
   updatedAt: TimeType
 }
@@ -22,6 +24,7 @@ export type UpdateAgentEmbedConfigDto = {
   title?: string | null
   logoUrl?: string | null
   primaryColor?: string | null
+  bannerText?: string | null
 }
 
 /** Returned by the public (unauthenticated) config endpoint — branding only, no secrets. */
@@ -30,4 +33,5 @@ export type EmbedPublicConfigDto = {
   title: string | null
   logoUrl: string | null
   primaryColor: string | null
+  bannerText: string | null
 }


### PR DESCRIPTION
Closes https://github.com/bayesimpact/internal-issues/issues/40

## What this does

A public agent URL can be shared for a test session (QR code at a congress, pilot team). Until now the page gave no hint that the agent was a test version or who it was for, and the welcome message is easy to omit.

- **Banner text** (optional): a new field in the agent's **Embed** tab. When set, a notice stays pinned above the conversation, on the standalone public page and inside the embedded widget. Empty means no banner, so existing configs are unchanged.
- **Public page link**: the Embed tab now shows the URL that serves the agent full screen without a host website, next to the script snippet. This makes the standalone use explicit in the product, as the issue asks.
- **Docs**: the help guide (en/fr) and its walkthrough describe the two uses (widget and standalone page) and the banner. The public chat API doc documents the new `bannerText` field of the config endpoint.

## Design notes

- The banner is a plain text field stored on the embed config (`banner_text`, nullable). It is returned by the anonymous config endpoint, so custom UIs built on the public API can show it too.
- The banner renders between the header and the messages, and also when the header is hidden (`hideHeader=1`), so it is never scrolled away.
- Neutral amber styling with an info icon, independent of the brand color, so it reads as a notice rather than as branding.
- The public page link uses the same URL the launcher builds for its iframe, with `displayMode=drawer` so the chat fills the viewport edge to edge.
- The Embed tab keeps two `useState` calls: the "copied" state is now a small union (`snippet | publicPage`) instead of a boolean.
- In `docs/public-chat-api.md` I replaced the `displayMode` line in the config response. The endpoint never returned that field, so the doc was stale.

## How to test

1. Check out the branch, run `npm ci`, then apply the migration from `apps/api`:
   ```
   npm run migration:run
   ```
2. Start the stack (API, web, and the widget app `apps/web-embed`). Make sure the `agent-embed` feature flag is on for your project.
3. In Studio, open a conversation agent, go to the **Embed** tab:
   - Toggle **Enable embed** on.
   - Fill **Banner text** (for example "Test version, for the pilot team only") and click **Update**. Reload the tab: the text is persisted.
   - Copy the **Public page link** and open it in a new tab. The chat loads full screen with the banner pinned under the header. Send a few messages: the banner stays visible while the messages scroll.
   - Paste the **Embed snippet** in a local HTML file and open it. The widget shows the same banner.
   - Clear the banner text and **Update**: the banner disappears on both the page and the widget.
   - Toggle **Enable embed** off: the public page shows "not available" (existing behavior, this is how a temporary access is ended).
4. Storybook for the widget (`npm run storybook` in `apps/web-embed`): `Embed/EmbedChat` has two new stories, **WithBanner** and **With banner — header hidden**.
5. Help site (`npm run dev` in `apps/help`): the Embed guide in en and fr, including the walkthrough steps 4 and 6.

## What to review

- `apps/api/src/domains/public-chat/**`: entity, service whitelist, both controllers, factory, and the two e2e specs.
- `apps/api/src/migrations/1788785187296-add-embed-config-banner-text.ts`: generated with `migration:generate`, then up/down/up verified locally.
- `apps/web-embed/src/chat/components/ChatBanner.tsx` and `EmbedChat.tsx`: rendering and placement.
- `apps/web/.../tabs/EmbedTab.tsx`: the two new fields and the copy behavior.
- Wording of the en/fr labels and of the help guide.

## Verification

- `npm run typecheck`: 6/6 packages pass
- `npm run biome:check`: clean
- API tests for the whole `public-chat` domain: 10 suites, 64 tests pass
- Web tests: 17 files, 137 tests pass
- `apps/web-embed` and `apps/help` build

## Known gaps

- `EmbedTab` has no unit tests or stories, which predates this PR. The new field follows the existing `useState` form pattern of that tab.
- The banner is not shown in the brief loading and error shells of the widget, only once the chat is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
