### PR TITLE
fix(mcp-servers): scope the agent to the request project when toggling a server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Fixed
 
 ### Security
+- MCP servers can no longer be enabled or disabled on an agent that belongs to another project.
 
 ## [26.09.2] - 2026-09-08
 

--- a/apps/api/.dependency-cruiser-known-violations.json
+++ b/apps/api/.dependency-cruiser-known-violations.json
@@ -3475,6 +3475,15 @@
   {
     "type": "dependency",
     "from": "src/domains/mcp-servers/mcp-servers.module.ts",
+    "to": "src/domains/agents/agent.entity.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-domain-entity-import"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domains/mcp-servers/mcp-servers.module.ts",
     "to": "src/domains/projects/project.entity.ts",
     "rule": {
       "severity": "error",
@@ -3935,15 +3944,6 @@
     "type": "dependency",
     "from": "src/domains/agents/extraction-agent-sessions/extraction-agent-session-run-llm.service.ts",
     "to": "src/domains/documents/pdf-pages/pdf-pages.service.ts",
-    "rule": {
-      "severity": "warn",
-      "name": "no-cross-domain-service-reach"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domains/agents/extraction-agent-sessions/extraction-agent-session-run-llm.service.ts",
-    "to": "src/domains/projects/projects.service.ts",
     "rule": {
       "severity": "warn",
       "name": "no-cross-domain-service-reach"

--- a/apps/api/src/domains/mcp-servers/e2e-tests/agent-linking.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/agent-linking.spec.ts
@@ -12,7 +12,9 @@ import { removeNullish } from "@/common/utils/remove-nullish"
 import { agentFactory } from "@/domains/agents/agent.factory"
 import { AgentsModule } from "@/domains/agents/agents.module"
 import { addUserToAgent } from "@/domains/agents/memberships/agent-membership.factory"
+import type { Organization } from "@/domains/organizations/organization.entity"
 import { createOrganizationWithProject } from "@/domains/organizations/organization.factory"
+import { projectFactory } from "@/domains/projects/project.factory"
 import { setupUserGuardForTesting } from "../../../../test/e2e.helpers"
 import { expectResponse, type Requester, testRequester } from "../../../../test/request"
 import { PDF_EXPORT_BUILT_IN_NAME, PDF_EXPORT_PRESET_SLUG } from "../built-in/built-in-mcp-servers"
@@ -73,6 +75,36 @@ describe("McpServers - agent linking", () => {
     return { organization, project, mcpServer, agent }
   }
 
+  /** An agent of another organization, whose id the caller has no business with. */
+  const createAgentInOtherOrganization = async () => {
+    const other = await createOrganizationWithProject(repositories, {
+      user: { auth0Id: "auth0|other" },
+    })
+    const foreignAgent = agentFactory
+      .transient({ organization: other.organization, project: other.project })
+      .build({ name: "Foreign Agent" })
+    await repositories.agentRepository.save(foreignAgent)
+    return foreignAgent
+  }
+
+  /** An agent of a sibling project: same organization, so the caller is a member. */
+  const createAgentInOtherProject = async (organization: Organization) => {
+    const otherProject = projectFactory.transient({ organization }).build()
+    await repositories.projectRepository.save(otherProject)
+    const siblingAgent = agentFactory
+      .transient({ organization, project: otherProject })
+      .build({ name: "Sibling Agent" })
+    await repositories.agentRepository.save(siblingAgent)
+    return siblingAgent
+  }
+
+  const createBuiltInServer = async () =>
+    setup.module.get<BuiltInMcpServersService>(BuiltInMcpServersService).ensureBuiltInServer({
+      slug: PDF_EXPORT_PRESET_SLUG,
+      name: PDF_EXPORT_BUILT_IN_NAME,
+      config: { url: "https://pdf-converter.example.test/mcp" },
+    })
+
   it("should enable an MCP server for an agent", async () => {
     await createContext()
 
@@ -131,14 +163,7 @@ describe("McpServers - agent linking", () => {
 
   it("should enable and disable a built-in MCP server for an agent", async () => {
     await createContext()
-    const builtInServer = await setup.module
-      .get<BuiltInMcpServersService>(BuiltInMcpServersService)
-      .ensureBuiltInServer({
-        slug: PDF_EXPORT_PRESET_SLUG,
-        name: PDF_EXPORT_BUILT_IN_NAME,
-        config: { url: "https://pdf-converter.example.test/mcp" },
-      })
-    mcpServerId = builtInServer.id
+    mcpServerId = (await createBuiltInServer()).id
 
     const enableResponse = await request({
       route: McpServersRoutes.enableForAgent,
@@ -161,5 +186,79 @@ describe("McpServers - agent linking", () => {
     expect(
       await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
     ).toBeNull()
+  })
+
+  describe("with an agent from another project", () => {
+    const enable = () =>
+      request({
+        route: McpServersRoutes.enableForAgent,
+        pathParams: removeNullish({ organizationId, projectId, mcpServerId, agentId }),
+        token: accessToken,
+      })
+    const disable = () =>
+      request({
+        route: McpServersRoutes.disableForAgent,
+        pathParams: removeNullish({ organizationId, projectId, mcpServerId, agentId }),
+        token: accessToken,
+      })
+
+    it("should not enable a project server", async () => {
+      await createContext()
+      agentId = (await createAgentInOtherOrganization()).id
+
+      expectResponse(await enable(), 404)
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).toBeNull()
+    })
+
+    it("should not disable a project server", async () => {
+      await createContext()
+      agentId = (await createAgentInOtherOrganization()).id
+      await repositories.agentMcpServerRepository.save(
+        repositories.agentMcpServerRepository.create({ agentId, mcpServerId, enabled: true }),
+      )
+
+      expectResponse(await disable(), 404)
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).not.toBeNull()
+    })
+
+    it("should not enable the built-in server", async () => {
+      await createContext()
+      mcpServerId = (await createBuiltInServer()).id
+      agentId = (await createAgentInOtherOrganization()).id
+
+      expectResponse(await enable(), 404)
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).toBeNull()
+    })
+
+    it("should not enable the built-in server on an agent of a sibling project", async () => {
+      const { organization } = await createContext()
+      mcpServerId = (await createBuiltInServer()).id
+      agentId = (await createAgentInOtherProject(organization)).id
+
+      expectResponse(await enable(), 404)
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).toBeNull()
+    })
+
+    it("should not disable the built-in server", async () => {
+      await createContext()
+      mcpServerId = (await createBuiltInServer()).id
+      agentId = (await createAgentInOtherOrganization()).id
+      await repositories.agentMcpServerRepository.save(
+        repositories.agentMcpServerRepository.create({ agentId, mcpServerId, enabled: true }),
+      )
+
+      expectResponse(await disable(), 404)
+      expect(
+        await repositories.agentMcpServerRepository.findOne({ where: { agentId, mcpServerId } }),
+      ).not.toBeNull()
+    })
   })
 })

--- a/apps/api/src/domains/mcp-servers/mcp-servers.controller.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.controller.ts
@@ -3,18 +3,9 @@ import {
   type McpServerDto,
   McpServersRoutes,
 } from "@caseai-connect/api-contracts"
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Param,
-  Post,
-  Req,
-  UseGuards,
-  UsePipes,
-} from "@nestjs/common"
+import { Body, Controller, Delete, Get, Post, Req, UseGuards, UsePipes } from "@nestjs/common"
 import type {
+  EndpointRequestWithAgent,
   EndpointRequestWithMcpServer,
   EndpointRequestWithProject,
 } from "@/common/context/request.interface"
@@ -29,6 +20,8 @@ import type { McpServer } from "./mcp-server.entity"
 import { McpServerGuard } from "./mcp-server.guard"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { McpServersService } from "./mcp-servers.service"
+
+type EndpointRequestWithAgentAndMcpServer = EndpointRequestWithAgent & EndpointRequestWithMcpServer
 
 @UseGuards(JwtAuthGuard, UserGuard, ResourceContextGuard, McpServerGuard)
 @RequireContext("organization", "project")
@@ -74,14 +67,16 @@ export class McpServersController {
     return { data: { success: true } }
   }
 
+  // The agent is resolved from the request project: a built-in server is
+  // visible from every project, so the agent id alone would let one project
+  // toggle it on an agent of another.
   @Post(McpServersRoutes.enableForAgent.path)
   @CheckPolicy((policy) => policy.canCreate())
-  @AddContext("mcpServer")
+  @AddContext("mcpServer", "agent")
   async enableForAgent(
-    @Req() request: EndpointRequestWithMcpServer,
-    @Param("agentId") agentId: string,
+    @Req() request: EndpointRequestWithAgentAndMcpServer,
   ): Promise<typeof McpServersRoutes.enableForAgent.response> {
-    await this.mcpServersService.enableForAgent(agentId, request.mcpServer.id)
+    await this.mcpServersService.enableForAgent(request.agent.id, request.mcpServer.id)
     return { data: { success: true } }
   }
 
@@ -89,12 +84,11 @@ export class McpServersController {
   // Not canDelete(): turning a server off for an agent updates the agent's
   // configuration, and built-in servers can be toggled but never deleted.
   @CheckPolicy((policy) => policy.canUpdate())
-  @AddContext("mcpServer")
+  @AddContext("mcpServer", "agent")
   async disableForAgent(
-    @Req() request: EndpointRequestWithMcpServer,
-    @Param("agentId") agentId: string,
+    @Req() request: EndpointRequestWithAgentAndMcpServer,
   ): Promise<typeof McpServersRoutes.disableForAgent.response> {
-    await this.mcpServersService.disableForAgent(agentId, request.mcpServer.id)
+    await this.mcpServersService.disableForAgent(request.agent.id, request.mcpServer.id)
     return { data: { success: true } }
   }
 }

--- a/apps/api/src/domains/mcp-servers/mcp-servers.module.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.module.ts
@@ -1,10 +1,12 @@
 import { Module } from "@nestjs/common"
 import { ConfigModule } from "@nestjs/config"
 import { TypeOrmModule } from "@nestjs/typeorm"
+import { AgentContextResolver } from "@/common/context/resolvers/agent-context.resolver"
 import { McpServerContextResolver } from "@/common/context/resolvers/mcp-server-context.resolver"
 import { OrganizationContextResolver } from "@/common/context/resolvers/organization-context.resolver"
 import { ProjectContextResolver } from "@/common/context/resolvers/project-context.resolver"
 import { ResourceContextGuard } from "@/common/context/resource-context.guard"
+import { Agent } from "@/domains/agents/agent.entity"
 import { AuthModule } from "@/domains/auth/auth.module"
 import { MembershipsModule } from "@/domains/memberships/memberships.module"
 import { OrganizationsModule } from "@/domains/organizations/organizations.module"
@@ -20,7 +22,7 @@ import { McpServersService } from "./mcp-servers.service"
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([McpServer, AgentMcpServer, Project]),
+    TypeOrmModule.forFeature([McpServer, AgentMcpServer, Project, Agent]),
     ConfigModule,
     MembershipsModule,
     OrganizationsModule,
@@ -35,6 +37,7 @@ import { McpServersService } from "./mcp-servers.service"
     ResourceContextGuard,
     OrganizationContextResolver,
     ProjectContextResolver,
+    AgentContextResolver,
     McpServerContextResolver,
   ],
   controllers: [McpServersController],


### PR DESCRIPTION
## Problem

Follow-up to #739 (P0 security finding). `POST` and `DELETE /organizations/:organizationId/projects/:projectId/mcp-servers/:mcpServerId/agents/:agentId` passed the raw `agentId` path param to the service, which only wrote the agent-server link and never checked which project the agent belonged to. Since #739 the built-in PDF export server resolves for every project and its policy passes scope checks, so a project admin of project A could enable or disable it on an agent of another project or another organization. The same hole existed for project-owned servers.

## What changed

- Both routes now add `agent` to the request context, so the existing `AgentContextResolver` loads the agent by id, organization and project and answers 404 when it is not in the request project. The controller passes the resolved agent's id to the service.
- `McpServersModule` registers `AgentContextResolver` and the `Agent` entity. The resulting cross-domain entity import is absorbed into the dependency-cruiser baseline, matching the other modules that wire this resolver. Regenerating the baseline also dropped one stale warn-only entry that no longer matched any code.
- Five new e2e cases in `agent-linking.spec.ts`: enable and disable with an agent from another organization return 404 for a project server and for the built-in server, plus enable of the built-in server on an agent of a sibling project in the same organization. Each asserts the link table is left untouched.
- Changelog entry under Unreleased > Security.

## Testing

- `npm run biome:check`: clean, no fixes applied
- `npm run typecheck`: 6/6 tasks pass
- `npm run test -- src/domains/mcp-servers` (apps/api): 9 suites, 135 tests pass
- `npm run check:boundaries` (apps/api): no violations
- Negative check: with the controller and module changes stashed, the five new cases fail and the four pre-existing ones pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
