### PR TITLE
fix(mcp): skip unauthorized OAuth servers instead of dialing them unauthenticated

### DIFF
--- a/apps/api/src/domains/mcp-servers/mcp-servers.service.spec.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.service.spec.ts
@@ -542,6 +542,89 @@ describe("McpServersService", () => {
       )
     })
 
+    describe("with an OAuth server", () => {
+      const oauth = {
+        clientId: "client-123",
+        authorizationEndpoint: "https://auth.example.com/oauth2/authorize",
+        tokenEndpoint: "https://auth.example.com/oauth2/token",
+        resource: "https://mcp.example.com",
+      }
+      const url = "https://mcp.example.com/mcp"
+
+      it("should skip a server that was never authorized", async () => {
+        const agent = await createAgent()
+        const neverStarted = await service.createMcpServer({
+          projectId: agent.projectId,
+          name: "Never Started",
+          config: { url, authMethod: "oauth" },
+        })
+        const discoveredOnly = await service.createMcpServer({
+          projectId: agent.projectId,
+          name: "Discovered Only",
+          config: { url, authMethod: "oauth", oauth },
+        })
+        await service.enableForAgent(agent.id, neverStarted.id)
+        await service.enableForAgent(agent.id, discoveredOnly.id)
+
+        expect(await service.getEnabledServersForAgent(agent.id)).toEqual([])
+      })
+
+      it("should skip a server whose tokens expired without a refresh token", async () => {
+        const agent = await createAgent()
+        const tokens = { accessToken: "stale-token", expiresAt: Date.now() - 60_000 }
+        const server = await service.createMcpServer({
+          projectId: agent.projectId,
+          name: "Expired",
+          config: { url, authMethod: "oauth", oauth: { ...oauth, tokens } },
+        })
+        await service.enableForAgent(agent.id, server.id)
+
+        expect(await service.getEnabledServersForAgent(agent.id)).toEqual([])
+      })
+
+      it("should return a server with a valid access token as its api key", async () => {
+        const agent = await createAgent()
+        const tokens = { accessToken: "fresh-token", expiresAt: Date.now() + 3_600_000 }
+        const server = await service.createMcpServer({
+          projectId: agent.projectId,
+          name: "Authorized",
+          config: { url, authMethod: "oauth", oauth: { ...oauth, tokens } },
+        })
+        await service.enableForAgent(agent.id, server.id)
+
+        expect(await service.getEnabledServersForAgent(agent.id)).toEqual([
+          { id: server.id, url, authMethod: "oauth", apiKey: "fresh-token" },
+        ])
+      })
+
+      it("should keep api key and unauthenticated servers alongside a skipped one", async () => {
+        const agent = await createAgent()
+        const pending = await service.createMcpServer({
+          projectId: agent.projectId,
+          name: "Pending",
+          config: { url, authMethod: "oauth" },
+        })
+        const withApiKey = await service.createMcpServer({
+          projectId: agent.projectId,
+          name: "With Api Key",
+          config: { url: "https://keyed.example.com/mcp", authMethod: "apiKey", apiKey: "sk-key" },
+        })
+        const open = await service.createMcpServer({
+          projectId: agent.projectId,
+          name: "Open",
+          config: { url: "https://open.example.com/mcp", authMethod: "none" },
+        })
+        await service.enableForAgent(agent.id, pending.id)
+        await service.enableForAgent(agent.id, withApiKey.id)
+        await service.enableForAgent(agent.id, open.id)
+
+        const configs = await service.getEnabledServersForAgent(agent.id)
+
+        expect(configs.map((config) => config.id).sort()).toEqual([withApiKey.id, open.id].sort())
+        expect(configs.find((config) => config.id === withApiKey.id)?.apiKey).toBe("sk-key")
+      })
+    })
+
     describe("with Google IAM enabled", () => {
       beforeEach(() => {
         process.env.PDF_CONVERTER_AUTH = "google-iam"

--- a/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
+++ b/apps/api/src/domains/mcp-servers/mcp-servers.service.ts
@@ -1,5 +1,5 @@
 import type { McpServerAuthStatus } from "@caseai-connect/api-contracts"
-import { ForbiddenException, Injectable } from "@nestjs/common"
+import { ForbiddenException, Injectable, Logger } from "@nestjs/common"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { ConfigService } from "@nestjs/config"
 import { InjectRepository } from "@nestjs/typeorm"
@@ -29,6 +29,8 @@ export type {
 
 @Injectable()
 export class McpServersService {
+  private readonly logger = new Logger(McpServersService.name)
+
   constructor(
     @InjectRepository(McpServer)
     private readonly mcpServerRepository: Repository<McpServer>,
@@ -46,20 +48,34 @@ export class McpServersService {
     })
 
     const enabledServers = agentMcpServers.filter((agentMcpServer) => agentMcpServer.mcpServer)
-    return Promise.all(
-      enabledServers.map(async (agentMcpServer) => {
-        const { oauth, ...config } = this.decryptConfig(agentMcpServer.mcpServer)
-        if (!oauth) return this.toEnabledServer(agentMcpServer.mcpServer, config)
-        const accessToken = await this.mcpOauthService.getValidAccessToken(
-          agentMcpServer.mcpServer.id,
-          oauth,
-        )
-        return this.toEnabledServer(agentMcpServer.mcpServer, {
-          ...config,
-          apiKey: accessToken ?? undefined,
-        })
-      }),
+    const servers = await Promise.all(
+      enabledServers.map((agentMcpServer) =>
+        this.toEnabledServerIfUsable(agentMcpServer.mcpServer),
+      ),
     )
+    return servers.filter((server) => server !== null)
+  }
+
+  /**
+   * An OAuth server with no usable access token (never authorized, or tokens
+   * dropped after a definitive refresh failure) is left out rather than dialed
+   * unauthenticated, which would only produce a 401 on every turn.
+   */
+  private async toEnabledServerIfUsable(mcpServer: McpServer): Promise<EnabledMcpServer | null> {
+    const { oauth, ...config } = this.decryptConfig(mcpServer)
+    const usesOauth = oauth !== undefined || config.authMethod === "oauth"
+    if (!usesOauth) return this.toEnabledServer(mcpServer, config)
+
+    const accessToken = oauth
+      ? await this.mcpOauthService.getValidAccessToken(mcpServer.id, oauth)
+      : null
+    if (!accessToken) {
+      this.logger.warn(
+        `Skipping MCP server "${mcpServer.name}" (${mcpServer.id}): OAuth authorization is missing or expired`,
+      )
+      return null
+    }
+    return this.toEnabledServer(mcpServer, { ...config, apiKey: accessToken })
   }
 
   async createPreset(slug: string, name: string, config: McpServerConfig): Promise<McpServer> {


### PR DESCRIPTION
## Problem

A server created with `authMethod: "oauth"` that was never authorized, or whose tokens were dropped after a definitive refresh failure, was still returned by `getEnabledServersForAgent` with no api key. `McpClientService.connect` then dialed it without an Authorization header on every turn, caught the 401, logged an error and returned no tools. The agent quietly lost that server's tools and nobody got a signal, even though this is the normal state of a freshly created OAuth server.

## Fix

`getEnabledServersForAgent` now leaves out any server that uses OAuth (an `oauth` state present, or `authMethod: "oauth"` with none yet) when no valid access token can be obtained, and logs a warning naming the server id and name. Servers with a usable token, api key servers and unauthenticated servers are unchanged, as is the Google IAM audience handling in `toEnabledServer`. The OAuth initiate flow is untouched (handled in a separate PR). A follow-up should surface a "needs authorization" hint in the web app where a server is enabled on an agent, so the gap is visible to users and not only in the logs.

## Testing

Added service tests covering a never-authorized server (with and without discovered oauth state), tokens expired without a refresh token, a server with a valid token, and api key / none servers alongside a skipped one. `npm run biome:check`, `npm run typecheck`, and `npm run test -- src/domains/mcp-servers` plus the two agent-side specs that consume `getEnabledServersForAgent` all pass (15 suites, 224 tests).

Addresses https://github.com/bayesimpact/bayes-platform/pull/710#discussion_r3915044425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
