### PR TITLE
fix(mcp-oauth): try the RFC 8414 path-insertion metadata URL for path issuers

### DIFF
--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.spec.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.spec.ts
@@ -94,6 +94,50 @@ describe("discoverOauthConfiguration", () => {
     )
   })
 
+  it("tries the RFC 8414 path-insertion metadata URL first for an issuer with a path", async () => {
+    const pathIssuerMetadata = {
+      ...resourceMetadata,
+      authorization_servers: ["https://auth.example.com/tenant-a"],
+    }
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(json(pathIssuerMetadata))
+      .mockResolvedValueOnce(json(authServerMetadata))
+
+    const discovery = await discoverOauthConfiguration(MCP_URL)
+
+    expect(discovery?.authorizationEndpoint).toBe("https://auth.example.com/oauth2/authorize")
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[2][0]).toBe(
+      "https://auth.example.com/.well-known/oauth-authorization-server/tenant-a",
+    )
+  })
+
+  it("falls back through the MCP spec discovery order for an issuer with a path", async () => {
+    const pathIssuerMetadata = {
+      ...resourceMetadata,
+      authorization_servers: ["https://auth.example.com/tenant-a/"],
+    }
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(json(pathIssuerMetadata))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(json(authServerMetadata))
+
+    const discovery = await discoverOauthConfiguration(MCP_URL)
+
+    expect(discovery?.tokenEndpoint).toBe("https://auth.example.com/oauth2/token")
+    const metadataUrls = fetchMock.mock.calls.slice(2).map(([url]) => url)
+    expect(metadataUrls).toEqual([
+      "https://auth.example.com/.well-known/oauth-authorization-server/tenant-a",
+      "https://auth.example.com/.well-known/openid-configuration/tenant-a",
+      "https://auth.example.com/tenant-a/.well-known/oauth-authorization-server",
+      "https://auth.example.com/tenant-a/.well-known/openid-configuration",
+    ])
+  })
+
   it("accepts an http localhost authorization_endpoint (dev)", async () => {
     fetchMock
       .mockResolvedValueOnce(new Response(null, { status: 401 }))

--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.ts
@@ -55,12 +55,8 @@ export async function discoverOauthConfiguration(
   const resourceMetadata = await fetchJson<ProtectedResourceMetadata>(resourceMetadataUrl)
   if (!resourceMetadata?.authorization_servers?.length) return null
 
-  const issuer = (resourceMetadata.authorization_servers as string[])[0]!.replace(/\/$/, "")
-  const serverMetadata =
-    (await fetchJson<AuthorizationServerMetadata>(
-      `${issuer}/.well-known/oauth-authorization-server`,
-    )) ??
-    (await fetchJson<AuthorizationServerMetadata>(`${issuer}/.well-known/openid-configuration`))
+  const issuer = (resourceMetadata.authorization_servers as string[])[0]!
+  const serverMetadata = await fetchAuthorizationServerMetadata(issuer)
   if (!serverMetadata?.authorization_endpoint || !serverMetadata.token_endpoint) return null
   if (
     !isValidEndpointUrl(serverMetadata.authorization_endpoint) ||
@@ -147,6 +143,43 @@ async function probeForResourceMetadataUrl(mcpUrl: string): Promise<string> {
   const url = new URL(mcpUrl)
   const path: string = url.pathname === "/" ? "" : (url.pathname ?? "")
   return `${url.origin}/.well-known/oauth-protected-resource${path}`
+}
+
+/**
+ * Fetches RFC 8414 authorization server metadata, trying the well-known URLs
+ * in the order the MCP Authorization spec prescribes. For an issuer with a
+ * path component (`https://auth.example.com/tenant-a`) the path-insertion
+ * forms come first (`/.well-known/oauth-authorization-server/tenant-a`), then
+ * the path-appending forms. A path-less issuer only has the latter two.
+ */
+async function fetchAuthorizationServerMetadata(
+  issuer: string,
+): Promise<AuthorizationServerMetadata | null> {
+  for (const metadataUrl of authorizationServerMetadataUrls(issuer)) {
+    const serverMetadata = await fetchJson<AuthorizationServerMetadata>(metadataUrl)
+    if (serverMetadata) return serverMetadata
+  }
+  return null
+}
+
+function authorizationServerMetadataUrls(issuer: string): string[] {
+  let issuerUrl: URL
+  try {
+    issuerUrl = new URL(issuer)
+  } catch {
+    return []
+  }
+  const issuerPath = issuerUrl.pathname.replace(/\/$/, "")
+  const pathAppendingUrls = [
+    `${issuerUrl.origin}${issuerPath}/.well-known/oauth-authorization-server`,
+    `${issuerUrl.origin}${issuerPath}/.well-known/openid-configuration`,
+  ]
+  if (!issuerPath) return pathAppendingUrls
+  return [
+    `${issuerUrl.origin}/.well-known/oauth-authorization-server${issuerPath}`,
+    `${issuerUrl.origin}/.well-known/openid-configuration${issuerPath}`,
+    ...pathAppendingUrls,
+  ]
 }
 
 async function fetchJson<ResponseBody>(url: string): Promise<ResponseBody | null> {


### PR DESCRIPTION
For an authorization server issuer with a path component such as `https://auth.example.com/tenant-a`, discovery only fetched the path-appending well-known URLs (`.../tenant-a/.well-known/oauth-authorization-server`, then `.../tenant-a/.well-known/openid-configuration`). RFC 8414 and the MCP Authorization spec put the path-insertion form first, so an OAuth-only server that publishes just `https://auth.example.com/.well-known/oauth-authorization-server/tenant-a` 404ed on both attempts and the user saw "This MCP server does not advertise OAuth authorization".

Discovery now builds the candidate metadata URLs in the spec order for path issuers: path-insertion `oauth-authorization-server`, path-insertion `openid-configuration`, then the two path-appending forms. Path-less issuers keep the current two-URL behavior. The change is confined to `mcp-oauth-discovery.ts` and its spec.

Testing: two new cases in `mcp-oauth-discovery.spec.ts` (path issuer served only by the path-insertion form, and the full fallback order for a path issuer) were written first and failed, then pass with the fix. `npm run biome:check`, `npm run typecheck` and the `mcp-servers/oauth` specs (3 suites, 43 tests) all pass.

Addresses https://github.com/bayesimpact/bayes-platform/pull/710#discussion_r3915044379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
