### PR TITLE
docs(help): name the PDF export card button Download PDF verbatim

### DIFF
--- a/apps/help/src/content/docs/en/mcp-servers.mdx
+++ b/apps/help/src/content/docs/en/mcp-servers.mdx
@@ -4,7 +4,7 @@ highlight: MCP
 description: Connect external MCP tool servers to your workspace and enable them per agent, so an agent can call outside tools while it answers.
 category: guides-agents
 order: 8
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 import McpServersWalkthrough from "@/components/McpServersWalkthrough.astro"
@@ -119,9 +119,9 @@ without losing your place in the editor.
 
 When the platform is configured for it, every workspace ships with a **PDF export**
 server marked **Built-in**. It cannot be deleted, but you still switch it on per agent
-like any other server. Once it's on,
-the agent can turn a markdown answer into a downloadable PDF, shown to the user as a
-card with a **Download** button. That link is valid for 15 minutes.
+like any other server. Once it's on, the agent can turn a markdown answer into a
+downloadable PDF, shown to the user as a card with a **Download PDF** button. That
+link is valid for 15 minutes.
 
 ## Tips
 

--- a/apps/help/src/content/docs/fr/mcp-servers.mdx
+++ b/apps/help/src/content/docs/fr/mcp-servers.mdx
@@ -4,7 +4,7 @@ highlight: MCP
 description: Connectez des serveurs d'outils MCP externes à votre espace de travail et activez-les par agent, pour qu'un agent puisse appeler des outils externes pendant qu'il répond.
 category: guides-agents
 order: 8
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 import McpServersWalkthrough from "@/components/McpServersWalkthrough.astro"
@@ -130,9 +130,10 @@ connecter ou supprimer des serveurs sans perdre votre place dans l'éditeur.
 
 Lorsque la plateforme est configurée pour cela, chaque espace de travail dispose d'un
 serveur **PDF export** marqué **Intégré**. Il ne peut pas être supprimé, mais vous
-l'activez par agent comme n'importe quel autre serveur. Une fois activé, l'agent peut transformer une réponse markdown en PDF
-téléchargeable, affiché à l'utilisateur sous forme de carte avec un bouton
-**Télécharger**. Ce lien est valable 15 minutes.
+l'activez par agent comme n'importe quel autre serveur. Une fois activé, l'agent peut
+transformer une réponse markdown en PDF téléchargeable, affiché à l'utilisateur sous
+forme de carte avec un bouton **Download PDF** (le libellé est en anglais). Ce lien est
+valable 15 minutes.
 
 ## Conseils
 


### PR DESCRIPTION
## Problem

Follow-up to #739 (code review finding, P1 docs). The help pages for MCP servers describe the PDF export result card with a **Download** button (EN) and a **Télécharger** button (FR). The actual card (`apps/pdf-converter/card.html`) renders a single hardcoded English button labelled **Download PDF**, with no FR variant. The help-site rules require every on-screen label verbatim and in bold, and hardcoded English labels kept as-is in FR.

## Change

- `apps/help/src/content/docs/en/mcp-servers.mdx`: the card button is now **Download PDF**.
- `apps/help/src/content/docs/fr/mcp-servers.mdx`: same label kept in English, with the usual "(le libellé est en anglais)" note used on other FR pages.
- Both pages: `updated` bumped to 2026-09-08.

No other help page quotes strings from the card; the remaining PDF mentions across `apps/help/src/content` are about input documents. No CHANGELOG entry: the changelog has no docs section and help-site copy has never been listed there.

## Checks

- `npx turbo build --filter=@caseai-connect/help`: 60 pages built, 0 errors.
- `npx turbo typecheck --filter=@caseai-connect/help` (astro check): 0 errors (pre-existing warnings in untouched walkthrough components only).
- Built HTML for `dist/en/mcp-servers` and `dist/fr/mcp-servers` both contain `Download PDF`; `Télécharger` no longer appears as the card label in FR.
- `npm run biome:check`: 2131 files checked, no fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
