### PR TITLE
fix(web): show the tool result text when an MCP App card fails to render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Fixed
 
+- (beta) PDF export: when the download card cannot load, the reply shows the export result as text.
+
 ### Security
 
 ## [26.09.2] - 2026-09-08

--- a/apps/web-embed/src/chat/EmbedChat.stories.tsx
+++ b/apps/web-embed/src/chat/EmbedChat.stories.tsx
@@ -3,6 +3,7 @@ import {
   buildErrorMessage,
   buildStreamingMessage,
   emptyConversation,
+  failedMcpAppCardConversation,
   longConversation,
   markdownConversation,
   resourceCardsConversation,
@@ -106,6 +107,13 @@ export const ErrorState: Story = {
       { id: "user-err", role: "user", content: "This will fail.", status: "completed" },
       buildErrorMessage(),
     ],
+  },
+}
+
+export const FailedMcpAppCard: Story = {
+  name: "MCP App card failed to load",
+  args: {
+    messages: failedMcpAppCardConversation,
   },
 }
 

--- a/apps/web-embed/src/chat/chat.factory.ts
+++ b/apps/web-embed/src/chat/chat.factory.ts
@@ -168,3 +168,38 @@ export const resourceCardsOnlyConversation: AgentSessionMessageDto[] = [
     ],
   }),
 ]
+
+/**
+ * A reply with no prose whose MCP App card never completes its handshake. The card gives up
+ * after its 15 s initialization timeout and the tool result text takes its place in the bubble.
+ */
+export const failedMcpAppCardConversation: AgentSessionMessageDto[] = [
+  buildUserMessage("Export these notes as a PDF."),
+  buildAssistantMessage("", {
+    toolCalls: [
+      {
+        id: "call-pdf-export",
+        name: "export_pdf",
+        arguments: { markdown: "# Notes" },
+        result: {
+          content: [
+            {
+              type: "text",
+              text: "Created Notes.pdf (2 pages). Download: https://example.com/notes.pdf",
+            },
+          ],
+          structuredContent: {
+            fileName: "Notes.pdf",
+            downloadUrl: "https://example.com/notes.pdf",
+          },
+        },
+        mcpApp: {
+          mcpServerId: "mcp-server-1",
+          resourceUri: "ui://pdf-export/mcp-app.html",
+          // Never sends `ui/initialize`, so the host times out and falls back to text.
+          html: "<!DOCTYPE html><html><body></body></html>",
+        },
+      },
+    ],
+  }),
+]

--- a/apps/web-embed/src/chat/components/ChatMessage.tsx
+++ b/apps/web-embed/src/chat/components/ChatMessage.tsx
@@ -6,7 +6,7 @@ import { cn } from "../lib/cn"
 import { ChatBotMessage, ChatUserMessage } from "./index"
 import { MarkdownWrapper } from "./MarkdownWrapper"
 import { McpAppView } from "./McpAppView"
-import { getRenderableMcpApp } from "./mcp-app-view"
+import { getFailedMcpAppFallbackText, getRenderableMcpApp } from "./mcp-app-view"
 import { findSourcesTool, SourcesTool } from "./SourcesTool"
 import {
   findSurfaceResourcesTool,
@@ -25,21 +25,29 @@ export function ChatMessage({ message }: { message: AgentSessionMessageDto }) {
         const view = getRenderableMcpApp(toolCall)
         return view ? [{ toolCall, view }] : []
       })
+      const hasContent = message.content.trim().length > 0
       // A card that failed to render must not take the reply text down with it.
       const hideMarkdownRecap =
         !isStreaming &&
         mcpAppViews.some(({ toolCall }) => !failedMcpAppToolCallIds.includes(toolCall.id))
+      // The model may have written nothing because it expected the card to speak for the tool:
+      // once the card gave up, the tool result text stands in for the reply.
+      const failedMcpAppFallbackText = hasContent
+        ? ""
+        : getFailedMcpAppFallbackText(message.toolCalls, failedMcpAppToolCallIds)
+      const bubbleContent =
+        hasContent && !hideMarkdownRecap ? message.content : failedMcpAppFallbackText
       const surfaceResourcesTool = findSurfaceResourcesTool(message.toolCalls)
       const sourcesTool = findSourcesTool(message.toolCalls)
+      // A card that gave up rendering still ran its tool: the reply is not empty, only quiet.
       const isEmpty =
-        message.content.trim().length === 0 &&
+        !hasContent &&
         message.status === "completed" &&
-        !hideMarkdownRecap &&
+        mcpAppViews.length === 0 &&
         !hasSurfacedResources(message.toolCalls)
       // "aborted": the stream died with the server before anything was written.
       const isError = message.status === "error" || message.status === "aborted" || isEmpty
