### PR TITLE
test(mcp-servers): add role-based auth coverage for every route

### DIFF
--- a/apps/api/src/domains/mcp-servers/e2e-tests/auth.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/auth.spec.ts
@@ -1,3 +1,7 @@
+// Set before the module graph loads: initiateOauth reads it through
+// ConfigService.getOrThrow before any provider request.
+process.env.MCP_OAUTH_REDIRECT_URL = "https://app.test/oauth/mcp/callback"
+
 import { randomUUID } from "node:crypto"
 import { McpServersRoutes } from "@caseai-connect/api-contracts"
 import { afterAll } from "@jest/globals"
@@ -18,16 +22,23 @@ import { createOrganizationWithProject } from "@/domains/organizations/organizat
 import { projectFactory } from "@/domains/projects/project.factory"
 import { mockForeignAuth0Id, setupUserGuardForTesting } from "../../../../test/e2e.helpers"
 import { expectResponse, type Requester, testRequester } from "../../../../test/request"
+import { EncryptionService } from "../encryption.service"
 import { mcpServerFactory } from "../mcp-server.factory"
 import { McpServersModule } from "../mcp-servers.module"
 
 type ProjectRole = "owner" | "admin" | "member"
+
+// The OAuth routes reach out to the MCP server once the guard lets them
+// through. No test here exercises a provider, so every call answers 404.
+global.fetch = jest.fn()
+const fetchMock = global.fetch as jest.Mock
 
 describe("McpServers - auth and scoping", () => {
   let app: INestApplication<App>
   let request: Requester
   let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
   let repositories: AllRepositories
+  let encryptionService: EncryptionService
 
   let organizationId: string
   let projectId: string
@@ -42,6 +53,7 @@ describe("McpServers - auth and scoping", () => {
       applyOverrides: (moduleBuilder) => setupUserGuardForTesting(moduleBuilder, () => auth0Id),
     })
     repositories = setup.getAllRepositories()
+    encryptionService = setup.module.get(EncryptionService)
     app = setup.module.createNestApplication()
     await app.init()
     request = testRequester(app)
@@ -51,8 +63,12 @@ describe("McpServers - auth and scoping", () => {
     await clearTestDatabase(setup.dataSource)
     accessToken = "token"
     auth0Id = `auth0|${randomUUID()}`
+    organizationId = randomUUID()
+    projectId = randomUUID()
     mcpServerId = randomUUID()
     agentId = randomUUID()
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(new Response(null, { status: 404 }))
   })
 
   afterAll(async () => {
@@ -89,6 +105,21 @@ describe("McpServers - auth and scoping", () => {
     })
     await repositories.mcpServerRepository.save(foreignServer)
     return { otherProject, foreignServer }
+  }
+
+  /**
+   * The factory blob is not decryptable, which is fine for routes that never
+   * read it. The OAuth routes do, so give the current server a real config.
+   */
+  const giveServerDecryptableConfig = async () => {
+    await repositories.mcpServerRepository.update(
+      { id: mcpServerId },
+      {
+        encryptedConfig: encryptionService.encrypt(
+          JSON.stringify({ url: "https://mcp.example.com/mcp", authMethod: "oauth" }),
+        ),
+      },
+    )
   }
 
   const pathParams = () => removeNullish({ organizationId, projectId, mcpServerId, agentId })
@@ -137,6 +168,12 @@ describe("McpServers - auth and scoping", () => {
       await createContextForRole("owner")
       accessToken = null
       expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
     })
 
     it("allows a simple project member to list", async () => {
@@ -204,6 +241,16 @@ describe("McpServers - auth and scoping", () => {
       await createContextForRole("owner")
       accessToken = null
       expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+
+      expect(
+        await repositories.mcpServerRepository.findOne({ where: { id: mcpServerId } }),
+      ).not.toBeNull()
     })
 
     it.each<ProjectRole>(["owner", "admin"])("allows a project %s to delete", async (role) => {
@@ -275,6 +322,12 @@ describe("McpServers - auth and scoping", () => {
       expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
     })
 
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+    })
+
     it.each<ProjectRole>(["owner", "admin"])("allows a project %s to enable", async (role) => {
       await createContextForRole(role)
       expectResponse(await subject(), 201)
@@ -312,6 +365,27 @@ describe("McpServers - auth and scoping", () => {
       expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
     })
 
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+    })
+
+    it.each<ProjectRole>(["owner", "admin"])("allows a project %s to disable", async (role) => {
+      await createContextForRole(role)
+      await repositories.agentMcpServerRepository.save(
+        repositories.agentMcpServerRepository.create({ agentId, mcpServerId, enabled: true }),
+      )
+
+      expectResponse(await subject(), 200)
+
+      expect(
+        await repositories.agentMcpServerRepository.findOne({
+          where: { agentId, mcpServerId, enabled: true },
+        }),
+      ).toBeNull()
+    })
+
     it("forbids a simple project member from disabling", async () => {
       await createContextForRole("member")
       await repositories.agentMcpServerRepository.save(
@@ -336,6 +410,101 @@ describe("McpServers - auth and scoping", () => {
     it("succeeds even when no link exists", async () => {
       await createContextForRole("owner")
       expectResponse(await subject(), 200)
+    })
+  })
+
+  // Both OAuth routes are gated by canCreate(). The allowed-role cases assert
+  // the 400 the service raises once the guard lets the request through: a
+  // provider is never mocked here, the functional coverage lives in
+  // oauth.spec.ts. Anything but 401 or 403 proves the policy accepted the role.
+  describe("initiateOauth", () => {
+    const subject = () =>
+      request({
+        route: McpServersRoutes.initiateOauth,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+      })
+
+    it("requires an authentication token", async () => {
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+    })
+
+    it("forbids a simple project member from initiating", async () => {
+      await createContextForRole("member")
+      await giveServerDecryptableConfig()
+
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it.each<ProjectRole>(["owner", "admin"])("allows a project %s to initiate", async (role) => {
+      await createContextForRole(role)
+      await giveServerDecryptableConfig()
+
+      // 400: the stubbed server advertises no OAuth, so discovery ran past the guard.
+      expectResponse(await subject(), 400)
+
+      expect(fetchMock).toHaveBeenCalled()
+    })
+
+    it("returns 404 for a server of another project", async () => {
+      const { organization } = await createContextForRole("owner")
+      const { foreignServer } = await createServerInOtherProject(organization)
+      mcpServerId = foreignServer.id
+
+      expectResponse(await subject(), 404)
+    })
+  })
+
+  describe("completeOauth", () => {
+    const subject = () =>
+      request({
+        route: McpServersRoutes.completeOauth,
+        pathParams: pathParams(),
+        token: accessToken ?? undefined,
+        request: { payload: { code: "code-1", state: "state-1" } },
+      })
+
+    it("requires an authentication token", async () => {
+      accessToken = null
+      expectResponse(await subject(), 401, AUTH_ERRORS.NO_ACCESS_TOKEN)
+    })
+
+    it("requires the user to be a member of the organization", async () => {
+      await createContextForRole("owner")
+      auth0Id = mockForeignAuth0Id()
+      expectResponse(await subject(), 401, AUTH_ERRORS.NOT_MEMBER_OF_ORG)
+    })
+
+    it("forbids a simple project member from completing", async () => {
+      await createContextForRole("member")
+      await giveServerDecryptableConfig()
+
+      expectResponse(await subject(), 403, AUTH_ERRORS.UNAUTHORIZED_RESOURCE)
+    })
+
+    it.each<ProjectRole>(["owner", "admin"])("allows a project %s to complete", async (role) => {
+      await createContextForRole(role)
+      await giveServerDecryptableConfig()
+
+      // 400: no authorization is pending on this server, so the service ran past the guard.
+      expectResponse(await subject(), 400)
+    })
+
+    it("returns 404 for a server of another project", async () => {
+      const { organization } = await createContextForRole("owner")
+      const { foreignServer } = await createServerInOtherProject(organization)
+      mcpServerId = foreignServer.id
+
+      expectResponse(await subject(), 404)
     })
   })
 })

--- a/apps/api/src/domains/mcp-servers/e2e-tests/oauth.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/oauth.spec.ts
@@ -1,5 +1,6 @@
 process.env.MCP_OAUTH_REDIRECT_URL = "https://app.test/oauth/mcp/callback"
 
+import { randomUUID } from "node:crypto"
 import { McpServersRoutes } from "@caseai-connect/api-contracts"
 import { afterAll } from "@jest/globals"
 import type { INestApplication } from "@nestjs/common"
@@ -64,9 +65,9 @@ describe("McpServers - oauth", () => {
   let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
   let repositories: AllRepositories
 
-  let organizationId: string
-  let projectId: string
-  let mcpServerId: string
+  let organizationId: string = randomUUID()
+  let projectId: string = randomUUID()
+  let mcpServerId: string = randomUUID()
   let accessToken: string | undefined = "token"
   let auth0Id = "auth0|123"
 
@@ -180,8 +181,8 @@ describe("McpServers - oauth", () => {
   })
 
   it("requires authentication on both routes", async () => {
-    await createContext()
-    mcpServerId = await createServer()
+    // The guard answers before any context is resolved, so no server is needed.
+    mcpServerId = randomUUID()
     accessToken = undefined
 
     const initiateResponse = await initiate()


### PR DESCRIPTION
The mcp-servers auth spec did not cover `initiateOauth` and `completeOauth` at all, and four other routes had no not-a-member case. The only authorization check on the two OAuth routes was a no-token assertion in the functional spec, so a policy regression letting a plain member start or finish an OAuth flow would have shipped green.

Every route in the domain now has no token, foreign user, plain member and owner/admin cases in `auth.spec.ts`, plus a cross-project 404 for the OAuth routes. The allowed-role OAuth cases assert the 400 the service raises past the guard (no OAuth advertised, no pending authorization), with `fetch` stubbed to 404 so no provider is contacted. `disableForAgent` also gains its owner/admin cases. The functional no-token test in `oauth.spec.ts` uses a random id instead of creating a server first, since the guard answers before context resolution.

Testing: `npm run biome:check`, `npm run typecheck`, and `mcp-servers/e2e-tests/auth.spec.ts` + `oauth.spec.ts` (49 tests) all pass.

Addresses https://github.com/bayesimpact/bayes-platform/pull/710#discussion_r3915044433

🤖 Generated with [Claude Code](https://claude.com/claude-code)