### PR TITLE
fix(pdf-export): stamp the URL expiry on exported objects so the sweep never outruns it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Fixed
 
+- (beta) PDF export: exported PDFs are now kept exactly as long as their download link is valid.
+
 ### Security
 
 ## [26.09.2] - 2026-09-08

--- a/apps/api/src/domains/documents/pdf-exports/README.md
+++ b/apps/api/src/domains/documents/pdf-exports/README.md
@@ -6,30 +6,30 @@ GCS lifecycle rules only express whole days, so they cannot enforce a TTL measur
 
 ## Contract with the converter
 
-Both sides read the same env var names, so they must be set to the same values in every environment:
+The converter owns the lifetime of an export: when it uploads the PDF it stamps the exact instant the signed URL stops working on the object as its GCS `customTime`. The sweep reads that stamp back and deletes the object once it is in the past, so the two sides never have to agree on a TTL.
 
 | Env var | Default | Used by |
 |---------|---------|---------|
 | `GCS_STORAGE_BUCKET_NAME` | (unset) | both: the bucket exports are written to and swept from |
-| `PDF_EXPORT_TMP_PREFIX` | `tmp/pdf-exports/` | both: the folder exports live in |
-| `PDF_EXPORT_TTL_MINUTES` | `15` | both: lifetime of a signed download URL |
+| `PDF_EXPORT_TMP_PREFIX` | `tmp/pdf-exports/` | both: the folder exports live in, must match |
+| `PDF_EXPORT_TTL_MINUTES` | `15` | converter: lifetime of a signed download URL. Workers: fallback only, for legacy objects without a `customTime` |
 | `PDF_EXPORT_SWEEP_INTERVAL_SECONDS` | `300` | workers only: how often the sweep runs |
 | `PDF_EXPORTS_SWEEP_QUEUE_NAME` | (required, no default) | every worker process: the sweep queue name, must match `WORKER_QUEUE_NAMES` |
 
-If the converter signs URLs for longer than `PDF_EXPORT_TTL_MINUTES`, the sweep can delete an object a user still holds a valid URL for.
+Objects written before the converter stamped expiries have no `customTime`. For those the sweep falls back to `timeCreated` plus the workers' `PDF_EXPORT_TTL_MINUTES`; that fallback can be removed once none is left.
 
 Without `GCS_STORAGE_BUCKET_NAME` the sweep has nothing to sweep (local setups store files on disk through `LocalStorageService`), so the bucket provider yields `null` and each run returns immediately.
 
 ## Timing guarantees
 
-An export is deleted only once it is older than `PDF_EXPORT_TTL_MINUTES` plus a 60 second grace period (`PDF_EXPORTS_DELETE_GRACE_SECONDS`), which gives two bounds:
+An export is deleted only once its stamped expiry plus a 60 second grace period (`PDF_EXPORTS_DELETE_GRACE_SECONDS`) is in the past, which gives two bounds:
 
-- A signed URL always resolves for its whole lifetime, with the grace period to spare. The object outlives the URL, never the other way round.
+- A signed URL always resolves for its whole lifetime, with the grace period to spare. The object outlives the URL, never the other way round, whatever TTL the converter was configured with.
 - An export lives at most TTL + grace + one sweep interval, since an object that expires just after a run waits for the next one. With the defaults that is under 21 minutes.
 
 Each run lists at most 20 pages of 1000 objects (`PDF_EXPORTS_SWEEP_MAX_PAGES_PER_RUN`, `PDF_EXPORTS_SWEEP_PAGE_SIZE`) and deletes 20 objects at a time. A backlog larger than that is drained over the following runs rather than in one long job.
 
-Objects whose `timeCreated` is missing or unparseable are counted and left alone: deleting an object of unknown age could take out a live export.
+Objects with neither a parseable `customTime` nor a parseable `timeCreated` are counted and left alone: deleting an object of unknown age could take out a live export.
 
 ## Deployment
 