-      const showTextBubble =
-        isError || isStreaming || (!hideMarkdownRecap && message.content.trim().length > 0)
+      const showTextBubble = isError || isStreaming || bubbleContent.length > 0
 
       return (
         <div className="flex w-full flex-col">
@@ -54,12 +62,12 @@ export function ChatMessage({ message }: { message: AgentSessionMessageDto }) {
                 )}
               >
                 {isStreaming && message.content.trim().length === 0 && <ThinkingIndicator />}
-                {isError ? <ErrorIndicator /> : <MarkdownWrapper content={message.content} />}
+                {isError ? <ErrorIndicator /> : <MarkdownWrapper content={bubbleContent} />}
               </div>
 
-              {!isStreaming && !isError && message.content.trim().length > 0 && (
+              {!isStreaming && !isError && bubbleContent.length > 0 && (
                 <div className="mt-1 flex flex-col items-start">
-                  <CopyButton content={message.content} />
+                  <CopyButton content={bubbleContent} />
                   {sourcesTool && <SourcesTool toolCall={sourcesTool} />}
                 </div>
               )}

--- a/apps/web-embed/src/chat/components/mcp-app-view.ts
+++ b/apps/web-embed/src/chat/components/mcp-app-view.ts
@@ -25,6 +25,37 @@ export function hasRenderableMcpApp(toolCalls: AgentSessionToolCallDto[] | undef
   return (toolCalls ?? []).some((toolCall) => getRenderableMcpApp(toolCall) !== undefined)
 }
 
+/**
+ * Text fallback for an MCP App card that gave up rendering: the `text` parts of the tool
+ * result's `content` (the MCP `CallToolResult` shape), joined so nothing is lost when the model
+ * wrote no prose because it expected the card to speak for the tool.
+ */
+export function getMcpAppToolResultText(toolResult: unknown): string {
+  if (!toolResult || typeof toolResult !== "object" || !("content" in toolResult)) return ""
+  const { content } = toolResult as { content: unknown }
+  if (!Array.isArray(content)) return ""
+  return content
+    .flatMap((part: unknown) =>
+      part && typeof part === "object" && "text" in part && typeof part.text === "string"
+        ? [part.text.trim()]
+        : [],
+    )
+    .filter((text) => text.length > 0)
+    .join("\n")
+}
+
+/** Joined text of the tool results whose MCP App card failed to render, empty when none did. */
+export function getFailedMcpAppFallbackText(
+  toolCalls: AgentSessionToolCallDto[] | undefined,
+  failedToolCallIds: string[],
+): string {
+  return (toolCalls ?? [])
+    .filter((toolCall) => failedToolCallIds.includes(toolCall.id))
+    .map((toolCall) => getMcpAppToolResultText(toolCall.result))
+    .filter((text) => text.length > 0)
+    .join("\n\n")
+}
+
 /** Only `http:`/`https:` links are safe to open in a new tab from an MCP App. */
 export function isOpenableLink(url: string): boolean {
   try {

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
@@ -25,7 +25,7 @@ import { useFormResult } from "./form-result-context"
 import { useFormSubSessions } from "./form-sub-sessions-context"
 import { MarkdownWrapper } from "./MarkdownWrapper"
 import { McpAppView } from "./McpAppView"
-import { getRenderableMcpApp } from "./mcp-app-view"
+import { getFailedMcpAppFallbackText, getRenderableMcpApp } from "./mcp-app-view"
 import { SourcesTool } from "./SourcesTool"
 import { SubAgentFormResultSheet } from "./SubAgentFormResultSheet"
 import { SurfaceResourcesTool } from "./SurfaceResourcesTool"
@@ -67,6 +67,13 @@ export function AgentSessionMessage({
       const hideMarkdownRecap =
         !isStreaming &&
         mcpAppViews.some(({ toolCall }) => !failedMcpAppToolCallIds.includes(toolCall.id))
+      // The model may have written nothing because it expected the card to speak for the tool:
+      // once the card gave up, the tool result text stands in for the reply.
+      const failedMcpAppFallbackText = hasContent
+        ? ""
+        : getFailedMcpAppFallbackText(message.toolCalls, failedMcpAppToolCallIds)
+      const bubbleContent =
+        hasContent && !hideMarkdownRecap ? message.content : failedMcpAppFallbackText
       // Tool names this message delegated to that resolved to a form sub-session,
       // deduplicated so a sub-agent invoked twice shows a single affordance.
       const delegatedToolNames = [
@@ -96,11 +103,10 @@ export function AgentSessionMessage({
                 </BubbleContent>
               </Bubble>
             ) : (
-              hasContent &&
-              !hideMarkdownRecap && (
+              bubbleContent.length > 0 && (
                 <Bubble variant="muted">
                   <BubbleContent className="px-4 py-3">
-                    <MarkdownWrapper content={message.content} />
+                    <MarkdownWrapper content={bubbleContent} />
                   </BubbleContent>
                 </Bubble>
               )
@@ -131,8 +137,8 @@ export function AgentSessionMessage({
                     still persisted their results, so those affordances stay. */}
                 {!isInterrupted && <FeedbackCreator message={message} />}
 
-                {!isInterrupted && !hideMarkdownRecap && (
-                  <CopyToClipboard content={message.content} />
+                {!isInterrupted && bubbleContent.length > 0 && (
+                  <CopyToClipboard content={bubbleContent} />
                 )}
 
                 {renderMessageVersion?.(message)}

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.spec.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.spec.ts
@@ -1,6 +1,12 @@
 import type { AgentSessionToolCallDto } from "@caseai-connect/api-contracts"
 import { describe, expect, it } from "vitest"
-import { getRenderableMcpApp, hasRenderableMcpApp, isOpenableLink } from "./mcp-app-view"
+import {
+  getFailedMcpAppFallbackText,
+  getMcpAppToolResultText,
+  getRenderableMcpApp,
+  hasRenderableMcpApp,
+  isOpenableLink,
+} from "./mcp-app-view"
 
 const baseToolCall: AgentSessionToolCallDto = {
   id: "call-1",
@@ -70,6 +76,73 @@ describe("hasRenderableMcpApp", () => {
         },
       ]),
     ).toBe(true)
+  })
+})
+
+describe("getMcpAppToolResultText", () => {
+  it("joins the text parts of an MCP tool result", () => {
+    expect(
+      getMcpAppToolResultText({
+        content: [
+          { type: "text", text: "Created report.pdf (3 pages)." },
+          { type: "image", data: "...", mimeType: "image/png" },
+          { type: "text", text: "  Download: https://example.com/report.pdf  " },
+        ],
+        structuredContent: { fileName: "report.pdf" },
+      }),
+    ).toBe("Created report.pdf (3 pages).\nDownload: https://example.com/report.pdf")
+  })
+
+  it("is empty when the result has no text content", () => {
+    expect(getMcpAppToolResultText(undefined)).toBe("")
+    expect(getMcpAppToolResultText("plain string")).toBe("")
+    expect(getMcpAppToolResultText({ structuredContent: { title: "Ada" } })).toBe("")
+    expect(getMcpAppToolResultText({ content: "not a list" })).toBe("")
+    expect(getMcpAppToolResultText({ content: [{ type: "text", text: "   " }] })).toBe("")
+  })
+})
+
+describe("getFailedMcpAppFallbackText", () => {
+  const cardToolCall: AgentSessionToolCallDto = {
+    ...baseToolCall,
+    id: "call-card",
+    name: "export_pdf",
+    result: { content: [{ type: "text", text: "Created report.pdf (3 pages)." }] },
+    mcpApp: {
+      mcpServerId: "mcp-server-1",
+      resourceUri: "ui://pdf-export/mcp-app.html",
+      html: "<html><body>Card</body></html>",
+    },
+  }
+
+  it("is empty while no card has failed", () => {
+    expect(getFailedMcpAppFallbackText([baseToolCall, cardToolCall], [])).toBe("")
+    expect(getFailedMcpAppFallbackText(undefined, ["call-card"])).toBe("")
+  })
+
+  it("returns the tool result text of the cards that failed to render", () => {
+    expect(getFailedMcpAppFallbackText([baseToolCall, cardToolCall], ["call-card"])).toBe(
+      "Created report.pdf (3 pages).",
+    )
+  })
+
+  it("separates the text of several failed cards and skips results without text", () => {
+    const silentCard: AgentSessionToolCallDto = {
+      ...cardToolCall,
+      id: "call-silent",
+      result: { structuredContent: { title: "Ada" } },
+    }
+    const secondCard: AgentSessionToolCallDto = {
+      ...cardToolCall,
+      id: "call-second",
+      result: { content: [{ type: "text", text: "Created notes.pdf (1 page)." }] },
+    }
+    expect(
+      getFailedMcpAppFallbackText(
+        [cardToolCall, silentCard, secondCard],
+        ["call-card", "call-silent", "call-second"],
+      ),
+    ).toBe("Created report.pdf (3 pages).\n\nCreated notes.pdf (1 page).")
   })
 })
 

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.ts
@@ -25,6 +25,37 @@ export function hasRenderableMcpApp(toolCalls: AgentSessionToolCallDto[] | undef
   return (toolCalls ?? []).some((toolCall) => getRenderableMcpApp(toolCall) !== undefined)
 }
 
+/**
+ * Text fallback for an MCP App card that gave up rendering: the `text` parts of the tool
+ * result's `content` (the MCP `CallToolResult` shape), joined so nothing is lost when the model
+ * wrote no prose because it expected the card to speak for the tool.
+ */
+export function getMcpAppToolResultText(toolResult: unknown): string {
+  if (!toolResult || typeof toolResult !== "object" || !("content" in toolResult)) return ""
+  const { content } = toolResult as { content: unknown }
+  if (!Array.isArray(content)) return ""
+  return content
+    .flatMap((part: unknown) =>
+      part && typeof part === "object" && "text" in part && typeof part.text === "string"
+        ? [part.text.trim()]
+        : [],
+    )
+    .filter((text) => text.length > 0)
+    .join("\n")
+}
+
+/** Joined text of the tool results whose MCP App card failed to render, empty when none did. */
+export function getFailedMcpAppFallbackText(
+  toolCalls: AgentSessionToolCallDto[] | undefined,
+  failedToolCallIds: string[],
+): string {
+  return (toolCalls ?? [])
+    .filter((toolCall) => failedToolCallIds.includes(toolCall.id))
+    .map((toolCall) => getMcpAppToolResultText(toolCall.result))
+    .filter((text) => text.length > 0)
+    .join("\n\n")
+}
+
 /** Only `http:`/`https:` links are safe to open in a new tab from an MCP App. */
 export function isOpenableLink(url: string): boolean {
   try {

--- a/apps/web/src/stories/routes/Chat.stories.tsx
+++ b/apps/web/src/stories/routes/Chat.stories.tsx
@@ -159,3 +159,45 @@ export const InterruptedReply: Story = {
     ],
   },
 }
+
+/**
+ * A reply with no prose whose MCP App card never completes its handshake. The card gives up
+ * after its 15 s initialization timeout and the tool result text takes its place in the bubble.
+ */
+export const FailedMcpAppCard: Story = {
+  ...Default,
+  args: {
+    messages: [
+      agentSessionMessageFactory.build({ role: "user", content: "Export these notes as a PDF." }),
+      agentSessionMessageFactory.build({
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call-pdf-export",
+            name: "export_pdf",
+            arguments: { markdown: "# Notes" },
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: "Created Notes.pdf (2 pages). Download: https://example.com/notes.pdf",
+                },
+              ],
+              structuredContent: {
+                fileName: "Notes.pdf",
+                downloadUrl: "https://example.com/notes.pdf",
+              },
+            },
+            mcpApp: {
+              mcpServerId: "mcp-server-1",
+              resourceUri: "ui://pdf-export/mcp-app.html",
+              // Never sends `ui/initialize`, so the host times out and falls back to text.
+              html: "<!DOCTYPE html><html><body></body></html>",
+            },
+          },
+        ],
+      }),
+    ],
+  },
+}


### PR DESCRIPTION
## Problem

Follow-up to #739. When an MCP App card (`McpAppView`) gives up rendering (handshake error or 15 s timeout), it calls `onRenderFailed` and returns null. Both parents then dropped the card from the "hide markdown recap" set and fell back to `message.content`, which is empty when the model deferred to the card (as the PDF export tool asks it to). In the embed, the message was classified as empty and rendered a red error bubble although the tool call succeeded. In the web app, the message rendered blank. Nothing surfaced the tool result, contrary to the `onRenderFailed` docstring.

## Change

- `mcp-app-view.ts` (both apps, identical copies): `getMcpAppToolResultText` reads the `content[].text` parts of an MCP `CallToolResult`; `getFailedMcpAppFallbackText` joins them for the tool calls whose card failed.
- `AgentSessionMessage.tsx` and `ChatMessage.tsx`: when the assistant content is empty and a card failed, the bubble shows the tool result text instead (copy button follows). Non-empty assistant content keeps rendering as before. The embed no longer treats a reply with a failed card as empty or errored.
- Stories: `components/Chat > FailedMcpAppCard` (web) and `Embed/EmbedChat > MCP App card failed to load` show a card that never initializes and falls back to text after the timeout.
- Changelog entry under Unreleased / Fixed.

## Testing

- `npm run biome:check`: pass
- `npm run typecheck`: pass (web and web-embed included)
- `npx turbo test --filter=@caseai-connect/web`: 17 files, 145 tests pass
- `mcp-app-view.spec.ts`: 13 tests pass, including the new helper cases

Not verified in a browser: the Storybook stories wait on the real 15 s initialization timeout before the fallback text appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)