### PR TITLE
fix(web): keep MCP App cards alive when a sibling card fails to render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- (beta) MCP App cards no longer reload when a sibling card in the same reply fails to render.
 
 ### Security
 

--- a/apps/web-embed/src/chat/components/McpAppView.tsx
+++ b/apps/web-embed/src/chat/components/McpAppView.tsx
@@ -178,6 +178,13 @@ export function McpAppView({
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [hasFailed, setHasFailed] = useState(false)
+  // Parents pass an inline arrow that changes identity when any sibling card
+  // fails. Reading it through a ref keeps it out of the render effect deps, so
+  // a sibling failure does not tear down and re-handshake this card.
+  const onRenderFailedRef = useRef(onRenderFailed)
+  useEffect(() => {
+    onRenderFailedRef.current = onRenderFailed
+  })
 
   useEffect(() => {
     const iframe = iframeRef.current
@@ -269,7 +276,7 @@ export function McpAppView({
           error instanceof Error ? error.message : "unknown error",
         )
         setHasFailed(true)
-        onRenderFailed?.()
+        onRenderFailedRef.current?.()
       }
     }
 
@@ -312,7 +319,7 @@ export function McpAppView({
           void currentBridge.close()
         })
     }
-  }, [html, toolInput, toolResult, onRenderFailed])
+  }, [html, toolInput, toolResult])
 
   if (hasFailed) return null
 

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/McpAppView.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/McpAppView.tsx
@@ -178,6 +178,13 @@ export function McpAppView({
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [hasFailed, setHasFailed] = useState(false)
+  // Parents pass an inline arrow that changes identity when any sibling card
+  // fails. Reading it through a ref keeps it out of the render effect deps, so
+  // a sibling failure does not tear down and re-handshake this card.
+  const onRenderFailedRef = useRef(onRenderFailed)
+  useEffect(() => {
+    onRenderFailedRef.current = onRenderFailed
+  })
 
   useEffect(() => {
     const iframe = iframeRef.current
@@ -270,7 +277,7 @@ export function McpAppView({
           error instanceof Error ? error.message : "unknown error",
         )
         setHasFailed(true)
-        onRenderFailed?.()
+        onRenderFailedRef.current?.()
       }
     }
 
@@ -313,7 +320,7 @@ export function McpAppView({
           void currentBridge.close()
         })
     }
-  }, [html, toolInput, toolResult, onRenderFailed])
+  }, [html, toolInput, toolResult])
 
   if (hasFailed) return null
 


### PR DESCRIPTION
Follow-up to #739, addressing a P1 review finding.

## Problem

`McpAppView` listed `onRenderFailed` in the dependency array of its main render effect, even though the callback is only invoked from the effect's catch block. `AgentSessionMessage` and the embed `ChatMessage` pass an inline arrow whose identity changes whenever `failedMcpAppToolCallIds` changes. When one card in a reply failed, every sibling card received a new callback, its cleanup tore down the live AppBridge, and the effect re-ran with a new sandbox id, srcdoc reset and full handshake. Healthy cards flickered back to their loading shell.

## Change

- Read `onRenderFailed` through a ref that is refreshed after each render, and call the ref from the catch block.
- The render effect depends on `[html, toolInput, toolResult]` again, as before #739.
- The ref is updated inside a no-deps effect rather than during render, so the React Compiler keeps compiling the component.
- Applied identically to `apps/web` and `apps/web-embed`, which stay byte-for-byte equivalent apart from their pre-existing differences.
- Changelog entry under Unreleased / Fixed.

## Testing

- `npm run biome:check`: pass, no rewrites.
- `npm run typecheck`: pass (api, web, web-embed).
- `npx turbo test --filter=@caseai-connect/web`: 17 files, 140 tests pass.
- No component-level test was added: the web vitest setup runs in a node environment without jsdom or testing-library, so `McpAppView` (iframes, postMessage) cannot be mounted in a unit test. The existing `mcp-app-view.spec.ts` covers the pure helpers only and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
