### PR TITLE
fix(pdf-export): parse PDF export env vars the way the Go converter does

### DIFF
--- a/apps/api/src/config/positive-int-env.spec.ts
+++ b/apps/api/src/config/positive-int-env.spec.ts
@@ -1,0 +1,67 @@
+import { readPositiveIntEnv } from "./positive-int-env"
+
+describe("readPositiveIntEnv", () => {
+  const key = "POSITIVE_INT_ENV_SPEC_VALUE"
+  const originalValue = process.env[key]
+
+  beforeEach(() => {
+    delete process.env[key]
+  })
+
+  afterAll(() => {
+    if (originalValue === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = originalValue
+    }
+  })
+
+  it("parses a plain positive integer", () => {
+    process.env[key] = "42"
+    expect(readPositiveIntEnv(key)).toBe(42)
+  })
+
+  it("returns the default when unset", () => {
+    expect(readPositiveIntEnv(key, { defaultValue: 7 })).toBe(7)
+  })
+
+  it("returns the default when empty", () => {
+    process.env[key] = ""
+    expect(readPositiveIntEnv(key, { defaultValue: 7 })).toBe(7)
+  })
+
+  it("throws when unset without a default", () => {
+    expect(() => readPositiveIntEnv(key)).toThrow(
+      /POSITIVE_INT_ENV_SPEC_VALUE must be set to a positive integer\./,
+    )
+  })
+
+  it("throws when empty without a default", () => {
+    process.env[key] = ""
+    expect(() => readPositiveIntEnv(key, { unitWord: "seconds" })).toThrow(
+      /POSITIVE_INT_ENV_SPEC_VALUE must be set to a positive integer \(seconds\)\./,
+    )
+  })
+
+  it.each([
+    ["zero", "0"],
+    ["negative", "-5"],
+    ["a trailing unit", "15m"],
+    ["a decimal", "1.5"],
+    ["a leading plus sign", "+15"],
+    ["surrounding whitespace", " 15 "],
+    ["text", "not-a-number"],
+  ])("rejects %s even when a default is set", (_description, rawValue) => {
+    process.env[key] = rawValue
+    expect(() => readPositiveIntEnv(key, { defaultValue: 7 })).toThrow(
+      /POSITIVE_INT_ENV_SPEC_VALUE must be a positive integer\./,
+    )
+  })
+
+  it("mentions the unit word in the invalid-value error", () => {
+    process.env[key] = "0"
+    expect(() => readPositiveIntEnv(key, { unitWord: "seconds" })).toThrow(
+      /POSITIVE_INT_ENV_SPEC_VALUE must be a positive integer \(seconds\)\./,
+    )
+  })
+})

