### PR TITLE
fix(mcp-oauth): reject OAuth initiation on API key servers

### DIFF
--- a/apps/api/src/domains/mcp-servers/e2e-tests/oauth.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/oauth.spec.ts
@@ -15,6 +15,7 @@ import { createOrganizationWithProject } from "@/domains/organizations/organizat
 import { setupUserGuardForTesting } from "../../../../test/e2e.helpers"
 import { expectResponse, type Requester, testRequester } from "../../../../test/request"
 import { McpServersModule } from "../mcp-servers.module"
+import { McpServersService } from "../mcp-servers.service"
 
 global.fetch = jest.fn()
 const fetchMock = global.fetch as jest.Mock
@@ -101,12 +102,12 @@ describe("McpServers - oauth", () => {
     return { organization, project }
   }
 
-  const createServer = async (): Promise<string> => {
+  const createServer = async (payload: { apiKey?: string } = {}): Promise<string> => {
     const response = await request({
       route: McpServersRoutes.createOne,
       pathParams: removeNullish({ organizationId, projectId }),
       token: accessToken,
-      request: { payload: { name: "Knowledge Base", url: MCP_URL } },
+      request: { payload: { name: "Knowledge Base", url: MCP_URL, ...payload } },
     })
     expectResponse(response, 201)
     return response.body.data.id
@@ -148,6 +149,20 @@ describe("McpServers - oauth", () => {
     const response = await initiate()
 
     expectResponse(response, 400)
+  })
+
+  it("returns 400 on an API key server and keeps its key", async () => {
+    await createContext()
+    mcpServerId = await createServer({ apiKey: "secret-key" })
+
+    const response = await initiate()
+
+    expectResponse(response, 400)
+    expect(fetchMock).not.toHaveBeenCalled()
+    const mcpServer = await repositories.mcpServerRepository.findOneByOrFail({ id: mcpServerId })
+    const config = setup.module.get(McpServersService).getConfig(mcpServer)
+    expect(config.apiKey).toBe("secret-key")
+    expect(config.oauth).toBeUndefined()
   })
 
   it("completes OAuth and marks the server connected", async () => {

--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.spec.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.spec.ts
@@ -11,6 +11,7 @@ import { agentFactory } from "@/domains/agents/agent.factory"
 import { createOrganizationWithProject } from "@/domains/organizations/organization.factory"
 import { EncryptionService } from "../encryption.service"
 import type { McpServer } from "../mcp-server.entity"
+import type { McpServerConfig } from "../mcp-server-config.types"
 import { McpServersModule } from "../mcp-servers.module"
 import type { McpServerOauthState, McpServerOauthTokens } from "../mcp-servers.service"
 import { McpServersService } from "../mcp-servers.service"
@@ -93,13 +94,20 @@ describe("McpOauthService", () => {
     fetchMock.mockReset()
   })
 
-  const createServer = async (overrides: { url: string }): Promise<McpServer> => {
+  const createServer = async (config: McpServerConfig): Promise<McpServer> => {
     const { project } = await createOrganizationWithProject(repositories)
     return mcpServersService.createMcpServer({
       projectId: project.id,
       name: "Test MCP Server",
-      config: { url: overrides.url },
+      config,
     })
+  }
+
+  const expectApiKeyPreserved = async (mcpServerId: string) => {
+    const reloaded = await repositories.mcpServerRepository.findOneByOrFail({ id: mcpServerId })
+    const config = mcpServersService.getConfig(reloaded)
+    expect(config.apiKey).toBe("secret-key")
+    expect(config.oauth).toBeUndefined()
   }
 
   const initiateForServer = async (): Promise<{
@@ -199,6 +207,30 @@ describe("McpOauthService", () => {
       ([url]) => url === "https://auth.example.com/connect/register",
     )
     expect(registrationCalls).toHaveLength(1)
+  })
+
+  it("rejects initiation on an apiKey server before any discovery and keeps the key", async () => {
+    const mcpServer = await createServer({
+      url: MCP_URL,
+      authMethod: "apiKey",
+      apiKey: "secret-key",
+    })
+
+    await expect(mcpOauthService.initiateAuthorization(mcpServer)).rejects.toThrow(
+      BadRequestException,
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+    await expectApiKeyPreserved(mcpServer.id)
+  })
+
+  it("rejects initiation on a legacy server that stores a key without an authMethod", async () => {
+    const mcpServer = await createServer({ url: MCP_URL, apiKey: "secret-key" })
+
+    await expect(mcpOauthService.initiateAuthorization(mcpServer)).rejects.toThrow(
+      BadRequestException,
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+    await expectApiKeyPreserved(mcpServer.id)
   })
 
   it("throws BadRequestException when the server advertises no OAuth metadata", async () => {

--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.ts
@@ -59,6 +59,15 @@ export class McpOauthService {
 
   async initiateAuthorization(mcpServer: McpServer): Promise<{ authorizationUrl: string }> {
     const config = this.readConfig(mcpServer)
+    // Storing oauth state next to an API key would make the server look
+    // oauthPending and replace the key with a token that does not exist yet.
+    // Legacy configs predate authMethod, so a stored key with no oauth state
+    // counts as an API key server too.
+    if (config.authMethod === "apiKey" || (config.apiKey && !config.oauth)) {
+      throw new BadRequestException(
+        "This MCP server authenticates with an API key. OAuth cannot be started on it.",
+      )
+    }
     const redirectUri = this.configService.getOrThrow<string>("MCP_OAUTH_REDIRECT_URL")
 
     const discovery = await discoverOauthConfiguration(config.url)


### PR DESCRIPTION
The initiate endpoint only checked the create policy, not the server's auth method. One `POST .../oauth/initiate` on a server created with an API key stored `oauth.pendingAuth` next to the key. From then on the server reported `oauthPending`, every agent turn dialed it with no Authorization header, and there was no way back short of deleting the server.

`initiateAuthorization` now rejects with a 400 before any discovery fetch when the server authenticates with an API key. The check also covers legacy configs that store a key without an `authMethod`, and leaves servers created without a key (inferred `none`) free to start OAuth as before. The stored key is never touched.

Testing: two new `McpOauthService` cases (explicit apiKey and legacy key without authMethod, both asserting no fetch and the key preserved), one new e2e case on the initiate route; `npm run biome:check`, `npm run typecheck` and the `src/domains/mcp-servers` specs pass.

Addresses https://github.com/bayesimpact/bayes-platform/pull/710#discussion_r3915044392

🤖 Generated with [Claude Code](https://claude.com/claude-code)