### PR TITLE
fix(mcp-servers): retire the built-in PDF export server when PDF_CONVERTER_URL is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- (beta) PDF export: the built-in server disappears from workspaces when the export feature is turned off.
 
 ### Security
 

--- a/apps/api/src/domains/mcp-servers/built-in/built-in-mcp-servers.service.spec.ts
+++ b/apps/api/src/domains/mcp-servers/built-in/built-in-mcp-servers.service.spec.ts
@@ -4,6 +4,8 @@ import {
   setupTransactionalTestDatabase,
   teardownTestDatabase,
 } from "@/common/test/test-transaction-manager"
+import { agentFactory } from "@/domains/agents/agent.factory"
+import { createOrganizationWithProject } from "@/domains/organizations/organization.factory"
 import { McpServersModule } from "../mcp-servers.module"
 import { McpServersService } from "../mcp-servers.service"
 import { PDF_EXPORT_BUILT_IN_NAME, PDF_EXPORT_PRESET_SLUG } from "./built-in-mcp-servers"
@@ -51,8 +53,53 @@ describe("BuiltInMcpServersService", () => {
       const result = await service.syncFromEnvironment()
 
       expect(result).toEqual({ synced: [], skipped: [PDF_EXPORT_PRESET_SLUG] })
-      const stored = await repositories.mcpServerRepository.find()
+      const stored = await repositories.mcpServerRepository.find({ withDeleted: true })
       expect(stored).toHaveLength(0)
+    })
+
+    it("should retire an existing PDF export server when PDF_CONVERTER_URL is unset", async () => {
+      await service.syncFromEnvironment()
+      const created = await repositories.mcpServerRepository.findOneOrFail({
+        where: { presetSlug: PDF_EXPORT_PRESET_SLUG },
+      })
+      delete process.env.PDF_CONVERTER_URL
+
+      const result = await service.syncFromEnvironment()
+
+      expect(result).toEqual({ synced: [], skipped: [PDF_EXPORT_PRESET_SLUG] })
+      expect(await repositories.mcpServerRepository.count()).toBe(0)
+      const retired = await repositories.mcpServerRepository.findOneOrFail({
+        where: { id: created.id },
+        withDeleted: true,
+      })
+      expect(retired.deletedAt).not.toBeNull()
+    })
+
+    it("should hide a retired server from listings and agents, then restore both", async () => {
+      const { organization, project } = await createOrganizationWithProject(repositories)
+      const agent = agentFactory.transient({ organization, project }).build()
+      await repositories.agentRepository.save(agent)
+      await service.syncFromEnvironment()
+      const created = await repositories.mcpServerRepository.findOneOrFail({
+        where: { presetSlug: PDF_EXPORT_PRESET_SLUG },
+      })
+      await mcpServersService.enableForAgent(agent.id, created.id)
+
+      delete process.env.PDF_CONVERTER_URL
+      await service.syncFromEnvironment()
+
+      expect(await mcpServersService.listMcpServers(project.id)).toEqual([])
+      expect(await mcpServersService.getEnabledServersForAgent(agent.id)).toEqual([])
+
+      process.env.PDF_CONVERTER_URL = "https://pdf-converter.example.test"
+      const restored = await service.syncFromEnvironment()
+
+      expect(restored).toEqual({ synced: [PDF_EXPORT_PRESET_SLUG], skipped: [] })
+      const listed = await mcpServersService.listMcpServers(project.id)
+      expect(listed.map((mcpServer) => mcpServer.id)).toEqual([created.id])
+      expect(await mcpServersService.getEnabledServersForAgent(agent.id)).toEqual([
+        { id: created.id, url: "https://pdf-converter.example.test/mcp" },
+      ])
     })
 
     it("should create the PDF export server pointing at the converter's mcp endpoint", async () => {

--- a/apps/api/src/domains/mcp-servers/built-in/built-in-mcp-servers.service.ts
+++ b/apps/api/src/domains/mcp-servers/built-in/built-in-mcp-servers.service.ts
@@ -27,8 +27,9 @@ export class BuiltInMcpServersService {
 
   /**
    * Creates the built-in row or refreshes its name and config. The upsert on
-   * the preset slug also restores a row deleted by hand and tolerates
-   * concurrent boots of several instances. An unchanged row is left alone, so
+   * the preset slug also restores a row deleted by hand or retired by an
+   * earlier boot (see `retireBuiltInServer`) and tolerates concurrent boots
+   * of several instances. An unchanged row is left alone, so
    * restarting the API does not bump its updated_at.
    */
   async ensureBuiltInServer({
@@ -53,12 +54,35 @@ export class BuiltInMcpServersService {
     return this.mcpServerRepository.findOneOrFail({ where: { presetSlug: slug } })
   }
 
-  /** Returns the slugs that were synced and the ones the environment skips. */
+  /**
+   * Soft-deletes the live built-in row for `slug`, once the environment no
+   * longer provides the service behind it. Only the server row is touched: the
+   * per-agent links stay in place but stop resolving, since soft-deleted
+   * servers are excluded from listings and from an agent's enabled servers.
+   * Setting the variable again makes `ensureBuiltInServer` clear `deletedAt`
+   * on the same row, and the links come back with it. Returns whether a live
+   * row was retired.
+   */
+  async retireBuiltInServer(slug: string): Promise<boolean> {
+    const existing = await this.mcpServerRepository.findOne({ where: { presetSlug: slug } })
+    if (!existing) return false
+    await this.mcpServerRepository.softDelete({ id: existing.id })
+    return true
+  }
+
+  /**
+   * Returns the slugs that were synced and the ones the environment skips. A
+   * skipped slug whose row still exists is retired, so decommissioning the
+   * converter also removes the server from every workspace.
+   */
   async syncFromEnvironment(): Promise<{ synced: string[]; skipped: string[] }> {
     const converterUrl = this.configService.get<string>("PDF_CONVERTER_URL")
     if (!converterUrl) {
+      const retired = await this.retireBuiltInServer(PDF_EXPORT_PRESET_SLUG)
       this.logger.log(
-        `PDF_CONVERTER_URL is not set: skipping the built-in "${PDF_EXPORT_BUILT_IN_NAME}" MCP server`,
+        retired
+          ? `PDF_CONVERTER_URL is not set: retired the built-in "${PDF_EXPORT_BUILT_IN_NAME}" MCP server`
+          : `PDF_CONVERTER_URL is not set: skipping the built-in "${PDF_EXPORT_BUILT_IN_NAME}" MCP server`,
       )
       return { synced: [], skipped: [PDF_EXPORT_PRESET_SLUG] }
     }

--- a/apps/api/src/domains/mcp-servers/e2e-tests/list.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/list.spec.ts
@@ -138,4 +138,17 @@ describe("McpServers - list", () => {
     expect(response.body.data).toHaveLength(1)
     expect(response.body.data[0]).toMatchObject({ id: builtInServer.id, isBuiltIn: true })
   })
+
+  it("should not return a retired built-in server", async () => {
+    await createContext()
+    await createBuiltInServer()
+    await setup.module
+      .get<BuiltInMcpServersService>(BuiltInMcpServersService)
+      .retireBuiltInServer(PDF_EXPORT_PRESET_SLUG)
+
+    const response = await subject()
+
+    expectResponse(response, 200)
+    expect(response.body.data).toEqual([])
+  })
 })

--- a/apps/api/src/external/mcp/README.md
+++ b/apps/api/src/external/mcp/README.md
@@ -16,7 +16,7 @@ Some MCP servers are provided by the platform itself. They carry one of the slug
 |------|--------|----------|
 | `pdf-export` | "PDF export" (`apps/pdf-converter`) | `PDF_CONVERTER_URL` |
 
-- **Boot sync**: `BuiltInMcpServersService.syncFromEnvironment()` runs once in `main.ts`, before the API listens. It upserts the row on its preset slug, so it creates the row, refreshes its URL when the service moves, and restores it if it was deleted by hand. Without `PDF_CONVERTER_URL` the server is skipped and never listed.
+- **Boot sync**: `BuiltInMcpServersService.syncFromEnvironment()` runs once in `main.ts`, before the API listens. It upserts the row on its preset slug, so it creates the row, refreshes its URL when the service moves, and restores it if it was deleted by hand. Without `PDF_CONVERTER_URL` the server is skipped, and an existing row is soft-deleted: it disappears from every project's listing and from the enabled servers of the agents that had it. The per-agent links are kept, so setting the variable again brings the same row back with those agents still linked.
 - **IAM audience**: when `PDF_CONVERTER_AUTH=google-iam` (set by terraform in production, where the converter is locked behind Cloud Run invoker IAM), the enabled-server config carries a `googleIamAudience` — the converter URL origin. `McpClientService` then mints a Google ID token for it and sends it as `Authorization`, overriding any configured API key.
 - **Deletion**: `DELETE …/mcp-servers/:mcpServerId` on a built-in server answers 403, both in the policy and in `McpServersService.deleteMcpServer`.
 - **Storage**: temporary PDF exports are swept by the workers; see `apps/api/src/domains/documents/pdf-exports/README.md`.


### PR DESCRIPTION
Follow-up to #739 (code-review finding, P1 low).

## Problem

`BuiltInMcpServersService.syncFromEnvironment` only acted when `PDF_CONVERTER_URL` was set. Once the variable was removed or the converter decommissioned, the built-in "PDF export" row stayed listed first in every project, admins could not delete it (built-ins answer 403), and every agent that had it enabled tried to connect to the dead URL on each turn, logging an error and returning no tools.

## Change

- When `PDF_CONVERTER_URL` is unset, `syncFromEnvironment` now soft-deletes an existing built-in row (new `retireBuiltInServer(slug)`) and logs whether a row was retired or nothing was there. Soft-deleted servers are already excluded from `listMcpServers`, `findMcpServerById` and `getEnabledServersForAgent`, so the server disappears from listings and from agents' tool resolution.
- Only the server row is touched. Agent links stay in place, so setting the variable again restores the same row through the existing upsert and the agents that had it enabled get it back. Documented in the service comments and in `apps/api/src/external/mcp/README.md`.
- Changelog entry under Unreleased / Fixed.

## Testing

- `built-in-mcp-servers.service.spec.ts`: unset var with an existing row soft-deletes it; unset var with no row leaves nothing behind; a retired server is hidden from listings and from an agent's enabled servers, then setting the var again restores both.
- `e2e-tests/list.spec.ts`: a retired built-in is not listed.
- `npm run biome:check`: no fixes applied.
- `npm run typecheck`: 6/6 tasks successful.
- `npm run test -- src/domains/mcp-servers` (apps/api): 9 suites, 133 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
