### PR TITLE
refactor(mcp-oauth): share the OAuth endpoint URL allowlist through api-contracts

### DIFF
--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.ts
@@ -5,6 +5,8 @@
  * global fetch so they can be unit-tested without Nest.
  */
 
+import { isAllowedOauthEndpointUrl } from "@caseai-connect/api-contracts"
+
 export type McpOauthDiscovery = {
   authorizationEndpoint: string
   tokenEndpoint: string
@@ -17,24 +19,6 @@ export type McpOauthDiscovery = {
 // Outbound OAuth discovery calls hit third-party servers named in MCP server
 // config; a slow or hanging server must not block the request indefinitely.
 const OAUTH_FETCH_TIMEOUT_MS = 10_000
-
-/**
- * A discovered endpoint is later handed to the browser (authorization_endpoint
- * becomes a `window.location.assign` target). A hostile authorization server
- * could return a `javascript:` or `data:` URL, so every endpoint from
- * third-party JSON must be validated before use. `http:` is allowed only for
- * localhost, to keep local dev authorization servers working.
- */
-function isValidEndpointUrl(candidate: string): boolean {
-  let url: URL
-  try {
-    url = new URL(candidate)
-  } catch {
-    return false
-  }
-  if (url.protocol === "https:") return true
-  return url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1")
-}
 
 type ProtectedResourceMetadata = {
   resource?: string
@@ -63,13 +47,14 @@ export async function discoverOauthConfiguration(
     (await fetchJson<AuthorizationServerMetadata>(`${issuer}/.well-known/openid-configuration`))
   if (!serverMetadata?.authorization_endpoint || !serverMetadata.token_endpoint) return null
   if (
-    !isValidEndpointUrl(serverMetadata.authorization_endpoint) ||
-    !isValidEndpointUrl(serverMetadata.token_endpoint)
+    !isAllowedOauthEndpointUrl(serverMetadata.authorization_endpoint) ||
+    !isAllowedOauthEndpointUrl(serverMetadata.token_endpoint)
   ) {
     return null
   }
   const registrationEndpoint =
-    serverMetadata.registration_endpoint && isValidEndpointUrl(serverMetadata.registration_endpoint)
+    serverMetadata.registration_endpoint &&
+    isAllowedOauthEndpointUrl(serverMetadata.registration_endpoint)
       ? serverMetadata.registration_endpoint
       : undefined
 

--- a/apps/web/src/studio/features/mcp-servers/mcp-servers.thunks.ts
+++ b/apps/web/src/studio/features/mcp-servers/mcp-servers.thunks.ts
@@ -1,4 +1,4 @@
-import type { McpServerAuthMethod } from "@caseai-connect/api-contracts"
+import { isAllowedOauthEndpointUrl, type McpServerAuthMethod } from "@caseai-connect/api-contracts"
 import { createAsyncThunk } from "@reduxjs/toolkit"
 import { getCurrentId } from "@/common/features/helpers"
 import type { RootState, ThunkExtraArg } from "@/common/store"
@@ -7,20 +7,6 @@ import { savePendingMcpOauthContext } from "./mcp-oauth-storage"
 import type { McpServer } from "./mcp-servers.models"
 
 type ThunkConfig = { state: RootState; extra: ThunkExtraArg; rejectValue: string }
-
-// Defense in depth: the API already validates discovered OAuth endpoints, but
-// this is the last line before the URL reaches window.location.assign, a
-// javascript:/data: URL there would execute on the app origin.
-const isSafeAuthorizationUrl = (candidate: string): boolean => {
-  let url: URL
-  try {
-    url = new URL(candidate)
-  } catch {
-    return false
-  }
-  if (url.protocol === "https:") return true
-  return url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1")
-}
 
 const currentProjectScope = (state: RootState) => ({
   organizationId: getCurrentId({ state, name: "organizationId" }),
@@ -92,7 +78,9 @@ export const initiateMcpServerOauth = createAsyncThunk<void, { mcpServerId: stri
         ...scope,
         mcpServerId,
       })
-      if (!isSafeAuthorizationUrl(authorizationUrl)) {
+      // Defense in depth: the API already validated this URL at discovery time, but
+      // this is the last check before window.location.assign.
+      if (!isAllowedOauthEndpointUrl(authorizationUrl)) {
         return rejectWithValue("The authorization server returned an unsafe redirect URL.")
       }
       savePendingMcpOauthContext({ ...scope, mcpServerId })

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -67,6 +67,7 @@ export { defineRoute } from "./helpers"
 // Invitations
 export type * from "./invitations/invitations.dto"
 export { InvitationsRoutes } from "./invitations/invitations.routes"
+export { isAllowedOauthEndpointUrl } from "./mcp-servers/mcp-oauth-endpoint-url"
 // MCP Servers
 export * from "./mcp-servers/mcp-servers.dto"
 export { McpServersRoutes } from "./mcp-servers/mcp-servers.routes"

--- a/packages/api-contracts/src/mcp-servers/mcp-oauth-endpoint-url.ts
+++ b/packages/api-contracts/src/mcp-servers/mcp-oauth-endpoint-url.ts
@@ -1,0 +1,19 @@
+/**
+ * Allowlist for OAuth endpoint URLs discovered from third-party MCP servers.
+ *
+ * The API validates every discovered endpoint before storing it and the web
+ * app re-checks the authorization URL right before `window.location.assign`,
+ * where a `javascript:` or `data:` URL would run on the app origin. Both sides
+ * share this one rule so they cannot drift: `https:` is accepted, `http:` only
+ * for localhost so local dev authorization servers keep working.
+ */
+export function isAllowedOauthEndpointUrl(candidate: string): boolean {
+  let url: URL
+  try {
+    url = new URL(candidate)
+  } catch {
+    return false
+  }
+  if (url.protocol === "https:") return true
+  return url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+}


### PR DESCRIPTION
## Problem

The https-or-localhost allowlist for discovered OAuth endpoints existed twice, byte for byte: `isValidEndpointUrl` in the API discovery module and `isSafeAuthorizationUrl` in the web thunk that hands the URL to `window.location.assign`. Nothing tied the two copies together, so the one guarding the browser redirect could silently drift.

## Fix

Move the check to a single exported helper, `isAllowedOauthEndpointUrl`, in `packages/api-contracts/src/mcp-servers/mcp-oauth-endpoint-url.ts`, alongside the other runtime helpers api-contracts already ships. Both the API and the web app now import it. The rule itself is unchanged; the follow-up SSRF hardening now has one place to land.

## Testing

`npm run biome:check`, `npm run typecheck`, `npm run check:deps` (API), `mcp-oauth-discovery.spec.ts` (11 passed) and the web vitest suite (145 passed) all pass. api-contracts has no test runner, so the rule stays covered by the discovery spec's https, http localhost and `javascript:` cases.

Addresses https://github.com/bayesimpact/bayes-platform/pull/710#discussion_r3915044447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