--- a/apps/api/src/config/positive-int-env.ts
+++ b/apps/api/src/config/positive-int-env.ts
@@ -1,0 +1,39 @@
+const POSITIVE_INT_PATTERN = /^\d+$/
+
+export type PositiveIntEnvOptions = {
+  /** Returned when the variable is unset or empty. Without it, an unset variable throws. */
+  defaultValue?: number
+  /** Appended to error messages, e.g. "seconds" gives "must be a positive integer (seconds)". */
+  unitWord?: string
+}
+
+/**
+ * Reads a positive integer from the environment the way the Go services do
+ * (`strconv.Atoi`): only ASCII digits are accepted, so "15m" or "1.5" fail
+ * instead of silently truncating to 15 or 1. An unset or empty variable falls
+ * back to `defaultValue` when one is given and throws otherwise.
+ */
+export function readPositiveIntEnv(
+  environmentVariableName: string,
+  options: PositiveIntEnvOptions = {},
+): number {
+  const { defaultValue, unitWord } = options
+  const unitSuffix = unitWord === undefined ? "" : ` (${unitWord})`
+  const rawValue = process.env[environmentVariableName]
+
+  if (rawValue === undefined || rawValue === "") {
+    if (defaultValue === undefined) {
+      throw new Error(`${environmentVariableName} must be set to a positive integer${unitSuffix}.`)
+    }
+    return defaultValue
+  }
+
+  if (!POSITIVE_INT_PATTERN.test(rawValue)) {
+    throw new Error(`${environmentVariableName} must be a positive integer${unitSuffix}.`)
+  }
+  const parsed = Number.parseInt(rawValue, 10)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${environmentVariableName} must be a positive integer${unitSuffix}.`)
+  }
+  return parsed
+}

--- a/apps/api/src/domains/documents/embeddings/document-embeddings-stuck.config.spec.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings-stuck.config.spec.ts
@@ -46,6 +46,13 @@ describe("document-embeddings-stuck.config", () => {
     )
   })
 
+  it("throws when threshold env has a trailing unit", () => {
+    process.env[thresholdKey] = "3600s"
+    expect(() => getDocumentEmbeddingStuckThresholdSeconds()).toThrow(
+      /DOCUMENT_EMBEDDING_STUCK_THRESHOLD_SECONDS must be a positive integer \(seconds\)/,
+    )
+  })
+
   it("returns sweep interval seconds when set", () => {
     process.env[intervalKey] = "900"
     expect(getDocumentEmbeddingStuckSweepIntervalSeconds()).toBe(900)

--- a/apps/api/src/domains/documents/embeddings/document-embeddings-stuck.config.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings-stuck.config.ts
@@ -1,24 +1,13 @@
-function parseRequiredPositiveInt(
-  environmentVariableName: string,
-  unitWord: "milliseconds" | "seconds",
-): number {
-  const rawValue = process.env[environmentVariableName]
-  if (rawValue === undefined || rawValue === "") {
-    throw new Error(`${environmentVariableName} must be set to a positive integer (${unitWord}).`)
-  }
-  const parsed = Number.parseInt(rawValue, 10)
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`${environmentVariableName} must be a positive integer (${unitWord}).`)
-  }
-  return parsed
-}
+import { readPositiveIntEnv } from "@/config/positive-int-env"
 
 /** Max age for `queued` / `processing` before the sweep marks the document as timed out. */
 export function getDocumentEmbeddingStuckThresholdSeconds(): number {
-  return parseRequiredPositiveInt("DOCUMENT_EMBEDDING_STUCK_THRESHOLD_SECONDS", "seconds")
+  return readPositiveIntEnv("DOCUMENT_EMBEDDING_STUCK_THRESHOLD_SECONDS", { unitWord: "seconds" })
 }
 
 /** How often the BullMQ scheduler enqueues a stuck-embedding sweep job (Bull `every` uses ms internally). */
 export function getDocumentEmbeddingStuckSweepIntervalSeconds(): number {
-  return parseRequiredPositiveInt("DOCUMENT_EMBEDDING_STUCK_SWEEP_INTERVAL_SECONDS", "seconds")
+  return readPositiveIntEnv("DOCUMENT_EMBEDDING_STUCK_SWEEP_INTERVAL_SECONDS", {
+    unitWord: "seconds",
+  })
 }

--- a/apps/api/src/domains/documents/pdf-exports/README.md
+++ b/apps/api/src/domains/documents/pdf-exports/README.md
@@ -16,6 +16,8 @@ Both sides read the same env var names, so they must be set to the same values i
 | `PDF_EXPORT_SWEEP_INTERVAL_SECONDS` | `300` | workers only: how often the sweep runs |
 | `PDF_EXPORTS_SWEEP_QUEUE_NAME` | (required, no default) | every worker process: the sweep queue name, must match `WORKER_QUEUE_NAMES` |
 
+Both sides parse these the same way: an unset or empty variable takes the default, and the integer ones only accept plain digits (`15m` or `1.5` are rejected on both sides rather than truncated to `15` or `1`).
+
 If the converter signs URLs for longer than `PDF_EXPORT_TTL_MINUTES`, the sweep can delete an object a user still holds a valid URL for.
 
 Without `GCS_STORAGE_BUCKET_NAME` the sweep has nothing to sweep (local setups store files on disk through `LocalStorageService`), so the bucket provider yields `null` and each run returns immediately.

--- a/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.spec.ts
+++ b/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.spec.ts
@@ -57,11 +57,21 @@ describe("pdf-exports.config", () => {
     expect(getPdfExportTtlMinutes()).toBe(30)
   })
 
-  it("throws when the TTL is not a positive integer", () => {
-    process.env[ttlKey] = "not-a-number"
+  it.each([
+    ["text", "not-a-number"],
+    ["a trailing unit the converter rejects", "15m"],
+    ["a decimal the converter rejects", "1.5"],
+    ["zero", "0"],
+  ])("throws when the TTL is %s", (_description, rawValue) => {
+    process.env[ttlKey] = rawValue
     expect(() => getPdfExportTtlMinutes()).toThrow(
       /PDF_EXPORT_TTL_MINUTES must be a positive integer/,
     )
+  })
+
+  it("falls back to the default TTL when the variable is empty", () => {
+    process.env[ttlKey] = ""
+    expect(getPdfExportTtlMinutes()).toBe(15)
   })
 
   it("reads the TTL at the seven-day cap", () => {
@@ -83,8 +93,12 @@ describe("pdf-exports.config", () => {
     expect(getPdfExportTmpPrefix()).toBe("scratch/exports/")
   })
 
+  it("falls back to the default tmp prefix when the variable is empty, like the converter", () => {
+    process.env[prefixKey] = ""
+    expect(getPdfExportTmpPrefix()).toBe("tmp/pdf-exports/")
+  })
+
   it.each([
-    ["empty", ""],
     ["the bucket root", "/"],
     ["absolute", "/tmp/pdf-exports/"],
     ["traversing", "tmp/../"],

--- a/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.ts
+++ b/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.ts
@@ -1,39 +1,28 @@
+import { readPositiveIntEnv } from "@/config/positive-int-env"
+
 const DEFAULT_SWEEP_INTERVAL_SECONDS = 300 // 5 minutes
 const DEFAULT_TTL_MINUTES = 15
 /** GCS V4 signing caps a signed URL at seven days, and the converter rejects anything above it. */
 const MAX_TTL_MINUTES = 7 * 24 * 60
 const DEFAULT_TMP_PREFIX = "tmp/pdf-exports/"
 
-function parsePositiveIntWithDefault(
-  environmentVariableName: string,
-  defaultValue: number,
-): number {
-  const rawValue = process.env[environmentVariableName]
-  if (rawValue === undefined || rawValue === "") {
-    return defaultValue
-  }
-  const parsed = Number.parseInt(rawValue, 10)
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`${environmentVariableName} must be a positive integer.`)
-  }
-  return parsed
-}
-
 /** How often the BullMQ scheduler enqueues a PDF export sweep job (Bull `every` uses ms internally). */
 export function getPdfExportSweepIntervalSeconds(): number {
-  return parsePositiveIntWithDefault(
-    "PDF_EXPORT_SWEEP_INTERVAL_SECONDS",
-    DEFAULT_SWEEP_INTERVAL_SECONDS,
-  )
+  return readPositiveIntEnv("PDF_EXPORT_SWEEP_INTERVAL_SECONDS", {
+    defaultValue: DEFAULT_SWEEP_INTERVAL_SECONDS,
+  })
 }
 
 /**
  * Lifetime of a temporary PDF export. Must match the value the converter uses
  * to sign download URLs, otherwise the sweep can delete an object a user still
- * holds a valid URL for.
+ * holds a valid URL for. Parsed like the converter's `strconv.Atoi`, so "15m"
+ * or "1.5" are rejected here as well instead of truncating to 15 or 1.
  */
 export function getPdfExportTtlMinutes(): number {
-  const ttlMinutes = parsePositiveIntWithDefault("PDF_EXPORT_TTL_MINUTES", DEFAULT_TTL_MINUTES)
+  const ttlMinutes = readPositiveIntEnv("PDF_EXPORT_TTL_MINUTES", {
+    defaultValue: DEFAULT_TTL_MINUTES,
+  })
   if (ttlMinutes > MAX_TTL_MINUTES) {
     throw new Error(`PDF_EXPORT_TTL_MINUTES must be at most ${MAX_TTL_MINUTES} (seven days).`)
   }
@@ -41,17 +30,16 @@ export function getPdfExportTtlMinutes(): number {
 }
 
 /**
- * Object-name prefix the sweep lists and deletes under. Validated strictly: a
- * prefix that is empty, absolute, or not directory-shaped would make the sweep
- * delete expired objects across the whole bucket, not just the exports.
+ * Object-name prefix the sweep lists and deletes under. An unset or empty
+ * variable falls back to the default, matching the converter. A non-empty
+ * value is validated strictly: a prefix that is absolute or not
+ * directory-shaped would make the sweep delete expired objects across the
+ * whole bucket, not just the exports.
  */
 export function getPdfExportTmpPrefix(): string {
   const rawValue = process.env.PDF_EXPORT_TMP_PREFIX
-  const prefix = rawValue === undefined ? DEFAULT_TMP_PREFIX : rawValue
+  const prefix = rawValue === undefined || rawValue === "" ? DEFAULT_TMP_PREFIX : rawValue
 
-  if (prefix === "") {
-    throw new Error("PDF_EXPORT_TMP_PREFIX must not be empty (it would sweep the whole bucket).")
-  }
   if (prefix === "/" || prefix.startsWith("/")) {
     throw new Error(
       "PDF_EXPORT_TMP_PREFIX must be a relative object prefix, without a leading slash.",


### PR DESCRIPTION
Follow-up to #739, addressing a review finding on how the API parses the env vars it shares with the Go converter.

## Problem

`apps/api/src/domains/documents/pdf-exports/pdf-exports.config.ts` and `apps/pdf-converter/main.go` read the same variables but disagreed on edge cases:

- `PDF_EXPORT_TMP_PREFIX=` (empty): the converter falls back to the default prefix, the API threw "must not be empty" on every sweep job, so nothing was ever cleaned up.
- `PDF_EXPORT_TTL_MINUTES=15m` or `1.5`: the converter rejects these at boot (`strconv.Atoi`), the API used `Number.parseInt` and accepted them as 15 and 1. With `1.5` the sweep deleted exports after about two minutes while signed URLs lasted fifteen.

`parsePositiveIntWithDefault` was also a near-copy of `parseRequiredPositiveInt` in the stuck-embedding sweep config.

## Change

- New shared helper `readPositiveIntEnv` in `apps/api/src/config/positive-int-env.ts`: only `^\d+$` is accepted, zero and negatives are rejected, an unset or empty value returns `defaultValue` when given and throws otherwise. An optional `unitWord` keeps the existing error messages intact.
- `pdf-exports.config.ts` and `document-embeddings-stuck.config.ts` both use the helper. The embeddings config still throws when unset, with the same messages as before.
- `getPdfExportTmpPrefix` treats empty like unset and falls back to the default, matching the converter. The leading slash, `..` and trailing slash checks are unchanged.
- README documents that both sides parse these values the same way.

No changelog entry: this only affects operators setting malformed env values.

## Testing

From `apps/api`:

- `npm run biome:check` (root): no fixes applied
- `npm run typecheck`: clean
- `npm run test -- src/domains/documents/pdf-exports src/domains/documents/embeddings src/config`: 18 suites, 87 tests passed
- `npm run check:boundaries`: no new circular deps, no dependency violations

New spec cases: empty prefix falls back to the default, `15m` / `1.5` / `0` rejected for the TTL, empty TTL falls back to 15, a dedicated `positive-int-env.spec.ts`, and a trailing-unit rejection case for the embeddings config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
