### PR TITLE
feat(mcp): let MCP servers return a card in the reader's language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 - Public page link: the Embed tab shows the shareable URL that serves an agent without a host website.
 
 ### Changed
+- MCP app cards now follow the reader's interface language, when the MCP server offers a translation.
 
 ### Fixed
 - Refreshing the page during a reply no longer loses the answer.

--- a/apps/api/src/common/utils/accept-language.spec.ts
+++ b/apps/api/src/common/utils/accept-language.spec.ts
@@ -1,0 +1,33 @@
+import { AgentLocale } from "@caseai-connect/api-contracts"
+import { resolveSupportedLocale } from "./accept-language"
+
+describe("resolveSupportedLocale", () => {
+  it("reads a plain language tag", () => {
+    expect(resolveSupportedLocale("fr")).toBe(AgentLocale.FR)
+  })
+
+  it("drops the region subtag", () => {
+    expect(resolveSupportedLocale("fr-CA")).toBe(AgentLocale.FR)
+  })
+
+  it("prefers the highest quality supported language", () => {
+    expect(resolveSupportedLocale("de,en;q=0.5,fr;q=0.9")).toBe(AgentLocale.FR)
+  })
+
+  it("keeps header order between equal qualities", () => {
+    expect(resolveSupportedLocale("en,fr")).toBe(AgentLocale.EN)
+  })
+
+  it("ignores a language the caller declared unacceptable", () => {
+    expect(resolveSupportedLocale("fr;q=0,en")).toBe(AgentLocale.EN)
+  })
+
+  it("returns nothing when no supported language is offered", () => {
+    expect(resolveSupportedLocale("de-DE,es;q=0.8,*;q=0.1")).toBeUndefined()
+  })
+
+  it("returns nothing when the header is missing or not a string", () => {
+    expect(resolveSupportedLocale(undefined)).toBeUndefined()
+    expect(resolveSupportedLocale(["fr"])).toBeUndefined()
+  })
+})

--- a/apps/api/src/common/utils/accept-language.ts
+++ b/apps/api/src/common/utils/accept-language.ts
@@ -1,0 +1,38 @@
+import { AgentLocale } from "@caseai-connect/api-contracts"
+
+const SUPPORTED_LOCALES = Object.values(AgentLocale)
+
+/**
+ * Picks the caller's preferred UI language from an `Accept-Language` header.
+ *
+ * Only languages the platform itself ships are returned, so a locale we cannot
+ * translate to never travels to a third party. Region subtags are dropped
+ * (`fr-CA` -> `fr`): the platform has one catalogue per language.
+ *
+ * Returns `undefined` when the header is missing or names no supported
+ * language, which lets the caller leave the choice to whoever it forwards to.
+ */
+export function resolveSupportedLocale(acceptLanguage: unknown): AgentLocale | undefined {
+  if (typeof acceptLanguage !== "string") return undefined
+
+  const ranked = acceptLanguage
+    .split(",")
+    .map((entry) => {
+      const [tag = "", ...parameters] = entry.split(";")
+      const quality = parameters
+        .map((parameter) => parameter.trim())
+        .find((parameter) => parameter.startsWith("q="))
+      return {
+        language: tag.trim().toLowerCase().split("-")[0],
+        quality: quality ? Number(quality.slice(2)) : 1,
+      }
+    })
+    .filter((entry) => entry.language !== "" && Number.isFinite(entry.quality))
+    // `q=0` means "not acceptable", never a fallback.
+    .filter((entry) => entry.quality > 0)
+    .sort((left, right) => right.quality - left.quality)
+
+  return ranked.find((entry): entry is { language: AgentLocale; quality: number } =>
+    SUPPORTED_LOCALES.includes(entry.language as AgentLocale),
+  )?.language
+}

