### PR TITLE
fix(pdf-converter): give PDF export signing and upload their own deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Fixed
 
+- (beta) PDF export: large documents no longer fail at the upload step after a slow render.
+
 ### Security
 
 ## [26.09.2] - 2026-09-08

--- a/apps/pdf-converter/README.md
+++ b/apps/pdf-converter/README.md
@@ -143,6 +143,12 @@ Sans and DejaVu Sans Mono (Bitstream Vera licence, see
 - `PDF_EXPORT_MAX_MARKDOWN_BYTES` (default `1048576`, 1 MiB) — markdown input size cap.
 - `PDF_EXPORT_TMP_PREFIX` (default `tmp/pdf-exports/`) — GCS prefix exports are written
   under; must be a relative object path ending with `/`.
+- `PDF_CONVERTER_RENDER_TIMEOUT_MS` (default `60000`, 60s) — budget for waiting for a
+  render slot plus rendering the markdown; on expiry the tool answers "could not render
+  the PDF in time".
+- `PDF_CONVERTER_UPLOAD_TIMEOUT_MS` (default `30000`, 30s) — separate budget for signing
+  and uploading the rendered PDF, so a slow render never leaves the upload without
+  time; on expiry the tool answers "could not store the PDF".
 
 ### Smoke test
 
@@ -168,6 +174,7 @@ service is only bound on the developer's machine.
 - `PORT` (default `3002`) — listen port.
 - `PDF_CONVERTER_MAX_PDF_BYTES` (default `52428800`, 50MB) — source PDF size limit.
 - `PDF_CONVERTER_RENDER_TIMEOUT_MS` (default `60000`, 60s) — hard per-request deadline for rendering work; must stay below the API client's 120s request timeout.
+- `PDF_CONVERTER_UPLOAD_TIMEOUT_MS` (default `30000`, 30s) — separate deadline for signing and uploading an exported PDF once it is rendered; the sum with the render timeout must stay below the API client's 120s request timeout.
 - `PDF_EXPORT_TTL_MINUTES` (default `15`, max `10080`) — how long a signed PDF export download link stays valid; see [MCP endpoint](#mcp-endpoint).
 - `PDF_EXPORT_MAX_MARKDOWN_BYTES` (default `1048576`, 1 MiB) — markdown input size cap for the PDF export tool.
 - `PDF_EXPORT_TMP_PREFIX` (default `tmp/pdf-exports/`) — GCS prefix PDF exports are written under.

--- a/apps/pdf-converter/main.go
+++ b/apps/pdf-converter/main.go
@@ -46,6 +46,18 @@ func main() {
 		}
 		renderTimeout = time.Duration(parsed) * time.Millisecond
 	}
+	// Separate deadline for signing and uploading an exported PDF, so a
+	// render that used most of renderTimeout still gets a full upload budget.
+	// renderTimeout + uploadTimeout must stay below the API client's request
+	// timeout (120s) for the same reason as above.
+	uploadTimeout := 30 * time.Second
+	if fromEnv := os.Getenv("PDF_CONVERTER_UPLOAD_TIMEOUT_MS"); fromEnv != "" {
+		parsed, err := strconv.ParseInt(fromEnv, 10, 64)
+		if err != nil || parsed <= 0 {
+			log.Fatalf("invalid PDF_CONVERTER_UPLOAD_TIMEOUT_MS: %q", fromEnv)
+		}
+		uploadTimeout = time.Duration(parsed) * time.Millisecond
+	}
 
 	exportTTL := 15 * time.Minute
 	if fromEnv := os.Getenv("PDF_EXPORT_TTL_MINUTES"); fromEnv != "" {
@@ -79,6 +91,7 @@ func main() {
 		MaxMarkdownBytes: maxMarkdownBytes,
 		TmpPrefix:        exportTmpPrefix,
 		Timeout:          renderTimeout,
+		UploadTimeout:    uploadTimeout,
 		MaxPages:         pdfExportMaxPages,
 	}
 

--- a/apps/pdf-converter/mcp.go
+++ b/apps/pdf-converter/mcp.go
@@ -52,12 +52,17 @@ type pdfExportConfig struct {
 	MaxMarkdownBytes int
 	// TmpPrefix ends with "/" and is a valid relative object path.
 	TmpPrefix string
-	Timeout   time.Duration
-	MaxPages  int
-	// Now and NewID are injection points for tests; nil means time.Now and
-	// uuid.NewString.
-	Now   func() time.Time
-	NewID func() string
+	// Timeout bounds waiting for a render slot plus the render itself.
+	Timeout time.Duration
+	// UploadTimeout bounds signing and uploading the rendered PDF, separately
+	// from Timeout, so a slow render never leaves the upload with no time.
+	UploadTimeout time.Duration
+	MaxPages      int
+	// Now, NewID and Render are injection points for tests; nil means
+	// time.Now, uuid.NewString and mdpdf.Render.
+	Now    func() time.Time
+	NewID  func() string
+	Render func(ctx context.Context, markdown []byte, opts mdpdf.Options) (mdpdf.Result, error)
 }
 
 func (cfg pdfExportConfig) now() time.Time {
@@ -72,6 +77,15 @@ func (cfg pdfExportConfig) newID() string {
 		return uuid.NewString()
 	}
 	return cfg.NewID()
+}
+
+func (cfg pdfExportConfig) render(
+	ctx context.Context, markdown []byte, opts mdpdf.Options,
+) (mdpdf.Result, error) {
+	if cfg.Render == nil {
+		return mdpdf.Render(ctx, markdown, opts)
+	}
+	return cfg.Render(ctx, markdown, opts)
 }
 
 // The "1 MiB" in the markdown description is the default of
@@ -119,33 +133,45 @@ func (exporter *pdfExporter) convert(
 	fileName := sanitizeFileName(in.FileName)
 	renderCtx, cancelRender := context.WithTimeout(ctx, exporter.cfg.Timeout)
 	defer cancelRender()
-	// Waiting for a slot is part of the render budget: an export that cannot
-	// get one before renderCtx expires fails like any other render timeout.
+	// The render budget covers waiting for a slot and the render itself, and
+	// nothing else: an export that cannot get a slot before renderCtx expires
+	// fails like any other render timeout, while signing and uploading run
+	// below on their own budget so a slow render cannot starve them.
 	if err := exporter.renderSlots.Acquire(renderCtx, 1); err != nil {
 		log.Printf("pdf export waited too long for a render slot: %v", err)
-		return nil, convertMarkdownOutput{}, errors.New("could not render the PDF, try again")
+		return nil, convertMarkdownOutput{}, errors.New("could not render the PDF in time, try again")
 	}
-	rendered, err := mdpdf.Render(renderCtx, []byte(markdown), mdpdf.Options{
+	rendered, err := exporter.cfg.render(renderCtx, []byte(markdown), mdpdf.Options{
 		Title:    in.Title,
 		FileName: fileName,
 		MaxPages: exporter.cfg.MaxPages,
 	})
 	exporter.renderSlots.Release(1)
+	cancelRender()
 	if errors.Is(err, mdpdf.ErrTooManyPages) {
 		return nil, convertMarkdownOutput{}, fmt.Errorf(
 			"the document would exceed %d pages, split it into smaller documents", exporter.cfg.MaxPages)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		log.Printf("pdf export render timed out after %s: %v", exporter.cfg.Timeout, err)
+		return nil, convertMarkdownOutput{}, errors.New("could not render the PDF in time, try a shorter document")
 	}
 	if err != nil {
 		log.Printf("pdf export render failed: %v", err)
 		return nil, convertMarkdownOutput{}, errors.New("could not render the PDF, try again")
 	}
 
+	// Signing and uploading get their own deadline, derived from the request
+	// context rather than from renderCtx, so a document that used most of the
+	// render budget still has the full upload budget left.
+	storeCtx, cancelStore := context.WithTimeout(ctx, exporter.cfg.UploadTimeout)
+	defer cancelStore()
 	// Sign before uploading: BucketHandle.SignedURL does not need the object
 	// to exist, and signing first means a signing failure never leaves an
 	// orphaned upload in the bucket.
 	object := exporter.cfg.TmpPrefix + exporter.cfg.newID() + "/" + fileName
 	expires := exporter.cfg.now().Add(exporter.cfg.TTL)
-	downloadURL, err := exporter.store.SignedURL(renderCtx, object, signedURLOptions{
+	downloadURL, err := exporter.store.SignedURL(storeCtx, object, signedURLOptions{
 		Expires:          expires,
 		DownloadFileName: fileName,
 	})
@@ -153,7 +179,7 @@ func (exporter *pdfExporter) convert(
 		log.Printf("pdf export signing of %s failed: %v", object, err)
 		return nil, convertMarkdownOutput{}, errors.New("could not store the PDF, try again")
 	}
-	if err := exporter.store.Upload(renderCtx, object, "application/pdf", rendered.PDF); err != nil {
+	if err := exporter.store.Upload(storeCtx, object, "application/pdf", rendered.PDF); err != nil {
 		log.Printf("pdf export upload to %s failed: %v", object, err)
 		return nil, convertMarkdownOutput{}, errors.New("could not store the PDF, try again")
 	}

--- a/apps/pdf-converter/mcp_test.go
+++ b/apps/pdf-converter/mcp_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/bayesimpact/bayes-platform/apps/pdf-converter/internal/mdpdf"
 )
 
 // testExportNow freezes the clock so the signed URL and expiresAt are exact.
@@ -24,6 +26,7 @@ func newTestExportConfig() pdfExportConfig {
 		MaxMarkdownBytes: 1 << 20,
 		TmpPrefix:        defaultPdfExportPrefix,
 		Timeout:          time.Minute,
+		UploadTimeout:    time.Minute,
 		MaxPages:         pdfExportMaxPages,
 		Now:              func() time.Time { return testExportNow },
 		NewID:            func() string { return "fixed-id" },
@@ -278,6 +281,76 @@ func TestMCPConvertMarkdownSignedURLFailure(t *testing.T) {
 	// an orphaned upload in the bucket.
 	if len(store.objects) != 0 {
 		t.Fatalf("expected no uploads when signing fails, store has %v", store.objects)
+	}
+}
+
+// TestMCPConvertMarkdownSlowRenderKeepsUploadBudget covers the split between
+// the render and the upload deadlines: a render that eats most of the render
+// budget must leave signing and uploading with their own full budget instead
+// of the few milliseconds left on the render context.
+func TestMCPConvertMarkdownSlowRenderKeepsUploadBudget(t *testing.T) {
+	config := newTestExportConfig()
+	config.Timeout = 300 * time.Millisecond
+	config.UploadTimeout = time.Minute
+	config.Render = func(ctx context.Context, _ []byte, _ mdpdf.Options) (mdpdf.Result, error) {
+		// Burn most of the render budget, then hand back a fake PDF.
+		select {
+		case <-time.After(250 * time.Millisecond):
+		case <-ctx.Done():
+			return mdpdf.Result{}, ctx.Err()
+		}
+		return mdpdf.Result{PDF: []byte("%PDF-1.4 fake"), PageCount: 1}, nil
+	}
+	store := &fakeStore{objects: map[string][]byte{}}
+	session := connectMCP(t, newMCPHandler(store, config))
+
+	callStart := time.Now()
+	result := callConvert(t, session, map[string]any{"markdown": "# Slow report\n"})
+	if result.IsError {
+		t.Fatalf("expected a successful call after a slow render, got %s", resultText(t, result))
+	}
+
+	const wantObject = "tmp/pdf-exports/fixed-id/document.pdf"
+	if _, found := store.objects[wantObject]; !found {
+		t.Fatalf("expected an upload at %q, store has %v", wantObject, store.objects)
+	}
+	deadline := store.storeDeadlines[wantObject]
+	if deadline.IsZero() {
+		t.Fatal("expected the store to be called with a deadline")
+	}
+	// Had the store inherited renderCtx, its deadline would sit within
+	// config.Timeout of the call start. The upload deadline must be well past
+	// the render one.
+	renderDeadlineUpperBound := callStart.Add(config.Timeout)
+	if !deadline.After(renderDeadlineUpperBound.Add(30 * time.Second)) {
+		t.Fatalf("expected the store deadline to be on its own budget (well after %s), got %s",
+			renderDeadlineUpperBound, deadline)
+	}
+}
+
+// TestMCPConvertMarkdownRenderTimeout checks that a render that blows its
+// budget is reported as a render problem, not as a storage one, and that
+// nothing is uploaded.
+func TestMCPConvertMarkdownRenderTimeout(t *testing.T) {
+	config := newTestExportConfig()
+	config.Timeout = 50 * time.Millisecond
+	config.Render = func(ctx context.Context, _ []byte, _ mdpdf.Options) (mdpdf.Result, error) {
+		<-ctx.Done()
+		return mdpdf.Result{}, fmt.Errorf("render markdown to pdf: %w", ctx.Err())
+	}
+	store := &fakeStore{objects: map[string][]byte{}}
+	session := connectMCP(t, newMCPHandler(store, config))
+
+	result := callConvert(t, session, map[string]any{"markdown": "# Never finishes\n"})
+	if !result.IsError {
+		t.Fatalf("expected an error result, got %+v", result)
+	}
+	text := resultText(t, result)
+	if !strings.Contains(text, "render") || strings.Contains(text, "store") {
+		t.Fatalf("expected a render timeout message, got %q", text)
+	}
+	if len(store.objects) != 0 {
+		t.Fatalf("expected no uploads after a render timeout, store has %v", store.objects)
 	}
 }
 

--- a/apps/pdf-converter/server_test.go
+++ b/apps/pdf-converter/server_test.go
@@ -26,6 +26,17 @@ type fakeStore struct {
 	signedDownloadFileNames map[string]string
 	// signErr, when set, makes SignedURL fail.
 	signErr error
+	// storeDeadlines records the deadline of the context each SignedURL and
+	// Upload call received, keyed by object; the zero time means none.
+	storeDeadlines map[string]time.Time
+}
+
+func (store *fakeStore) recordDeadline(ctx context.Context, object string) {
+	if store.storeDeadlines == nil {
+		store.storeDeadlines = map[string]time.Time{}
+	}
+	deadline, _ := ctx.Deadline()
+	store.storeDeadlines[object] = deadline
 }
 
 func (store *fakeStore) Download(ctx context.Context, object string, maxBytes int64) ([]byte, error) {
@@ -44,6 +55,7 @@ func (store *fakeStore) Download(ctx context.Context, object string, maxBytes in
 func (store *fakeStore) Upload(ctx context.Context, object string, contentType string, data []byte) error {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
+	store.recordDeadline(ctx, object)
 	store.objects[object] = data
 	if store.contentTypes == nil {
 		store.contentTypes = map[string]string{}
@@ -55,6 +67,7 @@ func (store *fakeStore) Upload(ctx context.Context, object string, contentType s
 func (store *fakeStore) SignedURL(ctx context.Context, object string, opts signedURLOptions) (string, error) {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
+	store.recordDeadline(ctx, object)
 	if store.signErr != nil {
 		return "", store.signErr
 	}


### PR DESCRIPTION
Follow-up to #739, fixing one P1 code-review finding.

## Problem

In `apps/pdf-converter/mcp.go` the export handler created a single `renderCtx` from `PDF_CONVERTER_RENDER_TIMEOUT_MS` (default 60s) and reused it for `SignedURL` and `Upload`. Slot wait, render, signing and upload therefore shared one budget: a document that rendered in 58s had 2s left for the upload, failed with "could not store the PDF, try again", and retrying reproduced the failure.

## Change

- The render context is cancelled as soon as the render returns and the slot is released. Signing and upload run under a new context derived from the request context with its own budget.
- New config knob `PDF_CONVERTER_UPLOAD_TIMEOUT_MS` (default 30s), wired in `main.go` the same way as the render timeout and documented in the README next to it, with a note that render + upload must stay below the API client's 120s request timeout.
- Error messages now tell the two apart: a render or slot-wait deadline answers "could not render the PDF in time", storage failures keep "could not store the PDF, try again".
- `pdfExportConfig.Render` is a new test injection point (nil means `mdpdf.Render`), following the existing `Now` and `NewID` pattern. The fake store records the deadline of the context each signing and upload call receives.
- Comment describing what the render budget covers updated accordingly.
- CHANGELOG entry under Unreleased / Fixed.

## Testing

Run in `apps/pdf-converter` (the same commands as `pdf-converter-ci.yml`, plus build and gofmt; there is no golangci config in the repo):

- `go build ./...` ok
- `go vet ./...` ok
- `go test ./...` ok (all packages)
- `gofmt -l .` prints nothing

New tests:

- `TestMCPConvertMarkdownSlowRenderKeepsUploadBudget`: a fake render burns 250ms of a 300ms render budget, then the store asserts the deadline it was handed is well past the render deadline and the export succeeds.
- `TestMCPConvertMarkdownRenderTimeout`: a render that waits for its context to expire yields a render-flavoured error message and no upload.

Not verified: `go test -race` (this machine has no cgo), and no live run against GCS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
