### PR TITLE
fix(mcp-oauth): block private and link-local hosts in OAuth discovery fetches

### DIFF
--- a/apps/api/.env-example
+++ b/apps/api/.env-example
@@ -89,6 +89,9 @@ MCP_ENCRYPTION_KEY=your-64-char-hex-key-here
 # Frontend callback URL registered with MCP OAuth providers
 MCP_OAUTH_REDIRECT_URL=https://connect.localhost:5173/oauth/mcp/callback
 
+# Local dev only: let MCP OAuth discovery reach http://localhost servers (production rejects non-public hosts).
+# MCP_OAUTH_ALLOW_INSECURE_LOCAL=true
+
 # Migrations only (SeedPlatformStaffByEmailDomain) — email domain granted the platform_staff role. Not read by the app at runtime.
 ORGANIZATION_CREATOR_EMAIL_DOMAIN=@example.com
 

--- a/apps/api/src/domains/mcp-servers/e2e-tests/oauth.spec.ts
+++ b/apps/api/src/domains/mcp-servers/e2e-tests/oauth.spec.ts
@@ -19,6 +19,12 @@ import { McpServersModule } from "../mcp-servers.module"
 global.fetch = jest.fn()
 const fetchMock = global.fetch as jest.Mock
 
+// The outbound URL guard resolves every discovery host before fetching;
+// resolve the example.com fixtures to a public address.
+jest.mock("node:dns/promises", () => ({
+  lookup: jest.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]),
+}))
+
 const MCP_URL = "https://mcp.example.com/mcp"
 
 const resourceMetadata = {

--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.spec.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.spec.ts
@@ -1,7 +1,15 @@
+import { lookup } from "node:dns/promises"
 import { discoverOauthConfiguration, registerOauthClient } from "./mcp-oauth-discovery"
+import { DisallowedOutboundUrlError } from "./outbound-url-guard"
 
 global.fetch = jest.fn()
 const fetchMock = global.fetch as jest.Mock
+
+// The outbound URL guard resolves every host before fetching; resolve the
+// example.com fixtures to a public address so discovery reaches the fetch mock.
+jest.mock("node:dns/promises", () => ({ lookup: jest.fn() }))
+const lookupMock = lookup as jest.Mock
+const PUBLIC_ADDRESS = { address: "93.184.216.34", family: 4 }
 
 const MCP_URL = "https://mcp.example.com/mcp"
 
@@ -26,7 +34,16 @@ const json = (body: unknown) =>
   })
 
 describe("discoverOauthConfiguration", () => {
-  beforeEach(() => fetchMock.mockReset())
+  beforeEach(() => {
+    fetchMock.mockReset()
+    lookupMock.mockReset()
+    lookupMock.mockResolvedValue([PUBLIC_ADDRESS])
+    delete process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL
+  })
+
+  afterAll(() => {
+    delete process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL
+  })
 
   it("follows WWW-Authenticate resource_metadata from a 401 probe", async () => {
     fetchMock
@@ -94,7 +111,8 @@ describe("discoverOauthConfiguration", () => {
     )
   })
 
-  it("accepts an http localhost authorization_endpoint (dev)", async () => {
+  it("accepts an http localhost authorization_endpoint with MCP_OAUTH_ALLOW_INSECURE_LOCAL", async () => {
+    process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL = "true"
     fetchMock
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
       .mockResolvedValueOnce(json(resourceMetadata))
@@ -110,6 +128,21 @@ describe("discoverOauthConfiguration", () => {
 
     expect(discovery?.authorizationEndpoint).toBe("http://localhost:4000/oauth2/authorize")
     expect(discovery?.tokenEndpoint).toBe("http://localhost:4000/oauth2/token")
+  })
+
+  it("returns null for an http localhost authorization_endpoint without the insecure-local flag", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(json(resourceMetadata))
+      .mockResolvedValueOnce(
+        json({
+          ...authServerMetadata,
+          authorization_endpoint: "http://localhost:4000/oauth2/authorize",
+          token_endpoint: "http://localhost:4000/oauth2/token",
+        }),
+      )
+
+    expect(await discoverOauthConfiguration(MCP_URL)).toBeNull()
   })
 
   it("returns null when authorization_endpoint is a javascript: URL", async () => {
@@ -171,6 +204,64 @@ describe("discoverOauthConfiguration", () => {
     expect(fetchMock.mock.calls[1][0]).toBe(
       "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
     )
+  })
+
+  it("rejects a private-host MCP URL before making any request", async () => {
+    await expect(
+      discoverOauthConfiguration("https://169.254.169.254/latest/meta-data/"),
+    ).rejects.toBeInstanceOf(DisallowedOutboundUrlError)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects an MCP URL whose hostname resolves to a private address before making any request", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.5", family: 4 }])
+
+    await expect(discoverOauthConfiguration(MCP_URL)).rejects.toBeInstanceOf(
+      DisallowedOutboundUrlError,
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects a plain http MCP URL", async () => {
+    await expect(discoverOauthConfiguration("http://mcp.example.com/mcp")).rejects.toBeInstanceOf(
+      DisallowedOutboundUrlError,
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns null without fetching authorization server metadata when the issuer is a private host", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        json({ ...resourceMetadata, authorization_servers: ["https://10.0.0.5"] }),
+      )
+
+    expect(await discoverOauthConfiguration(MCP_URL)).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns null without fetching authorization server metadata when the issuer resolves to a private address", async () => {
+    lookupMock.mockImplementation(async (hostname: string) =>
+      hostname === "auth.example.com" ? [{ address: "192.168.1.20", family: 4 }] : [PUBLIC_ADDRESS],
+    )
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(json(resourceMetadata))
+
+    expect(await discoverOauthConfiguration(MCP_URL)).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns null when token_endpoint points at a private host", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(json(resourceMetadata))
+      .mockResolvedValueOnce(
+        json({ ...authServerMetadata, token_endpoint: "https://127.0.0.1/oauth2/token" }),
+      )
+
+    expect(await discoverOauthConfiguration(MCP_URL)).toBeNull()
   })
 })
 

--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth-discovery.ts
@@ -3,7 +3,13 @@
  * RFC 9728 (protected resource metadata), RFC 8414 (authorization server
  * metadata) and RFC 7591 (dynamic client registration). Pure functions over
  * global fetch so they can be unit-tested without Nest.
+ *
+ * Every URL fetched here is attacker-influenced (the MCP URL comes from a
+ * project member, the rest from that server's responses), so each one passes
+ * through the outbound URL guard before any request is made.
  */
+
+import { assertAllowedOutboundUrl, isAllowedOutboundUrl } from "./outbound-url-guard"
 
 export type McpOauthDiscovery = {
   authorizationEndpoint: string
@@ -20,20 +26,14 @@ const OAUTH_FETCH_TIMEOUT_MS = 10_000
 
 /**
  * A discovered endpoint is later handed to the browser (authorization_endpoint
- * becomes a `window.location.assign` target). A hostile authorization server
- * could return a `javascript:` or `data:` URL, so every endpoint from
- * third-party JSON must be validated before use. `http:` is allowed only for
- * localhost, to keep local dev authorization servers working.
+ * becomes a `window.location.assign` target) or fetched server-side (token and
+ * registration endpoints). A hostile authorization server could return a
+ * `javascript:` or `data:` URL, or point at an internal host, so every
+ * endpoint from third-party JSON goes through the outbound URL guard. `http:`
+ * is allowed only for localhost behind MCP_OAUTH_ALLOW_INSECURE_LOCAL.
  */
-function isValidEndpointUrl(candidate: string): boolean {
-  let url: URL
-  try {
-    url = new URL(candidate)
-  } catch {
-    return false
-  }
-  if (url.protocol === "https:") return true
-  return url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+function isValidEndpointUrl(candidate: string): Promise<boolean> {
+  return isAllowedOutboundUrl(candidate)
 }
 
 type ProtectedResourceMetadata = {
@@ -48,14 +48,22 @@ type AuthorizationServerMetadata = {
   registration_endpoint?: string
 }
 
+/**
+ * Returns null when the server advertises no usable OAuth metadata. Throws
+ * DisallowedOutboundUrlError when the MCP URL itself is not a public https
+ * URL; callers surface that to the user since it is their input.
+ */
 export async function discoverOauthConfiguration(
   mcpUrl: string,
 ): Promise<McpOauthDiscovery | null> {
+  await assertAllowedOutboundUrl(mcpUrl)
   const resourceMetadataUrl = await probeForResourceMetadataUrl(mcpUrl)
+  if (!(await isAllowedOutboundUrl(resourceMetadataUrl))) return null
   const resourceMetadata = await fetchJson<ProtectedResourceMetadata>(resourceMetadataUrl)
   if (!resourceMetadata?.authorization_servers?.length) return null
 
   const issuer = (resourceMetadata.authorization_servers as string[])[0]!.replace(/\/$/, "")
+  if (!(await isAllowedOutboundUrl(issuer))) return null
   const serverMetadata =
     (await fetchJson<AuthorizationServerMetadata>(
       `${issuer}/.well-known/oauth-authorization-server`,
@@ -63,13 +71,14 @@ export async function discoverOauthConfiguration(
     (await fetchJson<AuthorizationServerMetadata>(`${issuer}/.well-known/openid-configuration`))
   if (!serverMetadata?.authorization_endpoint || !serverMetadata.token_endpoint) return null
   if (
-    !isValidEndpointUrl(serverMetadata.authorization_endpoint) ||
-    !isValidEndpointUrl(serverMetadata.token_endpoint)
+    !(await isValidEndpointUrl(serverMetadata.authorization_endpoint)) ||
+    !(await isValidEndpointUrl(serverMetadata.token_endpoint))
   ) {
     return null
   }
   const registrationEndpoint =
-    serverMetadata.registration_endpoint && isValidEndpointUrl(serverMetadata.registration_endpoint)
+    serverMetadata.registration_endpoint &&
+    (await isValidEndpointUrl(serverMetadata.registration_endpoint))
       ? serverMetadata.registration_endpoint
       : undefined
 

--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.spec.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.spec.ts
@@ -19,6 +19,12 @@ import { McpOauthService } from "./mcp-oauth.service"
 global.fetch = jest.fn()
 const fetchMock = global.fetch as jest.Mock
 
+// The outbound URL guard resolves every discovery host before fetching;
+// resolve the example.com fixtures to a public address.
+jest.mock("node:dns/promises", () => ({
+  lookup: jest.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]),
+}))
+
 const MCP_URL = "https://mcp.example.com/mcp"
 
 const resourceMetadata = {
@@ -211,6 +217,15 @@ describe("McpOauthService", () => {
     await expect(mcpOauthService.initiateAuthorization(mcpServer)).rejects.toThrow(
       BadRequestException,
     )
+  })
+
+  it("throws BadRequestException without any request when the MCP URL is a private host", async () => {
+    const mcpServer = await createServer({ url: "https://169.254.169.254/latest/meta-data/" })
+
+    await expect(mcpOauthService.initiateAuthorization(mcpServer)).rejects.toThrow(
+      BadRequestException,
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("throws BadRequestException when there is no registration endpoint and no stored client", async () => {

--- a/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/mcp-oauth.service.ts
@@ -11,6 +11,7 @@ import { McpServer } from "../mcp-server.entity"
 import type { McpServerConfig, McpServerOauthState } from "../mcp-server-config.types"
 import { discoverOauthConfiguration, registerOauthClient } from "./mcp-oauth-discovery"
 import { isAccessTokenExpired } from "./oauth-tokens"
+import { DisallowedOutboundUrlError } from "./outbound-url-guard"
 import { codeChallengeS256, generateCodeVerifier, generateState } from "./pkce"
 
 const PENDING_AUTH_TTL_MS = 10 * 60 * 1000
@@ -61,7 +62,14 @@ export class McpOauthService {
     const config = this.readConfig(mcpServer)
     const redirectUri = this.configService.getOrThrow<string>("MCP_OAUTH_REDIRECT_URL")
 
-    const discovery = await discoverOauthConfiguration(config.url)
+    const discovery = await discoverOauthConfiguration(config.url).catch((error: unknown) => {
+      if (error instanceof DisallowedOutboundUrlError) {
+        throw new BadRequestException(
+          "The MCP server URL must be a public https URL to use OAuth authorization.",
+        )
+      }
+      throw error
+    })
     if (!discovery) {
       throw new BadRequestException(
         "This MCP server does not advertise OAuth authorization. Use an API key instead.",

--- a/apps/api/src/domains/mcp-servers/oauth/outbound-url-guard.spec.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/outbound-url-guard.spec.ts
@@ -1,0 +1,196 @@
+import { lookup } from "node:dns/promises"
+import {
+  assertAllowedOutboundUrl,
+  DisallowedOutboundUrlError,
+  isAllowedOutboundUrl,
+  isPrivateOrLocalAddress,
+} from "./outbound-url-guard"
+
+jest.mock("node:dns/promises", () => ({ lookup: jest.fn() }))
+const lookupMock = lookup as jest.Mock
+
+const PUBLIC_V4 = { address: "93.184.216.34", family: 4 }
+const PUBLIC_V6 = { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 }
+
+describe("isPrivateOrLocalAddress", () => {
+  it.each([
+    "127.0.0.1",
+    "127.255.255.254",
+    "0.0.0.0",
+    "0.1.2.3",
+    "10.0.0.1",
+    "10.255.255.255",
+    "172.16.0.1",
+    "172.31.255.255",
+    "192.168.1.1",
+    "169.254.169.254",
+    "::",
+    "::1",
+    "[::1]",
+    "fe80::1",
+    "febf::1",
+    "fe80::1%eth0",
+    "fc00::1",
+    "fd12:3456:789a::1",
+    "::ffff:127.0.0.1",
+    "::ffff:10.0.0.1",
+    "::ffff:169.254.169.254",
+    "::ffff:7f00:1",
+    "::ffff:a9fe:a9fe",
+  ])("treats %s as private or local", (address) => {
+    expect(isPrivateOrLocalAddress(address)).toBe(true)
+  })
+
+  it.each([
+    "93.184.216.34",
+    "8.8.8.8",
+    "172.15.255.255",
+    "172.32.0.1",
+    "192.169.0.1",
+    "11.0.0.1",
+    "2606:2800:220:1:248:1893:25c8:1946",
+    "2001:db8::1",
+    "::ffff:93.184.216.34",
+    "fec0::1",
+  ])("treats %s as public", (address) => {
+    expect(isPrivateOrLocalAddress(address)).toBe(false)
+  })
+
+  it("treats unparseable input as private", () => {
+    expect(isPrivateOrLocalAddress("not-an-ip")).toBe(true)
+    expect(isPrivateOrLocalAddress("")).toBe(true)
+  })
+})
+
+describe("assertAllowedOutboundUrl", () => {
+  const originalFlag = process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL
+
+  beforeEach(() => {
+    lookupMock.mockReset()
+    lookupMock.mockResolvedValue([PUBLIC_V4, PUBLIC_V6])
+    delete process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL
+  })
+
+  afterAll(() => {
+    if (originalFlag === undefined) delete process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL
+    else process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL = originalFlag
+  })
+
+  it("accepts an https URL whose host resolves to public addresses", async () => {
+    await expect(assertAllowedOutboundUrl("https://mcp.example.com/mcp")).resolves.toBeUndefined()
+    expect(lookupMock).toHaveBeenCalledWith("mcp.example.com", { all: true })
+  })
+
+  it.each([
+    "javascript:alert(1)//",
+    "data:text/html,<script>evil()</script>",
+    "ftp://mcp.example.com/",
+    "http://mcp.example.com/mcp",
+    "not a url",
+  ])("rejects %s by scheme without resolving DNS", async (candidate) => {
+    await expect(assertAllowedOutboundUrl(candidate)).rejects.toBeInstanceOf(
+      DisallowedOutboundUrlError,
+    )
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    "https://127.0.0.1/",
+    "https://10.1.2.3/",
+    "https://172.20.0.1/",
+    "https://192.168.0.10/",
+    "https://169.254.169.254/latest/meta-data/",
+    "https://0.0.0.0/",
+    "https://[::1]/",
+    "https://[fe80::1]/",
+    "https://[fd00::1]/",
+    "https://[::ffff:127.0.0.1]/",
+  ])("rejects the literal private host in %s without resolving DNS", async (candidate) => {
+    await expect(assertAllowedOutboundUrl(candidate)).rejects.toBeInstanceOf(
+      DisallowedOutboundUrlError,
+    )
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+
+  it("accepts a literal public IP host", async () => {
+    await expect(assertAllowedOutboundUrl("https://93.184.216.34/")).resolves.toBeUndefined()
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects a hostname that resolves to a private address", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.5", family: 4 }])
+    await expect(assertAllowedOutboundUrl("https://internal.example.com/")).rejects.toThrow(
+      /private or local/,
+    )
+  })
+
+  it("rejects a hostname when any one of its addresses is private", async () => {
+    lookupMock.mockResolvedValue([PUBLIC_V4, { address: "::ffff:169.254.169.254", family: 6 }])
+    await expect(assertAllowedOutboundUrl("https://mixed.example.com/")).rejects.toThrow(
+      /private or local/,
+    )
+  })
+
+  it("rejects a hostname that does not resolve", async () => {
+    lookupMock.mockRejectedValue(Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" }))
+    await expect(assertAllowedOutboundUrl("https://missing.example.com/")).rejects.toThrow(
+      /could not be resolved/,
+    )
+  })
+
+  it("rejects https://localhost without the insecure-local flag", async () => {
+    lookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }])
+    await expect(assertAllowedOutboundUrl("https://localhost:4000/")).rejects.toBeInstanceOf(
+      DisallowedOutboundUrlError,
+    )
+  })
+
+  describe("with MCP_OAUTH_ALLOW_INSECURE_LOCAL=true", () => {
+    beforeEach(() => {
+      process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL = "true"
+    })
+
+    it.each([
+      "http://localhost:4000/",
+      "http://127.0.0.1:4000/",
+      "http://[::1]:4000/",
+    ])("accepts %s", async (candidate) => {
+      await expect(assertAllowedOutboundUrl(candidate)).resolves.toBeUndefined()
+      expect(lookupMock).not.toHaveBeenCalled()
+    })
+
+    it("still rejects http for any other host", async () => {
+      await expect(assertAllowedOutboundUrl("http://mcp.example.com/")).rejects.toBeInstanceOf(
+        DisallowedOutboundUrlError,
+      )
+    })
+
+    it("still rejects private addresses other than loopback", async () => {
+      await expect(assertAllowedOutboundUrl("https://10.0.0.5/")).rejects.toBeInstanceOf(
+        DisallowedOutboundUrlError,
+      )
+      await expect(assertAllowedOutboundUrl("http://169.254.169.254/")).rejects.toBeInstanceOf(
+        DisallowedOutboundUrlError,
+      )
+    })
+
+    it("still rejects non-http schemes on localhost", async () => {
+      await expect(assertAllowedOutboundUrl("javascript://localhost/")).rejects.toBeInstanceOf(
+        DisallowedOutboundUrlError,
+      )
+    })
+  })
+})
+
+describe("isAllowedOutboundUrl", () => {
+  beforeEach(() => {
+    lookupMock.mockReset()
+    lookupMock.mockResolvedValue([PUBLIC_V4])
+  })
+
+  it("returns true for an allowed URL and false for a disallowed one", async () => {
+    expect(await isAllowedOutboundUrl("https://auth.example.com/authorize")).toBe(true)
+    expect(await isAllowedOutboundUrl("https://192.168.0.1/authorize")).toBe(false)
+    expect(await isAllowedOutboundUrl("javascript:alert(1)//")).toBe(false)
+  })
+})

--- a/apps/api/src/domains/mcp-servers/oauth/outbound-url-guard.ts
+++ b/apps/api/src/domains/mcp-servers/oauth/outbound-url-guard.ts
@@ -1,0 +1,175 @@
+/**
+ * SSRF guard for outbound requests whose destination comes from user input
+ * or from a third-party server's response (MCP URL, OAuth discovery
+ * documents). Rejects anything that is not public https, resolving hostnames
+ * through DNS so a public name pointing at an internal address is caught too.
+ *
+ * Set MCP_OAUTH_ALLOW_INSECURE_LOCAL=true in local development to keep
+ * http://localhost servers working; the flag never relaxes the check for any
+ * other host.
+ */
+
+import { lookup } from "node:dns/promises"
+import { isIP } from "node:net"
+
+export class DisallowedOutboundUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DisallowedOutboundUrlError"
+  }
+}
+
+const LOCALHOST_NAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"])
+
+function isInsecureLocalAllowed(): boolean {
+  return process.env.MCP_OAUTH_ALLOW_INSECURE_LOCAL === "true"
+}
+
+function isLocalhostName(hostname: string): boolean {
+  return LOCALHOST_NAMES.has(hostname.toLowerCase())
+}
+
+function parseIpv4(address: string): number[] | null {
+  const octets = address.split(".")
+  if (octets.length !== 4) return null
+  const values = octets.map((octet) => (/^\d{1,3}$/.test(octet) ? Number(octet) : Number.NaN))
+  return values.every((value) => value >= 0 && value <= 255) ? values : null
+}
+
+function isPrivateIpv4(octets: number[]): boolean {
+  const [first, second] = octets as [number, number, number, number]
+  if (first === 0) return true // 0.0.0.0/8 (unspecified, "this host")
+  if (first === 10) return true // RFC 1918
+  if (first === 127) return true // loopback
+  if (first === 169 && second === 254) return true // link-local, cloud metadata
+  if (first === 172 && second >= 16 && second <= 31) return true // RFC 1918
+  if (first === 192 && second === 168) return true // RFC 1918
+  return false
+}
+
+/** Expands an IPv6 literal into its eight 16-bit groups, or null if malformed. */
+function parseIpv6(address: string): number[] | null {
+  let text = address
+  // Trailing dotted-quad form (::ffff:127.0.0.1): fold it into two hex groups.
+  const lastColon = text.lastIndexOf(":")
+  const tail = text.slice(lastColon + 1)
+  if (tail.includes(".")) {
+    const octets = parseIpv4(tail)
+    if (!octets) return null
+    const [a, b, c, d] = octets as [number, number, number, number]
+    text = `${text.slice(0, lastColon + 1)}${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`
+  }
+  const halves = text.split("::")
+  if (halves.length > 2) return null
+  const toGroups = (part: string): number[] | null => {
+    if (part === "") return []
+    const groups = part
+      .split(":")
+      .map((group) => (/^[0-9a-f]{1,4}$/i.test(group) ? Number.parseInt(group, 16) : Number.NaN))
+    return groups.some(Number.isNaN) ? null : groups
+  }
+  const head = toGroups(halves[0] ?? "")
+  const rest = halves.length === 2 ? toGroups(halves[1] ?? "") : []
+  if (!head || !rest) return null
+  const missing = 8 - head.length - rest.length
+  if (halves.length === 2 ? missing < 1 : missing !== 0) return null
+  return [...head, ...new Array<number>(missing).fill(0), ...rest]
+}
+
+function isPrivateIpv6(groups: number[]): boolean {
+  const [g0, g1, g2, g3, g4, g5, g6, g7] = groups as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ]
+  const isMapped = g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0xffff
+  if (isMapped) {
+    return isPrivateIpv4([g6 >> 8, g6 & 0xff, g7 >> 8, g7 & 0xff])
+  }
+  const allZeroPrefix =
+    g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0 && g6 === 0
+  if (allZeroPrefix && (g7 === 0 || g7 === 1)) return true // :: and ::1
+  if ((g0 & 0xffc0) === 0xfe80) return true // fe80::/10 link-local
+  if ((g0 & 0xfe00) === 0xfc00) return true // fc00::/7 unique-local
+  return false
+}
+
+/**
+ * True for loopback, unspecified, RFC 1918, link-local, unique-local and
+ * IPv4-mapped equivalents. Unparseable input counts as private so a malformed
+ * literal is never fetched.
+ */
+export function isPrivateOrLocalAddress(address: string): boolean {
+  const bare = address.startsWith("[") && address.endsWith("]") ? address.slice(1, -1) : address
+  const zoneStripped = bare.split("%")[0] ?? bare
+  const family = isIP(zoneStripped)
+  if (family === 4) {
+    const octets = parseIpv4(zoneStripped)
+    return octets ? isPrivateIpv4(octets) : true
+  }
+  if (family === 6) {
+    const groups = parseIpv6(zoneStripped)
+    return groups ? isPrivateIpv6(groups) : true
+  }
+  return true
+}
+
+/**
+ * Throws DisallowedOutboundUrlError unless `candidate` is an https URL whose
+ * host resolves only to public addresses. With
+ * MCP_OAUTH_ALLOW_INSECURE_LOCAL=true, http and loopback are also accepted
+ * for localhost, 127.0.0.1 and ::1 only.
+ */
+export async function assertAllowedOutboundUrl(candidate: string): Promise<void> {
+  let url: URL
+  try {
+    url = new URL(candidate)
+  } catch {
+    throw new DisallowedOutboundUrlError("URL is not parseable")
+  }
+  const hostname = url.hostname
+  if (isInsecureLocalAllowed() && isLocalhostName(hostname)) {
+    if (url.protocol === "https:" || url.protocol === "http:") return
+    throw new DisallowedOutboundUrlError(`URL scheme ${url.protocol} is not allowed`)
+  }
+  if (url.protocol !== "https:") {
+    throw new DisallowedOutboundUrlError(`URL scheme ${url.protocol} is not allowed`)
+  }
+  if (hostname === "") throw new DisallowedOutboundUrlError("URL has no host")
+
+  if (isIP(hostname.replace(/^\[|\]$/g, "")) !== 0) {
+    if (isPrivateOrLocalAddress(hostname)) {
+      throw new DisallowedOutboundUrlError(`Host ${hostname} is a private or local address`)
+    }
+    return
+  }
+
+  let addresses: { address: string }[]
+  try {
+    addresses = await lookup(hostname, { all: true })
+  } catch {
+    throw new DisallowedOutboundUrlError(`Host ${hostname} could not be resolved`)
+  }
+  if (addresses.length === 0) {
+    throw new DisallowedOutboundUrlError(`Host ${hostname} could not be resolved`)
+  }
+  if (addresses.some((entry) => isPrivateOrLocalAddress(entry.address))) {
+    throw new DisallowedOutboundUrlError(`Host ${hostname} resolves to a private or local address`)
+  }
+}
+
+/** Boolean form of assertAllowedOutboundUrl for callers that skip rather than fail. */
+export async function isAllowedOutboundUrl(candidate: string): Promise<boolean> {
+  try {
+    await assertAllowedOutboundUrl(candidate)
+    return true
+  } catch (error) {
+    if (error instanceof DisallowedOutboundUrlError) return false
+    throw error
+  }
+}


### PR DESCRIPTION
## Problem

OAuth discovery fetches the URL a project member enters as the MCP server, then the `resource_metadata` URL and `authorization_servers` issuer that server names, with only a scheme check on the final endpoints. That check also accepted plain http for localhost in every environment. A member with create rights could point discovery at loopback, RFC 1918, link-local (cloud instance metadata at 169.254.169.254) or other internal hosts as a blind SSRF probe.

## Fix

New `apps/api/src/domains/mcp-servers/oauth/outbound-url-guard.ts` (Node built-ins only, no new dependency): `assertAllowedOutboundUrl` requires https, resolves the hostname with `dns.lookup(host, { all: true })`, and rejects literal or resolved addresses in `0.0.0.0/8`, `127/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `::`, `::1`, `fe80::/10`, `fc00::/7` and their IPv4-mapped IPv6 forms. Unresolvable hosts are rejected too. Discovery applies it to the MCP URL before the probe (a rejection surfaces as a 400 with a clear message), to the resource metadata URL, to the discovered issuer before the well-known URLs are built, and to every discovered endpoint through `isValidEndpointUrl`.

The http localhost exception now sits behind a new env flag, `MCP_OAUTH_ALLOW_INSECURE_LOCAL=true` (documented in `apps/api/.env-example`). With it set, http and loopback are accepted for `localhost`, `127.0.0.1` and `::1` only; nothing changes for other hosts.

Out of scope, to be done as a follow-up: applying the same guard to the MCP client's own connection to the server URL, and the DNS rebinding window between this check and the fetch (would need address pinning in the fetch dispatcher).

## Testing

`npm run biome:check` (pass), `npm run typecheck` (pass), `npm run check:boundaries` in `apps/api` (pass), and the `src/domains/mcp-servers` API specs: 14 suites, 264 tests passing, including 62 new guard unit tests and 6 new discovery tests (private-host and http MCP URLs rejected before any fetch, private issuer and endpoints dropped, localhost http gated by the flag).

Addresses https://github.com/bayesimpact/bayes-platform/pull/710#discussion_r3915186685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