--- a/apps/api/src/domains/agents/shared/agent-session-messages/agent-messages.controller.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/agent-messages.controller.ts
@@ -5,6 +5,7 @@ import {
 import {
   Body,
   Controller,
+  Headers,
   HttpCode,
   HttpStatus,
   Inject,
@@ -21,6 +22,7 @@ import { getRequiredConnectScope } from "@/common/context/request-context.helper
 import { RequireContext } from "@/common/context/require-context.decorator"
 import { ResourceContextGuard } from "@/common/context/resource-context.guard"
 import { CheckPolicy } from "@/common/policies/check-policy.decorator"
+import { resolveSupportedLocale } from "@/common/utils/accept-language"
 import { BaseAgentSessionGuard } from "@/domains/agents/base-agent-sessions/base-agent-session.guard"
 import { JwtAuthGuard } from "@/domains/auth/jwt-auth.guard"
 import {
@@ -57,6 +59,7 @@ export class AgentMessagesController {
   @Post(AgentSessionMessagesRoutes.getAll.path)
   async getAll(
     @Req() request: EndpointRequestWithAgentSession<ConversationAgentSession>,
+    @Headers("accept-language") acceptLanguage?: string,
   ): Promise<typeof AgentSessionMessagesRoutes.getAll.response> {
     const connectScope = getRequiredConnectScope(request)
     const agentSessionId = request.agentSession.id
@@ -68,6 +71,7 @@ export class AgentMessagesController {
       agentId: request.agent.id,
       sessionId: agentSessionId,
       messages,
+      locale: resolveSupportedLocale(acceptLanguage),
     })
     return { data: toDtos(messages, htmlByKey) }
   }
@@ -77,6 +81,7 @@ export class AgentMessagesController {
   async getOne(
     @Req() request: EndpointRequestWithAgentSession<ConversationAgentSession>,
     @Param("messageId") messageId: string,
+    @Headers("accept-language") acceptLanguage?: string,
   ): Promise<typeof AgentSessionMessagesRoutes.getOne.response> {
     const connectScope = getRequiredConnectScope(request)
     const message = await this.conversationAgentSessionsService.getMessageById({
@@ -96,6 +101,7 @@ export class AgentMessagesController {
             agentId: request.agent.id,
             sessionId: request.agentSession.id,
             messages: [message],
+            locale: resolveSupportedLocale(acceptLanguage),
           })
     return { data: toDto(message, htmlByKey) }
   }

--- a/apps/api/src/domains/agents/shared/agent-session-messages/mcp-app-html.service.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/mcp-app-html.service.spec.ts
@@ -58,6 +58,32 @@ describe("McpAppHtmlService", () => {
     expect(close).toHaveBeenCalled()
   })
 
+  it("forwards the reader's language so the server can localize the card", async () => {
+    readResource.mockResolvedValue(mcpAppResource("<html>carte</html>"))
+
+    await service.readLiveHtml({
+      agentId: "agent-1",
+      sessionId: "session-1",
+      locale: "fr",
+      messages: [
+        {
+          toolCalls: [
+            {
+              id: "call-1",
+              name: "get_patient",
+              arguments: {},
+              mcpApp: { mcpServerId, resourceUri },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({ context: expect.objectContaining({ locale: "fr" }) }),
+    )
+  })
+
   it("does not connect when no message has an MCP App pointer", async () => {
     const htmlByKey = await service.readLiveHtml({
       agentId: "agent-1",
@@ -146,6 +172,7 @@ describe("McpAppHtmlService", () => {
           agentId: "agent-1",
           sessionId: "session-1",
           externalVisitorId: "visitor-1",
+          locale: null,
         },
       }),
     )

--- a/apps/api/src/domains/agents/shared/agent-session-messages/mcp-app-html.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/mcp-app-html.service.ts
@@ -101,19 +101,25 @@ export class McpAppHtmlService {
     sessionId,
     messages,
     externalVisitorId = null,
+    locale = null,
   }: {
     agentId: string
     sessionId: string
     messages: Array<{ toolCalls?: AgentMessageToolCall[] | null }>
     /** Forwarded on public/embed sessions so MCP servers can attribute the read. */
     externalVisitorId?: string | null
+    /**
+     * Language the reader has the interface in. Cards are read per request, so
+     * the same conversation renders in each reader's own language.
+     */
+    locale?: string | null
   }): Promise<Map<string, string>> {
     const refs = collectMcpAppRefs(messages)
     if (refs.length === 0) return new Map()
 
     const enabledServers = await this.mcpServersService.getEnabledServersForAgent(agentId)
     const htmlByKey = new Map<string, string>()
-    const context = { agentId, sessionId, externalVisitorId }
+    const context = { agentId, sessionId, externalVisitorId, locale }
 
     for (const [server, resourceUris] of groupUrisByEnabledServer(refs, enabledServers)) {
       await this.readHtmlFromServer({ context, htmlByKey, resourceUris, server })

--- a/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools.service.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/streaming/tools.service.ts
@@ -111,6 +111,7 @@ export class ToolsService {
     const mcp = await this.buildMcpTools({
       agent,
       session: agentSessionScope.session,
+      locale: agentSessionScope.agentSettings.locale,
       onExecute,
     })
 
@@ -147,10 +148,13 @@ export class ToolsService {
   private async buildMcpTools({
     agent,
     session,
+    locale,
     onExecute,
   }: {
     agent: Agent
     session: AgentSessionScope["session"]
+    /** The agent's own language: what the model will answer the tool result in. */
+    locale: string
     onExecute: OnExecute
   }): Promise<McpToolset> {
     const closeFns: (() => Promise<void>)[] = []
@@ -163,6 +167,7 @@ export class ToolsService {
       agentId: agent.id,
       sessionId: session.id,
       externalVisitorId: "externalVisitorId" in session ? session.externalVisitorId : null,
+      locale,
     }
 
     for (const server of await this.mcpServersService.getEnabledServersForAgent(agent.id)) {

--- a/apps/api/src/domains/public-chat/public-chat.controller.ts
+++ b/apps/api/src/domains/public-chat/public-chat.controller.ts
@@ -6,6 +6,7 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  Headers,
   Post,
   Query,
   Req,
@@ -13,6 +14,7 @@ import {
   UseGuards,
 } from "@nestjs/common"
 import { Observable } from "rxjs"
+import { resolveSupportedLocale } from "@/common/utils/accept-language"
 import { EmbedTokenGuard } from "./guards/embed-token.guard"
 import { PublicSessionTokenGuard } from "./guards/public-session-token.guard"
 import type { PublicChatRequest, PublicChatSessionRequest } from "./public-chat.request"
@@ -54,8 +56,12 @@ export class PublicChatController {
   @Get(PublicChatRoutes.getSession.path)
   async getSession(
     @Req() request: PublicChatSessionRequest,
+    @Headers("accept-language") acceptLanguage?: string,
   ): Promise<typeof PublicChatRoutes.getSession.response> {
-    const sessionDto = await this.publicChatService.getSession(request.publicSession)
+    const sessionDto = await this.publicChatService.getSession(
+      request.publicSession,
+      resolveSupportedLocale(acceptLanguage),
+    )
     return { data: sessionDto }
   }
 

--- a/apps/api/src/domains/public-chat/public-chat.service.ts
+++ b/apps/api/src/domains/public-chat/public-chat.service.ts
@@ -46,7 +46,11 @@ export class PublicChatService {
     return { sessionId: session.id, sessionToken }
   }
 
-  async getSession(publicSession: PublicAgentSession): Promise<PublicAgentSessionDto> {
+  /** `locale` is the widget's own language, so a card matches the page around it. */
+  async getSession(
+    publicSession: PublicAgentSession,
+    locale?: string,
+  ): Promise<PublicAgentSessionDto> {
     const { session, messages } = await this.publicAgentSessionsService.getSessionWithMessages(
       publicSession.id,
     )
@@ -55,6 +59,7 @@ export class PublicChatService {
       sessionId: session.id,
       messages,
       externalVisitorId: session.externalVisitorId,
+      locale,
     })
     return this.toSessionDto(session, messages, htmlByKey)
   }

--- a/apps/api/src/external/mcp/mcp-request-headers.spec.ts
+++ b/apps/api/src/external/mcp/mcp-request-headers.spec.ts
@@ -24,6 +24,18 @@ describe("buildMcpRequestHeaders", () => {
     expect(headers[MCP_CONTEXT_HEADERS.sessionId]).toBe("session-1")
   })
 
+  it("forwards the reader's language so the server can localize its card", () => {
+    const headers = buildMcpRequestHeaders({ context: { ...context, locale: "fr" } })
+
+    expect(headers[MCP_CONTEXT_HEADERS.locale]).toBe("fr")
+  })
+
+  it("omits the language header when the locale is unknown", () => {
+    const headers = buildMcpRequestHeaders({ context: { ...context, locale: null } })
+
+    expect(headers).not.toHaveProperty(MCP_CONTEXT_HEADERS.locale)
+  })
+
   it("keeps the server's auth and its static headers", () => {
     const headers = buildMcpRequestHeaders({
       apiKey: "secret",

--- a/apps/api/src/external/mcp/mcp-request-headers.ts
+++ b/apps/api/src/external/mcp/mcp-request-headers.ts
@@ -17,12 +17,21 @@ export type McpConversationContext = {
    * Travail: the "identifiant DE"). Absent on internal sessions.
    */
   externalVisitorId?: string | null
+  /**
+   * Language the answer is rendered in, as a plain language tag ("fr", "en").
+   * Forwarded so a server can return a localized MCP App card or tool result.
+   * Absent when we have nothing better than a guess, and the server then picks
+   * its own default.
+   */
+  locale?: string | null
 }
 
 export const MCP_CONTEXT_HEADERS = {
   agentId: "X-Bayes-Agent-Id",
   sessionId: "X-Bayes-Session-Id",
   externalVisitorId: "X-Bayes-External-Visitor-Id",
+  /** Standard header rather than an `X-Bayes-` one: servers already parse it. */
+  locale: "Accept-Language",
 } as const
 
 /**
@@ -56,6 +65,9 @@ export function buildMcpRequestHeaders({
     headers[MCP_CONTEXT_HEADERS.sessionId] = context.sessionId
     if (context.externalVisitorId) {
       headers[MCP_CONTEXT_HEADERS.externalVisitorId] = context.externalVisitorId
+    }
+    if (context.locale) {
+      headers[MCP_CONTEXT_HEADERS.locale] = context.locale
     }
   }
 

--- a/apps/web-embed/src/App.tsx
+++ b/apps/web-embed/src/App.tsx
@@ -115,7 +115,7 @@ function LiveChat({
     logoUrl: remoteConfig?.logoUrl ?? undefined,
   }
 
-  const { status, messages, isStreaming, errorKey, send, reset } = usePublicChat(embedToken)
+  const { status, messages, isStreaming, errorKey, send, reset } = usePublicChat(embedToken, locale)
 
   useEffect(() => {
     function onMessage(event: MessageEvent) {

--- a/apps/web-embed/src/api/public-chat-api.ts
+++ b/apps/web-embed/src/api/public-chat-api.ts
@@ -31,13 +31,21 @@ export async function createSession(
   return json.data
 }
 
+/**
+ * `locale` is the widget's own language: the API forwards it to MCP servers so
+ * a card renders in the language of the page the widget sits on.
+ */
 export async function getSession(
   embedToken: string,
   sessionId: string,
   sessionToken: string,
+  locale?: string,
 ): Promise<PublicAgentSessionDto> {
   const response = await fetch(`${API_BASE}/public/agents/${embedToken}/sessions/${sessionId}`, {
-    headers: { "X-Session-Token": sessionToken },
+    headers: {
+      "X-Session-Token": sessionToken,
+      ...(locale ? { "Accept-Language": locale } : {}),
+    },
   })
   if (!response.ok) throw new ApiError(response.status, "Failed to load session")
   const json = (await response.json()) as { data: PublicAgentSessionDto }

--- a/apps/web-embed/src/chat/components/McpAppView.tsx
+++ b/apps/web-embed/src/chat/components/McpAppView.tsx
@@ -2,6 +2,7 @@ import { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js"
 import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 const HOST_INFO = { name: "caseai-connect", version: "1.0.0" }
 const INITIALIZE_TIMEOUT_MS = 15_000
@@ -158,6 +159,11 @@ export function McpAppView({
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [hasFailed, setHasFailed] = useState(false)
+  // The card reads `hostContext.locale` to translate itself (MCP Apps spec).
+  // Changing it remounts the card so the app re-reads the context; server-side
+  // translation is separate, and follows the `Accept-Language` we send the API.
+  const { i18n } = useTranslation()
+  const locale = i18n.language
 
   useEffect(() => {
     const iframe = iframeRef.current
@@ -180,7 +186,7 @@ export function McpAppView({
           HOST_INFO,
           { logging: {}, sandbox: {} },
           {
-            hostContext: { displayMode: "inline", platform: "web" },
+            hostContext: { displayMode: "inline", platform: "web", locale },
           },
         )
         bridge = appBridge
@@ -277,7 +283,7 @@ export function McpAppView({
           void currentBridge.close()
         })
     }
-  }, [html, toolInput, toolResult])
+  }, [html, toolInput, toolResult, locale])
 
   if (hasFailed) return null
 

--- a/apps/web-embed/src/hooks/usePublicChat.ts
+++ b/apps/web-embed/src/hooks/usePublicChat.ts
@@ -99,7 +99,7 @@ export type UsePublicChatResult = {
   reset: () => void
 }
 
-export function usePublicChat(embedToken: string): UsePublicChatResult {
+export function usePublicChat(embedToken: string, locale?: string): UsePublicChatResult {
   const [status, setStatus] = useState<PublicChatStatus>("initializing")
   const [messages, setMessages] = useState<AgentSessionMessageDto[]>([])
   const [isStreaming, setIsStreaming] = useState(false)
@@ -109,6 +109,12 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
   // without re-triggering effects.
   const sessionRef = useRef<StoredSession | null>(null)
   const resetNonceRef = useRef(0)
+  // Read on every session fetch instead of being a callback dependency: a
+  // language switch must not restart the conversation.
+  const localeRef = useRef(locale)
+  useEffect(() => {
+    localeRef.current = locale
+  }, [locale])
 
   const startFreshSession = useCallback(
     async (nonce: number) => {
@@ -127,6 +133,7 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
         embedToken,
         newSession.sessionId,
         newSession.sessionToken,
+        localeRef.current,
       )
       if (resetNonceRef.current !== nonce) return
       setMessages(sessionData.messages.map(toDisplayMessage))
@@ -156,7 +163,12 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
 
       if (stored) {
         try {
-          const sessionData = await getSession(embedToken, stored.sessionId, stored.sessionToken)
+          const sessionData = await getSession(
+            embedToken,
+            stored.sessionId,
+            stored.sessionToken,
+            localeRef.current,
+          )
           if (!stillCurrent()) return
           sessionRef.current = stored
           setMessages(sessionData.messages.map(toDisplayMessage))
@@ -216,6 +228,7 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
               embedToken,
               session.sessionId,
               session.sessionToken,
+              localeRef.current,
             )
             if (!stillCurrent()) return
             consecutiveFailures = 0
@@ -341,6 +354,7 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
                 embedToken,
                 session.sessionId,
                 session.sessionToken,
+                localeRef.current,
               )
               if (resetNonceRef.current !== nonce) return
               setMessages(sessionData.messages.map(toDisplayMessage))

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/McpAppView.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/McpAppView.tsx
@@ -2,6 +2,7 @@ import { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js"
 import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 const HOST_INFO = { name: "caseai-connect", version: "1.0.0" }
 const INITIALIZE_TIMEOUT_MS = 15_000
@@ -158,6 +159,11 @@ export function McpAppView({
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [hasFailed, setHasFailed] = useState(false)
+  // The card reads `hostContext.locale` to translate itself (MCP Apps spec).
+  // Changing it remounts the card so the app re-reads the context; server-side
+  // translation is separate, and follows the `Accept-Language` we send the API.
+  const { i18n } = useTranslation()
+  const locale = i18n.language
 
   useEffect(() => {
     const iframe = iframeRef.current
@@ -180,7 +186,7 @@ export function McpAppView({
           HOST_INFO,
           { logging: {}, sandbox: {} },
           {
-            hostContext: { displayMode: "inline", platform: "web" },
+            hostContext: { displayMode: "inline", platform: "web", locale },
           },
         )
         bridge = appBridge
@@ -282,7 +288,7 @@ export function McpAppView({
           void currentBridge.close()
         })
     }
-  }, [html, toolInput, toolResult])
+  }, [html, toolInput, toolResult, locale])
 
   if (hasFailed) return null
 

--- a/apps/web/src/external/axios.ts
+++ b/apps/web/src/external/axios.ts
@@ -1,4 +1,5 @@
 import axios, { type AxiosInstance } from "axios"
+import i18n from "@/i18n"
 import { Auth0AuthenticationError, getAccessToken, logoutAuth0 } from "./auth0Client"
 
 let axiosInstance: AxiosInstance | null = null
@@ -17,6 +18,9 @@ const buildAxiosInstance = (): AxiosInstance => {
   // This ensures tokens are always fresh and handles refresh automatically
   axiosInstance.interceptors.request.use(
     async (config) => {
+      // The interface language, not the browser's: what the user picked here is
+      // what MCP servers should render their cards in.
+      config.headers["Accept-Language"] = i18n.language
       try {
         const token = await getAccessToken()
         config.headers.Authorization = `Bearer ${token}`


### PR DESCRIPTION
## Summary

MCP App cards were always rendered in the language the MCP server defaults to, even when the whole interface was in French. A card has two halves — the HTML the server returns, and the code running inside the iframe — so the language now travels on two channels.

**Server side.** The reader's `Accept-Language` is resolved to a language the platform actually ships (`fr` / `en`, region subtag dropped, `q=0` respected) and forwarded on the MCP transport, so a server can return already-translated HTML from `resources/read`. Cards are re-read on every request and nothing is stored, so one conversation renders in each reader's own language. The header travels under the same rules as the other context headers: a server's static configuration cannot spoof it.

**Card side.** `hostContext.locale` is passed to the `AppBridge` in both hosts — the field the MCP Apps spec defines for an app to translate itself. Changing it remounts the card so the app re-reads its context.

**Tool calls** keep forwarding the agent's own locale instead: a tool result goes to the model, which answers in the agent's configured language.

Note that `@ai-sdk/mcp`'s `readResource` takes only `{ uri, options }` — no per-request `_meta` — so transport headers are the only server-side channel available.

This gives MCP servers both mechanisms. It cannot translate a card whose HTML is hard-coded in English and which ignores `hostContext.locale`; the server has to do its part.

## Changes

- `apps/api/src/common/utils/accept-language.ts` — resolves the header to a supported language
- `mcp-request-headers.ts` — `locale` in the conversation context, emitted as `Accept-Language`
- `mcp-app-html.service.ts` + both controllers — the reader's language reaches the card read
- `tools.service.ts` — the agent's locale on the tool-call path
- `apps/web` and `apps/web-embed` — `hostContext.locale`, plus sending `Accept-Language` to the API

## Test plan

- 7 new cases: header resolution, locale forwarding in the MCP headers, reader's locale reaching the MCP connection
- `biome:check`, `typecheck` (6/6), `check:boundaries`, and the 137 web tests pass
- `test:parallel`: 302 suites passed (6 skipped), 2406 tests, zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