--- a/apps/api/src/domains/documents/pdf-exports/pdf-exports-sweep.service.spec.ts
+++ b/apps/api/src/domains/documents/pdf-exports/pdf-exports-sweep.service.spec.ts
@@ -3,14 +3,17 @@ import { Logger } from "@nestjs/common"
 import { PDF_EXPORTS_SWEEP_MAX_PAGES_PER_RUN } from "./pdf-exports.constants"
 import { PdfExportsSweepService } from "./pdf-exports-sweep.service"
 
+type FakeFileMetadata = { customTime?: string; timeCreated?: string }
+
 type FakeFile = {
   name: string
-  metadata: { timeCreated?: string }
+  metadata: FakeFileMetadata
   delete: jest.Mock
 }
 
 describe("PdfExportsSweepService", () => {
-  // TTL 15 min + 60 s grace: anything created before 11:44:00 is expired at noon.
+  // 60 s grace: an export whose customTime is before 11:59:00 is expired at noon.
+  // Legacy objects without customTime: TTL 15 min + grace, created before 11:44:00.
   const now = new Date("2026-05-04T12:00:00.000Z")
   const prefixKey = "PDF_EXPORT_TMP_PREFIX"
   const ttlKey = "PDF_EXPORT_TTL_MINUTES"
@@ -42,11 +45,19 @@ describe("PdfExportsSweepService", () => {
     }
   })
 
-  const buildFile = (name: string, timeCreated?: string): FakeFile => ({
+  const buildFile = (name: string, metadata: FakeFileMetadata = {}): FakeFile => ({
     name,
-    metadata: timeCreated === undefined ? {} : { timeCreated },
+    metadata,
     delete: jest.fn().mockResolvedValue([{}]),
   })
+
+  /** An export the converter stamped with its URL expiry, as every current export is. */
+  const buildStampedFile = (name: string, customTime: string): FakeFile =>
+    buildFile(name, { customTime, timeCreated: "2026-05-04T11:00:00.000Z" })
+
+  /** An export written before the converter stamped expiries: only `timeCreated` is known. */
+  const buildLegacyFile = (name: string, timeCreated?: string): FakeFile =>
+    buildFile(name, timeCreated === undefined ? {} : { timeCreated })
 
   /** Serves `pages` in order, chaining them with a page token like GCS does. */
   const buildBucket = (pages: FakeFile[][]) => {
@@ -63,12 +74,15 @@ describe("PdfExportsSweepService", () => {
   }
 
   it("deletes expired exports across every page and keeps fresh ones", async () => {
-    const expiredOnFirstPage = buildFile(
+    const expiredOnFirstPage = buildStampedFile(
       "tmp/pdf-exports/aaa/report.pdf",
-      "2026-05-04T11:00:00.000Z",
+      "2026-05-04T11:58:59.000Z",
     )
-    const freshOnFirstPage = buildFile("tmp/pdf-exports/bbb/report.pdf", "2026-05-04T11:55:00.000Z")
-    const expiredOnSecondPage = buildFile(
+    const freshOnFirstPage = buildStampedFile(
+      "tmp/pdf-exports/bbb/report.pdf",
+      "2026-05-04T11:59:00.000Z",
+    )
+    const expiredOnSecondPage = buildStampedFile(
       "tmp/pdf-exports/ccc/report.pdf",
       "2026-05-03T09:00:00.000Z",
     )
@@ -87,22 +101,70 @@ describe("PdfExportsSweepService", () => {
     )
   })
 
-  it("keeps files whose creation date is missing or unparseable", async () => {
-    const withoutDate = buildFile("tmp/pdf-exports/aaa/report.pdf")
-    const withBadDate = buildFile("tmp/pdf-exports/bbb/report.pdf", "not-a-date")
-    const bucket = buildBucket([[withoutDate, withBadDate]])
+  it("trusts the stamped expiry over the locally configured TTL", async () => {
+    process.env[ttlKey] = "15"
+    // Created 50 minutes ago, well past the local TTL, but the converter signed
+    // its URL for an hour: it must survive.
+    const stillDownloadable = buildFile("tmp/pdf-exports/aaa/report.pdf", {
+      customTime: "2026-05-04T12:10:00.000Z",
+      timeCreated: "2026-05-04T11:10:00.000Z",
+    })
+    // Created 5 minutes ago, within the local TTL, but its URL already expired
+    // (the converter ran with a shorter TTL): it must go.
+    const alreadyExpired = buildFile("tmp/pdf-exports/bbb/report.pdf", {
+      customTime: "2026-05-04T11:57:00.000Z",
+      timeCreated: "2026-05-04T11:55:00.000Z",
+    })
+    const bucket = buildBucket([[stillDownloadable, alreadyExpired]])
 
     const result = await new PdfExportsSweepService(bucket).sweepExpiredExports(now)
 
-    expect(result).toEqual({ scanned: 2, deleted: 0, failed: 0, skipped: false })
+    expect(result).toEqual({ scanned: 2, deleted: 1, failed: 0, skipped: false })
+    expect(stillDownloadable.delete).not.toHaveBeenCalled()
+    expect(alreadyExpired.delete).toHaveBeenCalledTimes(1)
+  })
+
+  it("falls back to creation date plus TTL for legacy objects without a stamped expiry", async () => {
+    const expiredLegacy = buildLegacyFile(
+      "tmp/pdf-exports/aaa/report.pdf",
+      "2026-05-04T11:43:59.000Z",
+    )
+    const freshLegacy = buildLegacyFile(
+      "tmp/pdf-exports/bbb/report.pdf",
+      "2026-05-04T11:44:00.000Z",
+    )
+    const bucket = buildBucket([[expiredLegacy, freshLegacy]])
+
+    const result = await new PdfExportsSweepService(bucket).sweepExpiredExports(now)
+
+    expect(result).toEqual({ scanned: 2, deleted: 1, failed: 0, skipped: false })
+    expect(expiredLegacy.delete).toHaveBeenCalledTimes(1)
+    expect(freshLegacy.delete).not.toHaveBeenCalled()
+  })
+
+  it("keeps files whose expiry and creation date are both missing or unparseable", async () => {
+    const withoutDate = buildLegacyFile("tmp/pdf-exports/aaa/report.pdf")
+    const withBadDate = buildLegacyFile("tmp/pdf-exports/bbb/report.pdf", "not-a-date")
+    const withBadExpiryAndNoDate = buildFile("tmp/pdf-exports/ccc/report.pdf", {
+      customTime: "not-a-date",
+    })
+    const bucket = buildBucket([[withoutDate, withBadDate, withBadExpiryAndNoDate]])
+
+    const result = await new PdfExportsSweepService(bucket).sweepExpiredExports(now)
+
+    expect(result).toEqual({ scanned: 3, deleted: 0, failed: 0, skipped: false })
     expect(withoutDate.delete).not.toHaveBeenCalled()
     expect(withBadDate.delete).not.toHaveBeenCalled()
+    expect(withBadExpiryAndNoDate.delete).not.toHaveBeenCalled()
   })
 
   it("counts a rejected delete as failed without failing the sweep", async () => {
-    const undeletable = buildFile("tmp/pdf-exports/aaa/report.pdf", "2026-05-04T10:00:00.000Z")
+    const undeletable = buildStampedFile(
+      "tmp/pdf-exports/aaa/report.pdf",
+      "2026-05-04T10:00:00.000Z",
+    )
     undeletable.delete.mockRejectedValue(new Error("permission denied"))
-    const deletable = buildFile("tmp/pdf-exports/bbb/report.pdf", "2026-05-04T10:00:00.000Z")
+    const deletable = buildStampedFile("tmp/pdf-exports/bbb/report.pdf", "2026-05-04T10:00:00.000Z")
     const bucket = buildBucket([[undeletable, deletable]])
 
     const result = await new PdfExportsSweepService(bucket).sweepExpiredExports(now)
@@ -110,11 +172,14 @@ describe("PdfExportsSweepService", () => {
     expect(result).toEqual({ scanned: 2, deleted: 1, failed: 1, skipped: false })
   })
 
-  it("honours the configured TTL and prefix", async () => {
+  it("honours the configured prefix and the legacy TTL for unstamped objects", async () => {
     process.env[prefixKey] = "scratch/exports/"
     process.env[ttlKey] = "60"
-    // Older than 15 min but within the 60 min TTL, so still live.
-    const withinLongerTtl = buildFile("scratch/exports/aaa/report.pdf", "2026-05-04T11:30:00.000Z")
+    // Older than 15 min but within the 60 min legacy TTL, so still live.
+    const withinLongerTtl = buildLegacyFile(
+      "scratch/exports/aaa/report.pdf",
+      "2026-05-04T11:30:00.000Z",
+    )
     const bucket = buildBucket([[withinLongerTtl]])
 
     const result = await new PdfExportsSweepService(bucket).sweepExpiredExports(now)
@@ -135,7 +200,7 @@ describe("PdfExportsSweepService", () => {
     const pages = Array.from(
       { length: PDF_EXPORTS_SWEEP_MAX_PAGES_PER_RUN + 5 },
       (_page, index) => [
-        buildFile(`tmp/pdf-exports/page-${index}/report.pdf`, "2026-05-04T10:00:00.000Z"),
+        buildStampedFile(`tmp/pdf-exports/page-${index}/report.pdf`, "2026-05-04T10:00:00.000Z"),
       ],
     )
     const bucket = buildBucket(pages)

--- a/apps/api/src/domains/documents/pdf-exports/pdf-exports-sweep.service.ts
+++ b/apps/api/src/domains/documents/pdf-exports/pdf-exports-sweep.service.ts
@@ -20,6 +20,12 @@ export type PdfExportsSweepResult = {
  * Deletes temporary PDF exports written by `apps/pdf-converter` once their
  * signed download URLs have expired. GCS lifecycle rules only express whole
  * days, so this sweep is what actually enforces the minutes-scale TTL.
+ *
+ * The converter stamps each export's URL expiry on the object as its GCS
+ * `customTime`, so the writer alone decides when an export dies and the sweep
+ * never has to agree with it on a TTL. Objects without `customTime` were
+ * written before that stamp existed and fall back to `timeCreated` plus the
+ * locally configured TTL.
  */
 @Injectable()
 export class PdfExportsSweepService {
@@ -36,13 +42,16 @@ export class PdfExportsSweepService {
     }
 
     const prefix = getPdfExportTmpPrefix()
-    const maxAgeSeconds = getPdfExportTtlMinutes() * 60 + PDF_EXPORTS_DELETE_GRACE_SECONDS
-    const cutoff = new Date(now.getTime() - maxAgeSeconds * 1000)
+    const graceMilliseconds = PDF_EXPORTS_DELETE_GRACE_SECONDS * 1000
+    // Delete once the expiry plus the grace period is in the past.
+    const expiryCutoff = new Date(now.getTime() - graceMilliseconds)
+    const legacyTtlMilliseconds = getPdfExportTtlMinutes() * 60 * 1000
+    const legacyCreationCutoff = new Date(expiryCutoff.getTime() - legacyTtlMilliseconds)
 
     let scanned = 0
     let deleted = 0
     let failed = 0
-    let withoutCreationDate = 0
+    let withoutExpiry = 0
     let pageToken: string | undefined
 
     for (let pageIndex = 0; pageIndex < PDF_EXPORTS_SWEEP_MAX_PAGES_PER_RUN; pageIndex += 1) {
@@ -56,12 +65,21 @@ export class PdfExportsSweepService {
 
       const expiredFiles: File[] = []
       for (const file of files) {
-        const createdAt = parseTimeCreated(file)
-        if (createdAt === undefined) {
-          withoutCreationDate += 1
+        const expiresAt = parseCustomTime(file)
+        if (expiresAt !== undefined) {
+          if (expiresAt < expiryCutoff) {
+            expiredFiles.push(file)
+          }
           continue
         }
-        if (createdAt < cutoff) {
+        // Legacy fallback for objects written before the converter stamped
+        // the expiry; it can be removed once no such object is left.
+        const createdAt = parseTimeCreated(file)
+        if (createdAt === undefined) {
+          withoutExpiry += 1
+          continue
+        }
+        if (createdAt < legacyCreationCutoff) {
           expiredFiles.push(file)
         }
       }
@@ -85,7 +103,7 @@ export class PdfExportsSweepService {
       )
     }
     this.logger.log(
-      `PDF export sweep finished under ${prefix} (scanned ${scanned}, deleted ${deleted}, failed ${failed}, without creation date ${withoutCreationDate}).`,
+      `PDF export sweep finished under ${prefix} (scanned ${scanned}, deleted ${deleted}, failed ${failed}, without expiry or creation date ${withoutExpiry}).`,
     )
 
     return { scanned, deleted, failed, skipped: false }
@@ -121,12 +139,20 @@ export class PdfExportsSweepService {
   }
 }
 
+/** URL expiry the converter stamped as the GCS custom time, `undefined` when missing or unparseable. */
+function parseCustomTime(file: File): Date | undefined {
+  return parseMetadataDate(file.metadata?.customTime)
+}
+
 /** Creation date from the object metadata, `undefined` when it is missing or unparseable. */
 function parseTimeCreated(file: File): Date | undefined {
-  const timeCreated = file.metadata?.timeCreated
-  if (timeCreated === undefined) {
+  return parseMetadataDate(file.metadata?.timeCreated)
+}
+
+function parseMetadataDate(rawValue: string | undefined): Date | undefined {
+  if (rawValue === undefined) {
     return undefined
   }
-  const createdAt = new Date(timeCreated)
-  return Number.isNaN(createdAt.getTime()) ? undefined : createdAt
+  const parsed = new Date(rawValue)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed
 }

--- a/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.spec.ts
+++ b/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.spec.ts
@@ -48,11 +48,12 @@ describe("pdf-exports.config", () => {
     )
   })
 
-  it("defaults the TTL to 15 minutes", () => {
+  // The TTL is only the fallback for legacy objects without a stamped expiry.
+  it("defaults the legacy TTL to 15 minutes", () => {
     expect(getPdfExportTtlMinutes()).toBe(15)
   })
 
-  it("reads the TTL override", () => {
+  it("reads the legacy TTL override", () => {
     process.env[ttlKey] = "30"
     expect(getPdfExportTtlMinutes()).toBe(30)
   })

--- a/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.ts
+++ b/apps/api/src/domains/documents/pdf-exports/pdf-exports.config.ts
@@ -28,9 +28,11 @@ export function getPdfExportSweepIntervalSeconds(): number {
 }
 
 /**
- * Lifetime of a temporary PDF export. Must match the value the converter uses
- * to sign download URLs, otherwise the sweep can delete an object a user still
- * holds a valid URL for.
+ * Legacy fallback only: the lifetime assumed for exports that carry no
+ * `customTime` stamp because they were written before the converter set one.
+ * Current exports carry their exact expiry, so this value no longer has to
+ * match the converter's `PDF_EXPORT_TTL_MINUTES`. Remove once no legacy
+ * object is left.
  */
 export function getPdfExportTtlMinutes(): number {
   const ttlMinutes = parsePositiveIntWithDefault("PDF_EXPORT_TTL_MINUTES", DEFAULT_TTL_MINUTES)

--- a/apps/api/src/domains/documents/pdf-exports/pdf-exports.constants.ts
+++ b/apps/api/src/domains/documents/pdf-exports/pdf-exports.constants.ts
@@ -28,8 +28,8 @@ export const PDF_EXPORTS_SWEEP_PAGE_SIZE = 1000
 export const PDF_EXPORTS_SWEEP_MAX_PAGES_PER_RUN = 20
 
 /**
- * Extra delay past the TTL before an object is deleted, so a signed URL handed
- * out just before expiry still resolves for its whole lifetime.
+ * Extra delay past the expiry before an object is deleted, so a download that
+ * starts in the last second of a signed URL's lifetime still completes.
  */
 export const PDF_EXPORTS_DELETE_GRACE_SECONDS = 60
 

--- a/apps/pdf-converter/README.md
+++ b/apps/pdf-converter/README.md
@@ -100,14 +100,15 @@ link cannot open a new tab, and without `allow-downloads` browsers open the tab 
 block the download because it was started from a sandboxed frame. The card follows
 `hostContext.theme` (light by default) rather than the OS colour scheme.
 
-### The `tmp/pdf-exports/` prefix and the 15-minute TTL contract
+### The `tmp/pdf-exports/` prefix and the TTL contract
 
 Every export is written once to `{PDF_EXPORT_TMP_PREFIX}{uuid}/{fileName}` and this
 service never deletes it — `SignedURL` only hands out a link that stops working after
-`PDF_EXPORT_TTL_MINUTES`, the object itself stays in GCS. Deleting it is the API's job:
-a worker sweeps `PDF_EXPORT_TMP_PREFIX` for objects older than
-`PDF_EXPORT_TTL_MINUTES` and removes them. If that sweep is ever disabled, exported
-PDFs accumulate in the bucket.
+`PDF_EXPORT_TTL_MINUTES`, the object itself stays in GCS. The upload stamps that same
+expiry on the object as its GCS `customTime`, so the object carries its own lifetime.
+Deleting it is the API's job: a worker sweeps `PDF_EXPORT_TMP_PREFIX` and removes
+objects whose `customTime` is in the past, without needing its own copy of the TTL.
+If that sweep is ever disabled, exported PDFs accumulate in the bucket.
 
 ### Signing requirements
 
@@ -139,7 +140,9 @@ Sans and DejaVu Sans Mono (Bitstream Vera licence, see
 
 - `PDF_EXPORT_TTL_MINUTES` (default `15`, max `10080`) — how long a signed download link
   stays valid; capped at seven days because that is GCS V4 signing's own limit — a
-  higher value starts the service and then fails every export once uploaded.
+  higher value starts the service and then fails every export once uploaded. Only this
+  service needs it: the expiry is stamped on each object, and the API workers' copy of
+  the variable is a fallback for objects written before that stamp existed.
 - `PDF_EXPORT_MAX_MARKDOWN_BYTES` (default `1048576`, 1 MiB) — markdown input size cap.
 - `PDF_EXPORT_TMP_PREFIX` (default `tmp/pdf-exports/`) — GCS prefix exports are written
   under; must be a relative object path ending with `/`.

--- a/apps/pdf-converter/mcp.go
+++ b/apps/pdf-converter/mcp.go
@@ -153,7 +153,12 @@ func (exporter *pdfExporter) convert(
 		log.Printf("pdf export signing of %s failed: %v", object, err)
 		return nil, convertMarkdownOutput{}, errors.New("could not store the PDF, try again")
 	}
-	if err := exporter.store.Upload(renderCtx, object, "application/pdf", rendered.PDF); err != nil {
+	// The expiry travels with the object: the API sweep reads it back as the
+	// GCS custom time, so the converter alone decides how long an export lives.
+	if err := exporter.store.Upload(renderCtx, object, rendered.PDF, uploadOptions{
+		ContentType: "application/pdf",
+		ExpiresAt:   expires,
+	}); err != nil {
 		log.Printf("pdf export upload to %s failed: %v", object, err)
 		return nil, convertMarkdownOutput{}, errors.New("could not store the PDF, try again")
 	}

--- a/apps/pdf-converter/mcp_test.go
+++ b/apps/pdf-converter/mcp_test.go
@@ -156,6 +156,12 @@ func TestMCPConvertMarkdownHappyPath(t *testing.T) {
 	if store.contentTypes[wantObject] != "application/pdf" {
 		t.Fatalf("expected content type application/pdf, got %q", store.contentTypes[wantObject])
 	}
+	// The sweep in apps/api deletes the object from this stamp, so it must be
+	// the exact instant the signed URL stops working.
+	if wantCustomTime := testExportNow.Add(15 * time.Minute); !store.customTimes[wantObject].Equal(wantCustomTime) {
+		t.Fatalf("expected the object custom time to equal the url expiry %s, got %s",
+			wantCustomTime, store.customTimes[wantObject])
+	}
 	if store.signedDownloadFileNames[wantObject] != "Rapport final.pdf" {
 		t.Fatalf("expected the signed url to carry the download file name %q, got %q",
 			"Rapport final.pdf", store.signedDownloadFileNames[wantObject])

--- a/apps/pdf-converter/server.go
+++ b/apps/pdf-converter/server.go
@@ -123,7 +123,7 @@ func newServer(
 				}
 				uploads.Go(func() error {
 					object := fmt.Sprintf("%spage-%d.png", body.OutputPrefix, pageNumber)
-					return store.Upload(uploadCtx, object, "image/png", pngBytes)
+					return store.Upload(uploadCtx, object, pngBytes, uploadOptions{ContentType: "image/png"})
 				})
 				return nil
 			})

--- a/apps/pdf-converter/server_test.go
+++ b/apps/pdf-converter/server_test.go
@@ -21,6 +21,9 @@ type fakeStore struct {
 	objects map[string][]byte
 	// contentTypes records the content type each object was uploaded with.
 	contentTypes map[string]string
+	// customTimes records the ExpiresAt each object was uploaded with (zero
+	// when none was set).
+	customTimes map[string]time.Time
 	// signedDownloadFileNames records the DownloadFileName each SignedURL call
 	// was given, keyed by object.
 	signedDownloadFileNames map[string]string
@@ -41,14 +44,18 @@ func (store *fakeStore) Download(ctx context.Context, object string, maxBytes in
 	return data, nil
 }
 
-func (store *fakeStore) Upload(ctx context.Context, object string, contentType string, data []byte) error {
+func (store *fakeStore) Upload(ctx context.Context, object string, data []byte, opts uploadOptions) error {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 	store.objects[object] = data
 	if store.contentTypes == nil {
 		store.contentTypes = map[string]string{}
 	}
-	store.contentTypes[object] = contentType
+	store.contentTypes[object] = opts.ContentType
+	if store.customTimes == nil {
+		store.customTimes = map[string]time.Time{}
+	}
+	store.customTimes[object] = opts.ExpiresAt
 	return nil
 }
 
@@ -104,6 +111,10 @@ func TestRenderDocumentHappyPath(t *testing.T) {
 	}
 	if _, found := store.objects["org1/proj1/derived/doc1/page-2.png"]; !found {
 		t.Fatalf("page-2.png missing")
+	}
+	// Page images are permanent derived data: only PDF exports carry an expiry.
+	if customTime := store.customTimes["org1/proj1/derived/doc1/page-1.png"]; !customTime.IsZero() {
+		t.Fatalf("expected no custom time on page images, got %s", customTime)
 	}
 }
 
@@ -191,7 +202,7 @@ func (store *stalledUploadStore) Download(ctx context.Context, object string, ma
 	return store.objects[object], nil
 }
 
-func (store *stalledUploadStore) Upload(ctx context.Context, object string, contentType string, data []byte) error {
+func (store *stalledUploadStore) Upload(ctx context.Context, object string, data []byte, opts uploadOptions) error {
 	<-ctx.Done()
 	return ctx.Err()
 }

--- a/apps/pdf-converter/store.go
+++ b/apps/pdf-converter/store.go
@@ -36,9 +36,19 @@ type signedURLOptions struct {
 	DownloadFileName string
 }
 
+// uploadOptions describes how one object is written.
+type uploadOptions struct {
+	ContentType string
+	// ExpiresAt, when set, is stamped on the object as its GCS custom time so
+	// the sweep in apps/api deletes it exactly when its signed URL stops
+	// working, whatever TTL the sweep itself is configured with. Zero leaves
+	// the object without a custom time.
+	ExpiresAt time.Time
+}
+
 type objectStore interface {
 	Download(ctx context.Context, object string, maxBytes int64) ([]byte, error)
-	Upload(ctx context.Context, object string, contentType string, data []byte) error
+	Upload(ctx context.Context, object string, data []byte, opts uploadOptions) error
 	SignedURL(ctx context.Context, object string, opts signedURLOptions) (string, error)
 }
 
@@ -71,9 +81,11 @@ func (store *gcsStore) Download(ctx context.Context, object string, maxBytes int
 	return data, nil
 }
 
-func (store *gcsStore) Upload(ctx context.Context, object string, contentType string, data []byte) error {
+func (store *gcsStore) Upload(ctx context.Context, object string, data []byte, opts uploadOptions) error {
 	writer := store.bucket.Object(object).NewWriter(ctx)
-	writer.ContentType = contentType
+	writer.ContentType = opts.ContentType
+	// Writer embeds ObjectAttrs; a zero CustomTime is simply not sent.
+	writer.CustomTime = opts.ExpiresAt
 	// The payload is fully in memory and small (a page PNG or an exported
 	// PDF); ChunkSize 0 uploads it in a single request instead of staging a
 	// 16MiB resumable buffer.


### PR DESCRIPTION
Follow-up to #739 (code review finding, P1).

## Problem

The Go converter and the API workers each read `PDF_EXPORT_TTL_MINUTES` independently. The converter uses it to sign download URLs, the sweep uses it to compute `timeCreated + TTL + 60 s` and delete older objects. Raising the converter's TTL to 60 while the workers kept 15 made the sweep delete PDFs at T+16 min while users still held links valid until T+60 min. Nothing detected the drift, the READMEs only said both values must match.

## Change

The writer now owns the lifecycle.

- Converter: `Upload` takes an `uploadOptions` struct and stamps `ExpiresAt` on the object as its GCS `CustomTime`. The PDF export passes the exact instant its signed URL stops working; page images keep no custom time. The fake store records it and both `mcp_test.go` and `server_test.go` assert on it.
- Sweep: uses `file.metadata.customTime` as the expiry and deletes once `customTime + grace < now`. Objects without `customTime` (written before this change) fall back to the previous `timeCreated + TTL + grace` rule; the fallback is marked in code for later removal and `getPdfExportTtlMinutes` only serves it.
- Docs: both READMEs now describe the stamped expiry, `PDF_EXPORT_TTL_MINUTES` only has to be set on the converter, the workers' copy is the legacy fallback.
- Changelog entry under Unreleased / Fixed.

## Rollout

Deploy order does not matter. If the converter ships first, stamped objects are swept by the old code as before (customTime is ignored). If the workers ship first, unstamped objects take the fallback path, which is the current behaviour.

## Testing

- `npm run biome:check`, `npm run typecheck`: pass
- `npm run test -- src/domains/documents/pdf-exports` (apps/api): 5 suites, 29 tests pass
- `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` (apps/pdf-converter): pass, no files reported

Not verified against a real GCS bucket: the `customTime` round trip relies on `@google-cloud/storage` exposing `FileMetadata.customTime` (it does in the pinned typings) and on the Go client sending `Writer.CustomTime` (verified in the vendored `storage@v1.65.0` source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
