### PR TITLE
fix(agent-sessions): load MCP App card HTML after the transcript, with a per-card placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.
 - (beta) PDF export: the built-in server disappears from workspaces when the export feature is turned off.
 - (beta) MCP App cards no longer reload when a sibling card in the same reply fails to render.
 - (beta) PDF export: when the download card cannot load, the reply shows the export result as text.

--- a/apps/api/src/domains/agents/shared/agent-session-messages/agent-message.helpers.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/agent-message.helpers.spec.ts
@@ -1,8 +1,36 @@
 import type { AgentMessage } from "./agent-message.entity"
-import { applyLiveMcpAppHtml, mcpAppHtmlCacheKey, toDto, toDtos } from "./agent-message.helpers"
+import {
+  applyLiveMcpAppHtml,
+  mcpAppHtmlCacheKey,
+  toDto,
+  toDtos,
+  toMcpAppHtmlDtos,
+} from "./agent-message.helpers"
 
 const resourceUri = "ui://patient-summary/mcp-app.html"
 const mcpServerId = "mcp-server-1"
+
+describe("toMcpAppHtmlDtos", () => {
+  it("splits each cache key back into the server and uri the client matches on", () => {
+    const htmlByKey = new Map([
+      [mcpAppHtmlCacheKey(mcpServerId, resourceUri), "<html>card</html>"],
+      [mcpAppHtmlCacheKey("mcp-server-2", "ui://other/app.html"), "<html>other</html>"],
+    ])
+
+    expect(toMcpAppHtmlDtos(htmlByKey)).toEqual([
+      { mcpServerId, resourceUri, html: "<html>card</html>" },
+      {
+        mcpServerId: "mcp-server-2",
+        resourceUri: "ui://other/app.html",
+        html: "<html>other</html>",
+      },
+    ])
+  })
+
+  it("returns nothing when no card could be read", () => {
+    expect(toMcpAppHtmlDtos(new Map())).toEqual([])
+  })
+})
 
 describe("applyLiveMcpAppHtml", () => {
   it("hydrates live HTML onto the persisted MCP App pointer", () => {
@@ -109,6 +137,23 @@ describe("toDto", () => {
       ],
       attachmentDocumentId: undefined,
     })
+  })
+
+  it("keeps the MCP App pointer without HTML when no live map is given", () => {
+    // The message list is served without HTML: the client loads it separately so the
+    // transcript never waits on an MCP server.
+    const message = buildMessage({
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "get_patient",
+          arguments: {},
+          mcpApp: { mcpServerId, resourceUri },
+        },
+      ],
+    })
+
+    expect(toDto(message).toolCalls?.[0]?.mcpApp).toEqual({ mcpServerId, resourceUri })
   })
 
   it("throws when agent settings are not loaded", () => {

--- a/apps/api/src/domains/agents/shared/agent-session-messages/agent-message.helpers.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/agent-message.helpers.ts
@@ -1,8 +1,30 @@
-import type { AgentSessionMessageDto, AgentSessionToolCallDto } from "@caseai-connect/api-contracts"
+import type {
+  AgentSessionMcpAppHtmlDto,
+  AgentSessionMessageDto,
+  AgentSessionToolCallDto,
+} from "@caseai-connect/api-contracts"
 import type { AgentMessage, AgentMessageToolCall } from "./agent-message.entity"
 
+const MCP_APP_HTML_CACHE_KEY_SEPARATOR = "::"
+
 export function mcpAppHtmlCacheKey(mcpServerId: string, resourceUri: string): string {
-  return `${mcpServerId}::${resourceUri}`
+  return `${mcpServerId}${MCP_APP_HTML_CACHE_KEY_SEPARATOR}${resourceUri}`
+}
+
+/**
+ * The live HTML map as the client receives it: one entry per server and `ui://` the
+ * transcript points at. The client matches each tool call's pointer against it.
+ */
+export function toMcpAppHtmlDtos(htmlByKey: Map<string, string>): AgentSessionMcpAppHtmlDto[] {
+  return [...htmlByKey].map(([cacheKey, html]) => {
+    // A server id is a uuid and never contains the separator, so the first one splits the key.
+    const separatorIndex = cacheKey.indexOf(MCP_APP_HTML_CACHE_KEY_SEPARATOR)
+    return {
+      mcpServerId: cacheKey.slice(0, separatorIndex),
+      resourceUri: cacheKey.slice(separatorIndex + MCP_APP_HTML_CACHE_KEY_SEPARATOR.length),
+      html,
+    }
+  })
 }
 
 function liveHtmlForMcpApp(

--- a/apps/api/src/domains/agents/shared/agent-session-messages/agent-messages.controller.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/agent-messages.controller.ts
@@ -35,7 +35,7 @@ import { UserGuard } from "@/domains/users/user.guard"
 import type { ConversationAgentSession } from "../../conversation-agent-sessions/conversation-agent-session.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { ConversationAgentSessionsService } from "../../conversation-agent-sessions/conversation-agent-sessions.service"
-import { toDto, toDtos } from "./agent-message.helpers"
+import { toDto, toDtos, toMcpAppHtmlDtos } from "./agent-message.helpers"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { AgentMessageAttachmentDocumentsService } from "./agent-message-attachment-documents.service"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
@@ -64,12 +64,28 @@ export class AgentMessagesController {
       agentSessionId,
       connectScope,
     })
+    // MCP App HTML is served by `getMcpAppHtml`: reading it connects to every MCP server the
+    // transcript points at, which used to hold the whole thread behind a spinner.
+    return { data: toDtos(messages) }
+  }
+
+  @CheckPolicy((policy) => policy.canList())
+  @Post(AgentSessionMessagesRoutes.getMcpAppHtml.path)
+  async getMcpAppHtml(
+    @Req() request: EndpointRequestWithAgentSession<ConversationAgentSession>,
+  ): Promise<typeof AgentSessionMessagesRoutes.getMcpAppHtml.response> {
+    const connectScope = getRequiredConnectScope(request)
+    const agentSessionId = request.agentSession.id
+    const messages = await this.conversationAgentSessionsService.listMessagesForSession({
+      agentSessionId,
+      connectScope,
+    })
     const htmlByKey = await this.mcpAppHtmlService.readLiveHtml({
       agentId: request.agent.id,
       sessionId: agentSessionId,
       messages,
     })
-    return { data: toDtos(messages, htmlByKey) }
+    return { data: toMcpAppHtmlDtos(htmlByKey) }
   }
 
   @CheckPolicy((policy) => policy.canList())
@@ -87,17 +103,9 @@ export class AgentMessagesController {
     if (!message) {
       throw new NotFoundException("Message not found")
     }
-    // The client polls this while a reply is still being written and discards the snapshot
-    // unless it has settled, so the MCP markup is only worth fetching for a settled reply.
-    const htmlByKey =
-      message.status === "streaming"
-        ? new Map<string, string>()
-        : await this.mcpAppHtmlService.readLiveHtml({
-            agentId: request.agent.id,
-            sessionId: request.agentSession.id,
-            messages: [message],
-          })
-    return { data: toDto(message, htmlByKey) }
+    // The client polls this while a reply is still being written; the MCP App HTML it may
+    // need once settled is loaded through `getMcpAppHtml`, off the polling path.
+    return { data: toDto(message) }
   }
 
   @CheckPolicy((policy) => policy.canCreate())

--- a/apps/api/src/domains/agents/shared/agent-session-messages/e2e-tests/get-mcp-app-html.spec.ts
+++ b/apps/api/src/domains/agents/shared/agent-session-messages/e2e-tests/get-mcp-app-html.spec.ts
@@ -1,0 +1,147 @@
+import { AgentSessionMessagesRoutes } from "@caseai-connect/api-contracts"
+import type { INestApplication } from "@nestjs/common"
+import type { App } from "supertest/types"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { removeNullish } from "@/common/utils/remove-nullish"
+import { ConversationAgentSessionsModule } from "@/domains/agents/conversation-agent-sessions/conversation-agent-sessions.module"
+import { createOrganizationWithAgentSession } from "@/domains/organizations/organization.factory"
+import { setupUserGuardForTesting } from "../../../../../../test/e2e.helpers"
+import { type Requester, testRequester } from "../../../../../../test/request"
+import { agentMessageFactory, createChitChatConversation } from "../agent-messages.factory"
+import { McpAppHtmlService } from "../mcp-app-html.service"
+
+const resourceUri = "ui://pdf-export/mcp-app.html"
+
+describe("AgentSessionMessagesRoutes.getMcpAppHtml", () => {
+  let app: INestApplication<App>
+  let request: Requester
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  let repositories: AllRepositories
+  const readLiveHtml = jest.fn()
+
+  let organizationId: string
+  let projectId: string
+  let agentId: string
+  let agentSessionId: string
+  const accessToken = "token"
+  let auth0Id = "auth0|123"
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [ConversationAgentSessionsModule],
+      applyOverrides: (moduleBuilder) =>
+        setupUserGuardForTesting(moduleBuilder, () => auth0Id)
+          .overrideProvider(McpAppHtmlService)
+          .useValue({ readLiveHtml }),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+    request = testRequester(app)
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    readLiveHtml.mockReset()
+    readLiveHtml.mockResolvedValue(new Map())
+    auth0Id = "auth0|123"
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await app.close()
+  })
+
+  const createContext = async () => {
+    const { organization, user, project, agent, agentSettings, agentSession } =
+      await createOrganizationWithAgentSession({ repositories, agentType: "conversation" })
+
+    await createChitChatConversation(organization, project, agentSession, agentSettings, {
+      agentMessageRepository: repositories.agentMessageRepository,
+    })
+
+    organizationId = organization.id
+    projectId = project.id
+    agentId = agent.id
+    agentSessionId = agentSession.id
+    auth0Id = user.auth0Id
+
+    return { organization, user, project, agent, agentSettings, agentSession }
+  }
+
+  const listMessages = async () =>
+    request({
+      route: AgentSessionMessagesRoutes.getAll,
+      pathParams: removeNullish({ organizationId, projectId, agentId, agentSessionId }),
+      token: accessToken,
+      request: { payload: { type: "live" } },
+    })
+
+  const subject = async () =>
+    request({
+      route: AgentSessionMessagesRoutes.getMcpAppHtml,
+      pathParams: removeNullish({ organizationId, projectId, agentId, agentSessionId }),
+      token: accessToken,
+      request: { payload: { type: "live" } },
+    })
+
+  it("returns the message list without reading any MCP server", async () => {
+    await createContext()
+
+    const response = await listMessages()
+
+    expect(response.status).toBe(201)
+    expect(response.body.data).toHaveLength(2)
+    expect(readLiveHtml).not.toHaveBeenCalled()
+  })
+
+  it("returns the current HTML of each card the session points at", async () => {
+    const { organization, project, agentSettings, agentSession, agent } = await createContext()
+    const mcpServerId = "11111111-1111-4111-8111-111111111111"
+    const reply = agentMessageFactory
+      .assistant()
+      .transient({ organization, project, session: agentSession, agentSettings })
+      .build({
+        content: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            name: "export_pdf",
+            arguments: {},
+            result: { content: [{ type: "text", text: "Exported" }] },
+            mcpApp: { mcpServerId, resourceUri },
+          },
+        ],
+      })
+    await repositories.agentMessageRepository.save(reply)
+    readLiveHtml.mockResolvedValue(
+      new Map([[`${mcpServerId}::${resourceUri}`, "<html>card</html>"]]),
+    )
+
+    const response = await subject()
+
+    expect(response.status).toBe(201)
+    expect(response.body.data).toEqual([{ mcpServerId, resourceUri, html: "<html>card</html>" }])
+    expect(readLiveHtml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: agent.id,
+        sessionId: agentSession.id,
+        messages: expect.arrayContaining([expect.objectContaining({ id: reply.id })]),
+      }),
+    )
+  })
+
+  it("returns an empty list when the session has no MCP App card", async () => {
+    await createContext()
+
+    const response = await subject()
+
+    expect(response.status).toBe(201)
+    expect(response.body.data).toEqual([])
+  })
+})

--- a/apps/api/src/domains/public-chat/e2e-tests/auth.spec.ts
+++ b/apps/api/src/domains/public-chat/e2e-tests/auth.spec.ts
@@ -186,4 +186,44 @@ describe("PublicChat - Auth", () => {
       expect(response.status).toBe(200)
     })
   })
+
+  // ──────────────────────────────────────────────────
+  // GET /public/agents/:embedToken/sessions/:sessionId/mcp-app-html
+  // ──────────────────────────────────────────────────
+  describe("getMcpAppHtml", () => {
+    const subject = () =>
+      request(app.getHttpServer())
+        .get(`/public/agents/${embedToken}/sessions/${sessionId}/mcp-app-html`)
+        .set("Connection", "close")
+        .set("X-Session-Token", sessionToken ?? "")
+
+    it("returns 401 when embedToken does not exist", async () => {
+      await createContext()
+      embedToken = randomUUID()
+      const response = await subject()
+      expect(response.status).toBe(401)
+    })
+
+    it("returns 401 when X-Session-Token header is missing", async () => {
+      await createContext()
+      const response = await request(app.getHttpServer())
+        .get(`/public/agents/${embedToken}/sessions/${sessionId}/mcp-app-html`)
+        .set("Connection", "close")
+      expect(response.status).toBe(401)
+    })
+
+    it("returns 401 when session token is invalid", async () => {
+      await createContext()
+      sessionToken = "wrong-token"
+      const response = await subject()
+      expect(response.status).toBe(401)
+    })
+
+    it("returns 200 with an empty list for a session without cards", async () => {
+      await createContext()
+      const response = await subject()
+      expect(response.status).toBe(200)
+      expect(response.body.data).toEqual([])
+    })
+  })
 })

--- a/apps/api/src/domains/public-chat/e2e-tests/get-mcp-app-html.spec.ts
+++ b/apps/api/src/domains/public-chat/e2e-tests/get-mcp-app-html.spec.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto"
+import { afterAll } from "@jest/globals"
+import type { INestApplication } from "@nestjs/common"
+import request from "supertest"
+import type { App } from "supertest/types"
+import {
+  type AllRepositories,
+  clearTestDatabase,
+  setupE2eTestDatabase,
+  teardownE2eTestDatabase,
+} from "@/common/test/test-database"
+import { McpAppHtmlService } from "@/domains/agents/shared/agent-session-messages/mcp-app-html.service"
+import { createOrganizationWithAgent } from "@/domains/organizations/organization.factory"
+import { agentEmbedConfigFactory } from "../agent-embed-configs/agent-embed-config.factory"
+import { publicAgentSessionFactory } from "../public-agent-sessions/public-agent-session.factory"
+import { PublicChatModule } from "../public-chat.module"
+
+const resourceUri = "ui://pdf-export/mcp-app.html"
+
+describe("PublicChat - getMcpAppHtml", () => {
+  let app: INestApplication<App>
+  let repositories: AllRepositories
+  let setup: Awaited<ReturnType<typeof setupE2eTestDatabase>>
+  const readLiveHtml = jest.fn()
+
+  let embedToken: string
+  let sessionId: string
+  let sessionToken: string
+
+  beforeAll(async () => {
+    setup = await setupE2eTestDatabase({
+      additionalImports: [PublicChatModule],
+      applyOverrides: (moduleBuilder) =>
+        moduleBuilder.overrideProvider(McpAppHtmlService).useValue({ readLiveHtml }),
+    })
+    repositories = setup.getAllRepositories()
+    app = setup.module.createNestApplication()
+    await app.init()
+  })
+
+  beforeEach(async () => {
+    await clearTestDatabase(setup.dataSource)
+    readLiveHtml.mockReset()
+    readLiveHtml.mockResolvedValue(new Map())
+    embedToken = randomUUID()
+    sessionId = randomUUID()
+    sessionToken = randomUUID()
+  })
+
+  afterAll(async () => {
+    await teardownE2eTestDatabase(setup)
+    await app.close()
+  })
+
+  const createContext = async () => {
+    const { organization, project, agent, agentSettings } =
+      await createOrganizationWithAgent(repositories)
+    const embedConfig = agentEmbedConfigFactory
+      .transient({ organization, project, agent })
+      .build({ isEnabled: true })
+    await repositories.agentEmbedConfigRepository.save(embedConfig)
+
+    const knownToken = randomUUID()
+    const session = publicAgentSessionFactory
+      .transient({ embedConfig, sessionToken: knownToken })
+      .build()
+    await repositories.publicAgentSessionRepository.save(session)
+
+    embedToken = embedConfig.embedToken
+    sessionId = session.id
+    sessionToken = knownToken
+
+    return { organization, project, agent, agentSettings, embedConfig, session }
+  }
+
+  const saveReplyWithCard = async (
+    context: Awaited<ReturnType<typeof createContext>>,
+    mcpServerId: string,
+  ) => {
+    await repositories.agentMessageRepository.save({
+      id: randomUUID(),
+      sessionId,
+      organizationId: context.embedConfig.organizationId,
+      projectId: context.embedConfig.projectId,
+      agentSettingsId: context.agentSettings.id,
+      role: "assistant" as const,
+      content: "",
+      status: "completed" as const,
+      startedAt: new Date("2026-01-01T10:00:01Z"),
+      completedAt: new Date("2026-01-01T10:00:02Z"),
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "export_pdf",
+          arguments: {},
+          result: { content: [{ type: "text", text: "Exported" }] },
+          mcpApp: { mcpServerId, resourceUri },
+        },
+      ],
+      documentId: null,
+      attachmentDocumentId: null,
+      createdAt: new Date("2026-01-01T10:00:01Z"),
+      updatedAt: new Date("2026-01-01T10:00:02Z"),
+      deletedAt: null,
+    })
+  }
+
+  const getSession = () =>
+    request(app.getHttpServer())
+      .get(`/public/agents/${embedToken}/sessions/${sessionId}`)
+      .set("Connection", "close")
+      .set("X-Session-Token", sessionToken)
+
+  const subject = () =>
+    request(app.getHttpServer())
+      .get(`/public/agents/${embedToken}/sessions/${sessionId}/mcp-app-html`)
+      .set("Connection", "close")
+      .set("X-Session-Token", sessionToken)
+
+  it("returns the session without reading any MCP server", async () => {
+    const context = await createContext()
+    await saveReplyWithCard(context, randomUUID())
+
+    const response = await getSession()
+
+    expect(response.status).toBe(200)
+    expect(response.body.data.messages).toHaveLength(1)
+    expect(readLiveHtml).not.toHaveBeenCalled()
+  })
+
+  it("returns the current HTML of each card the session points at", async () => {
+    const context = await createContext()
+    const mcpServerId = randomUUID()
+    await saveReplyWithCard(context, mcpServerId)
+    readLiveHtml.mockResolvedValue(
+      new Map([[`${mcpServerId}::${resourceUri}`, "<html>card</html>"]]),
+    )
+
+    const response = await subject()
+
+    expect(response.status).toBe(200)
+    expect(response.body.data).toEqual([{ mcpServerId, resourceUri, html: "<html>card</html>" }])
+    expect(readLiveHtml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: context.agent.id,
+        sessionId,
+        externalVisitorId: context.session.externalVisitorId,
+      }),
+    )
+  })
+})

--- a/apps/api/src/domains/public-chat/public-chat.controller.ts
+++ b/apps/api/src/domains/public-chat/public-chat.controller.ts
@@ -60,6 +60,14 @@ export class PublicChatController {
   }
 
   @UseGuards(PublicSessionTokenGuard)
+  @Get(PublicChatRoutes.getMcpAppHtml.path)
+  async getMcpAppHtml(
+    @Req() request: PublicChatSessionRequest,
+  ): Promise<typeof PublicChatRoutes.getMcpAppHtml.response> {
+    return { data: await this.publicChatService.getMcpAppHtml(request.publicSession) }
+  }
+
+  @UseGuards(PublicSessionTokenGuard)
   @Sse(PublicChatRoutes.streamMessages.path, { method: 0 /* GET */ })
   streamMessages(
     @Req() request: PublicChatSessionRequest,

--- a/apps/api/src/domains/public-chat/public-chat.service.spec.ts
+++ b/apps/api/src/domains/public-chat/public-chat.service.spec.ts
@@ -25,64 +25,61 @@ function buildAssistantMessage(overrides: Partial<AgentMessage> = {}): AgentMess
 }
 
 describe("PublicChatService", () => {
-  it("hydrates MCP App HTML onto public session toolCalls", async () => {
-    const session = publicAgentSessionFactory.build({ externalVisitorId: "visitor-1" })
-    const message = buildAssistantMessage({
-      content: "Here is the summary.",
-      toolCalls: [
-        {
-          id: "call-1",
-          name: "get_patient",
-          arguments: { patientId: "p-1" },
-          result: { structuredContent: { title: "Ada" } },
-          mcpApp: { mcpServerId, resourceUri },
-        },
-      ],
-    })
+  const session = publicAgentSessionFactory.build({ externalVisitorId: "visitor-1" })
+  const messageWithCard = buildAssistantMessage({
+    content: "Here is the summary.",
+    toolCalls: [
+      {
+        id: "call-1",
+        name: "get_patient",
+        arguments: { patientId: "p-1" },
+        result: { structuredContent: { title: "Ada" } },
+        mcpApp: { mcpServerId, resourceUri },
+      },
+    ],
+  })
 
-    const readLiveHtml = jest
-      .fn()
-      .mockResolvedValue(new Map([[mcpAppHtmlCacheKey(mcpServerId, resourceUri), html]]))
-    const getSessionWithMessages = jest.fn().mockResolvedValue({ session, messages: [message] })
-
-    const service = new PublicChatService(
+  function buildService(readLiveHtml: jest.Mock, messages: AgentMessage[]) {
+    return new PublicChatService(
       {} as never,
       {} as never,
       {} as never,
-      { getSessionWithMessages } as never,
+      { getSessionWithMessages: jest.fn().mockResolvedValue({ session, messages }) } as never,
       {} as never,
       { readLiveHtml } as never,
     )
+  }
+
+  it("returns the session with card pointers without reading any MCP server", async () => {
+    // The widget shows the transcript at once and loads the card HTML afterwards.
+    const readLiveHtml = jest.fn()
+    const service = buildService(readLiveHtml, [messageWithCard])
 
     const dto = await service.getSession(session)
+
+    expect(readLiveHtml).not.toHaveBeenCalled()
+    expect(dto.messages[0]?.toolCalls?.[0]?.mcpApp).toEqual({ mcpServerId, resourceUri })
+  })
+
+  it("reads the current HTML of the cards the session points at", async () => {
+    const readLiveHtml = jest
+      .fn()
+      .mockResolvedValue(new Map([[mcpAppHtmlCacheKey(mcpServerId, resourceUri), html]]))
+    const service = buildService(readLiveHtml, [messageWithCard])
+
+    const entries = await service.getMcpAppHtml(session)
 
     expect(readLiveHtml).toHaveBeenCalledWith({
       agentId: session.agentId,
       sessionId: session.id,
-      messages: [message],
+      messages: [messageWithCard],
       externalVisitorId: "visitor-1",
     })
-    expect(dto.messages[0]?.toolCalls?.[0]?.mcpApp).toEqual({
-      mcpServerId,
-      resourceUri,
-      html,
-    })
+    expect(entries).toEqual([{ mcpServerId, resourceUri, html }])
   })
 
   it("omits toolCalls when the message has none", async () => {
-    const session = publicAgentSessionFactory.build()
-    const message = buildAssistantMessage()
-
-    const service = new PublicChatService(
-      {} as never,
-      {} as never,
-      {} as never,
-      {
-        getSessionWithMessages: jest.fn().mockResolvedValue({ session, messages: [message] }),
-      } as never,
-      {} as never,
-      { readLiveHtml: jest.fn().mockResolvedValue(new Map()) } as never,
-    )
+    const service = buildService(jest.fn(), [buildAssistantMessage()])
 
     const dto = await service.getSession(session)
 

--- a/apps/api/src/domains/public-chat/public-chat.service.ts
+++ b/apps/api/src/domains/public-chat/public-chat.service.ts
@@ -1,5 +1,6 @@
 import type {
   AgentEmbedConfigDto,
+  AgentSessionMcpAppHtmlDto,
   PublicAgentSessionDto,
   PublicSessionMessageDto,
   StreamEvent,
@@ -11,7 +12,7 @@ import { Agent } from "@/domains/agents/agent.entity"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { AgentSettingsService } from "@/domains/agents/settings/agent-settings.service"
 import type { AgentMessage } from "@/domains/agents/shared/agent-session-messages/agent-message.entity"
-import { applyLiveMcpAppHtml } from "@/domains/agents/shared/agent-session-messages/agent-message.helpers"
+import { toMcpAppHtmlDtos } from "@/domains/agents/shared/agent-session-messages/agent-message.helpers"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { McpAppHtmlService } from "@/domains/agents/shared/agent-session-messages/mcp-app-html.service"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
@@ -50,13 +51,23 @@ export class PublicChatService {
     const { session, messages } = await this.publicAgentSessionsService.getSessionWithMessages(
       publicSession.id,
     )
+    // MCP App HTML is served by `getMcpAppHtml`: reading it connects to every MCP server the
+    // transcript points at, which used to hold the whole widget behind its loading shell.
+    return this.toSessionDto(session, messages)
+  }
+
+  /** Current HTML of every MCP App card the session's replies point at. */
+  async getMcpAppHtml(publicSession: PublicAgentSession): Promise<AgentSessionMcpAppHtmlDto[]> {
+    const { session, messages } = await this.publicAgentSessionsService.getSessionWithMessages(
+      publicSession.id,
+    )
     const htmlByKey = await this.mcpAppHtmlService.readLiveHtml({
       agentId: session.agentId,
       sessionId: session.id,
       messages,
       externalVisitorId: session.externalVisitorId,
     })
-    return this.toSessionDto(session, messages, htmlByKey)
+    return toMcpAppHtmlDtos(htmlByKey)
   }
 
   async *streamResponse(
@@ -120,7 +131,6 @@ export class PublicChatService {
   private toSessionDto(
     session: PublicAgentSession,
     messages: AgentMessage[],
-    htmlByKey: Map<string, string> = new Map(),
   ): PublicAgentSessionDto {
     return {
       id: session.id,
@@ -132,7 +142,7 @@ export class PublicChatService {
           content: message.content,
           status: message.status ?? undefined,
           createdAt: message.createdAt.getTime(),
-          toolCalls: applyLiveMcpAppHtml(message.toolCalls, htmlByKey),
+          toolCalls: message.toolCalls ?? undefined,
         }),
       ),
       createdAt: session.createdAt.getTime(),

--- a/apps/web-embed/src/App.tsx
+++ b/apps/web-embed/src/App.tsx
@@ -115,7 +115,8 @@ function LiveChat({
     logoUrl: remoteConfig?.logoUrl ?? undefined,
   }
 
-  const { status, messages, isStreaming, errorKey, send, reset } = usePublicChat(embedToken)
+  const { status, messages, mcpAppHtml, isMcpAppHtmlLoading, isStreaming, errorKey, send, reset } =
+    usePublicChat(embedToken)
 
   useEffect(() => {
     function onMessage(event: MessageEvent) {
@@ -150,6 +151,8 @@ function LiveChat({
       displayMode={displayMode}
       hideHeader={hideHeader}
       messages={messages}
+      mcpAppHtml={mcpAppHtml}
+      isMcpAppHtmlLoading={isMcpAppHtmlLoading}
       isStreaming={isStreaming}
       onSendMessage={send}
       onClose={onClose}

--- a/apps/web-embed/src/api/public-chat-api.ts
+++ b/apps/web-embed/src/api/public-chat-api.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentSessionMcpAppHtmlDto,
   EmbedPublicConfigDto,
   PublicAgentSessionDto,
   StreamEventPayload,
@@ -41,6 +42,24 @@ export async function getSession(
   })
   if (!response.ok) throw new ApiError(response.status, "Failed to load session")
   const json = (await response.json()) as { data: PublicAgentSessionDto }
+  return json.data
+}
+
+/**
+ * Current HTML of the MCP App cards the session points at. Separate from `getSession` because
+ * the server has to contact each MCP server, which must not delay the transcript.
+ */
+export async function getMcpAppHtml(
+  embedToken: string,
+  sessionId: string,
+  sessionToken: string,
+): Promise<AgentSessionMcpAppHtmlDto[]> {
+  const response = await fetch(
+    `${API_BASE}/public/agents/${embedToken}/sessions/${sessionId}/mcp-app-html`,
+    { headers: { "X-Session-Token": sessionToken } },
+  )
+  if (!response.ok) throw new ApiError(response.status, "Failed to load MCP App cards")
+  const json = (await response.json()) as { data: AgentSessionMcpAppHtmlDto[] }
   return json.data
 }
 

--- a/apps/web-embed/src/chat/EmbedChat.stories.tsx
+++ b/apps/web-embed/src/chat/EmbedChat.stories.tsx
@@ -4,6 +4,7 @@ import {
   buildStreamingMessage,
   emptyConversation,
   failedMcpAppCardConversation,
+  loadingMcpAppCardConversation,
   longConversation,
   markdownConversation,
   resourceCardsConversation,
@@ -107,6 +108,14 @@ export const ErrorState: Story = {
       { id: "user-err", role: "user", content: "This will fail.", status: "completed" },
       buildErrorMessage(),
     ],
+  },
+}
+
+export const LoadingMcpAppCard: Story = {
+  name: "MCP App card loading",
+  args: {
+    messages: loadingMcpAppCardConversation,
+    isMcpAppHtmlLoading: true,
   },
 }
 

--- a/apps/web-embed/src/chat/EmbedChat.tsx
+++ b/apps/web-embed/src/chat/EmbedChat.tsx
@@ -1,4 +1,8 @@
-import type { AgentSessionMessageDto, EmbedDisplayMode } from "@caseai-connect/api-contracts"
+import type {
+  AgentSessionMcpAppHtmlDto,
+  AgentSessionMessageDto,
+  EmbedDisplayMode,
+} from "@caseai-connect/api-contracts"
 import { useEffect, useMemo, useRef } from "react"
 import { I18nextProvider, useTranslation } from "react-i18next"
 import type { SupportedLocale } from "../i18n"
@@ -34,6 +38,10 @@ export type EmbedChatProps = {
   displayMode?: EmbedDisplayMode
   /** All messages to display, in order */
   messages: AgentSessionMessageDto[]
+  /** Current HTML of the MCP App cards in the thread, loaded after the messages. */
+  mcpAppHtml?: AgentSessionMcpAppHtmlDto[]
+  /** The MCP servers have not answered yet: cards without HTML show a placeholder. */
+  isMcpAppHtmlLoading?: boolean
   /** Whether the assistant is currently streaming a response */
   isStreaming: boolean
   /** Called when the user submits a message */
@@ -71,6 +79,8 @@ function EmbedChatInner({
   theme,
   displayMode = "modal",
   messages,
+  mcpAppHtml = [],
+  isMcpAppHtmlLoading = false,
   isStreaming,
   onSendMessage,
   placeholder,
@@ -110,7 +120,12 @@ function EmbedChatInner({
 
       <ChatContent>
         {messages.map((message) => (
-          <ChatMessage key={message.id} message={message} />
+          <ChatMessage
+            key={message.id}
+            message={message}
+            mcpAppHtml={mcpAppHtml}
+            isMcpAppHtmlLoading={isMcpAppHtmlLoading}
+          />
         ))}
         <div ref={chatEndRef} />
       </ChatContent>

--- a/apps/web-embed/src/chat/chat.factory.ts
+++ b/apps/web-embed/src/chat/chat.factory.ts
@@ -170,6 +170,28 @@ export const resourceCardsOnlyConversation: AgentSessionMessageDto[] = [
 ]
 
 /**
+ * A reply whose MCP App card HTML is still being read from the MCP server: the transcript is on
+ * screen and the card holds its place with a placeholder.
+ */
+export const loadingMcpAppCardConversation: AgentSessionMessageDto[] = [
+  buildUserMessage("Export these notes as a PDF."),
+  buildAssistantMessage("", {
+    toolCalls: [
+      {
+        id: "call-pdf-export",
+        name: "export_pdf",
+        arguments: { markdown: "# Notes" },
+        result: {
+          content: [{ type: "text", text: "Created Notes.pdf (2 pages)." }],
+          structuredContent: { fileName: "Notes.pdf" },
+        },
+        mcpApp: { mcpServerId: "mcp-server-1", resourceUri: "ui://pdf-export/mcp-app.html" },
+      },
+    ],
+  }),
+]
+
+/**
  * A reply with no prose whose MCP App card never completes its handshake. The card gives up
  * after its 15 s initialization timeout and the tool result text takes its place in the bubble.
  */

--- a/apps/web-embed/src/chat/components/ChatMessage.tsx
+++ b/apps/web-embed/src/chat/components/ChatMessage.tsx
@@ -1,49 +1,76 @@
-import type { AgentSessionMessageDto } from "@caseai-connect/api-contracts"
+import type {
+  AgentSessionMcpAppHtmlDto,
+  AgentSessionMessageDto,
+} from "@caseai-connect/api-contracts"
 import { AlertCircleIcon, CopyIcon } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { cn } from "../lib/cn"
 import { ChatBotMessage, ChatUserMessage } from "./index"
 import { MarkdownWrapper } from "./MarkdownWrapper"
-import { McpAppView } from "./McpAppView"
-import { getFailedMcpAppFallbackText, getRenderableMcpApp } from "./mcp-app-view"
+import { McpAppPlaceholder, McpAppView } from "./McpAppView"
+import { getFailedMcpAppFallbackText, getRenderableMcpApp, hasMcpAppCard } from "./mcp-app-view"
 import { findSourcesTool, SourcesTool } from "./SourcesTool"
+import { Spinner } from "./Spinner"
 import {
   findSurfaceResourcesTool,
   hasSurfacedResources,
   SurfaceResourcesTool,
 } from "./SurfaceResourcesTool"
 
-export function ChatMessage({ message }: { message: AgentSessionMessageDto }) {
+export function ChatMessage({
+  message,
+  mcpAppHtml = [],
+  isMcpAppHtmlLoading = false,
+}: {
+  message: AgentSessionMessageDto
+  /** Current HTML of the MCP App cards in the thread, loaded after the messages. */
+  mcpAppHtml?: AgentSessionMcpAppHtmlDto[]
+  /** The MCP servers have not answered yet: cards without HTML hold their place. */
+  isMcpAppHtmlLoading?: boolean
+}) {
   // MCP App cards that gave up rendering; their reply text is shown instead.
   const [failedMcpAppToolCallIds, setFailedMcpAppToolCallIds] = useState<string[]>([])
 
   switch (message.role) {
     case "assistant": {
       const isStreaming = message.status === "streaming"
-      const mcpAppViews = (message.toolCalls ?? []).flatMap((toolCall) => {
-        const view = getRenderableMcpApp(toolCall)
-        return view ? [{ toolCall, view }] : []
-      })
+      // Every card this reply shows, with its view once the HTML is here. A card without a view
+      // is either still loading (placeholder) or unavailable (its text stands in).
+      const mcpAppCards = (message.toolCalls ?? [])
+        .filter(hasMcpAppCard)
+        .map((toolCall) => ({ toolCall, view: getRenderableMcpApp(toolCall, mcpAppHtml) }))
+      // Cards whose HTML never came, or that gave up rendering: their reply text is shown instead.
+      const unavailableMcpAppToolCallIds = [
+        ...failedMcpAppToolCallIds,
+        ...mcpAppCards
+          .filter(({ view }) => view === undefined && !isMcpAppHtmlLoading)
+          .map(({ toolCall }) => toolCall.id),
+      ]
       const hasContent = message.content.trim().length > 0
       // A card that failed to render must not take the reply text down with it.
       const hideMarkdownRecap =
         !isStreaming &&
-        mcpAppViews.some(({ toolCall }) => !failedMcpAppToolCallIds.includes(toolCall.id))
+        mcpAppCards.some(({ toolCall }) => !unavailableMcpAppToolCallIds.includes(toolCall.id))
       // The model may have written nothing because it expected the card to speak for the tool:
       // once the card gave up, the tool result text stands in for the reply.
       const failedMcpAppFallbackText = hasContent
         ? ""
-        : getFailedMcpAppFallbackText(message.toolCalls, failedMcpAppToolCallIds)
+        : getFailedMcpAppFallbackText(message.toolCalls, unavailableMcpAppToolCallIds)
       const bubbleContent =
         hasContent && !hideMarkdownRecap ? message.content : failedMcpAppFallbackText
       const surfaceResourcesTool = findSurfaceResourcesTool(message.toolCalls)
       const sourcesTool = findSourcesTool(message.toolCalls)
-      // A card that gave up rendering still ran its tool: the reply is not empty, only quiet.
+      // A card on screen, loading or rendered even if it later gave up, means the reply is not
+      // empty, only quiet. A card whose HTML never came counts as absent.
+      const hasCardOnScreen = mcpAppCards.some(
+        ({ view }) => view !== undefined || isMcpAppHtmlLoading,
+      )
       const isEmpty =
         !hasContent &&
         message.status === "completed" &&
-        mcpAppViews.length === 0 &&
+        !hasCardOnScreen &&
+        failedMcpAppFallbackText.length === 0 &&
         !hasSurfacedResources(message.toolCalls)
       // "aborted": the stream died with the server before anything was written.
       const isError = message.status === "error" || message.status === "aborted" || isEmpty
@@ -79,19 +106,23 @@ export function ChatMessage({ message }: { message: AgentSessionMessageDto }) {
           )}
 
           {!isStreaming &&
-            mcpAppViews.map(({ toolCall, view }) => (
-              <McpAppView
-                key={toolCall.id}
-                html={view.html}
-                toolInput={view.toolInput}
-                toolResult={view.toolResult}
-                onRenderFailed={() =>
-                  setFailedMcpAppToolCallIds((previous) =>
-                    previous.includes(toolCall.id) ? previous : [...previous, toolCall.id],
-                  )
-                }
-              />
-            ))}
+            mcpAppCards.map(({ toolCall, view }) =>
+              view ? (
+                <McpAppView
+                  key={toolCall.id}
+                  html={view.html}
+                  toolInput={view.toolInput}
+                  toolResult={view.toolResult}
+                  onRenderFailed={() =>
+                    setFailedMcpAppToolCallIds((previous) =>
+                      previous.includes(toolCall.id) ? previous : [...previous, toolCall.id],
+                    )
+                  }
+                />
+              ) : (
+                isMcpAppHtmlLoading && <McpAppPlaceholder key={toolCall.id} className="mt-2" />
+              ),
+            )}
         </div>
       )
     }
@@ -121,26 +152,6 @@ function ErrorIndicator() {
       <AlertCircleIcon className="size-4 shrink-0 text-red-600" />
       <span className="font-semibold">{t("message.error")}</span>
     </div>
-  )
-}
-
-function Spinner() {
-  return (
-    <svg
-      role="img"
-      aria-label="Loading"
-      className="size-4 animate-spin text-gray-400"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-      />
-    </svg>
   )
 }
 

--- a/apps/web-embed/src/chat/components/McpAppView.tsx
+++ b/apps/web-embed/src/chat/components/McpAppView.tsx
@@ -2,7 +2,10 @@ import { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js"
 import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { cn } from "../lib/cn"
 import { isOpenableLink } from "./mcp-app-view"
+import { Spinner } from "./Spinner"
 
 const HOST_INFO = { name: "caseai-connect", version: "1.0.0" }
 const INITIALIZE_TIMEOUT_MS = 15_000
@@ -161,6 +164,29 @@ class SandboxedPostMessageTransport implements Transport {
 }
 
 /**
+ * Holds a card's place while it cannot show yet: its HTML is still being read from the MCP
+ * server, or the iframe has not finished its handshake. Sized like the empty iframe so the
+ * reply does not jump when the card takes over.
+ */
+export function McpAppPlaceholder({ className }: { className?: string }) {
+  const { t } = useTranslation("chat")
+  return (
+    <div
+      aria-live="polite"
+      aria-busy="true"
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 text-gray-500 text-sm",
+        className,
+      )}
+      style={{ minHeight: INITIAL_IFRAME_HEIGHT_PX }}
+    >
+      <Spinner />
+      <span className="animate-pulse">{t("message.loadingCard")}</span>
+    </div>
+  )
+}
+
+/**
  * POC host: double iframe without a second domain.
  * Outer frame is sandboxed unique-origin; inner frame loads the MCP App HTML.
  */
@@ -178,6 +204,8 @@ export function McpAppView({
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [hasFailed, setHasFailed] = useState(false)
+  // The guest completed `ui/initialize`: until then the frame is blank and a placeholder covers it.
+  const [isInitialized, setIsInitialized] = useState(false)
   // Parents pass an inline arrow that changes identity when any sibling card
   // fails. Reading it through a ref keeps it out of the render effect deps, so
   // a sibling failure does not tear down and re-handshake this card.
@@ -190,6 +218,7 @@ export function McpAppView({
     const iframe = iframeRef.current
     if (!iframe) return
 
+    setIsInitialized(false)
     const sandboxId = crypto.randomUUID()
     let cancelled = false
     let attempt = 0
@@ -261,6 +290,7 @@ export function McpAppView({
         await initialized
         if (thisAttempt !== attempt || cancelled) return
 
+        setIsInitialized(true)
         // Apps often register `ontoolresult` after `connect()`, so the first
         // notification is dropped and the UI stays on its loading shell.
         resendOnNextSizeChange = true
@@ -323,13 +353,21 @@ export function McpAppView({
 
   if (hasFailed) return null
 
+  // The frame stays laid out (not hidden) while it initializes so the guest measures a real
+  // width and reports a usable height; the placeholder simply covers it until then.
   return (
-    <iframe
-      ref={iframeRef}
-      className="mt-2 w-full overflow-hidden rounded-md border border-gray-200 bg-white"
-      sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads"
-      style={{ height: INITIAL_IFRAME_HEIGHT_PX, border: 0 }}
-      title="MCP App"
-    />
+    <div className="relative mt-2">
+      {!isInitialized && <McpAppPlaceholder className="absolute inset-0" />}
+      <iframe
+        ref={iframeRef}
+        className={cn(
+          "block w-full overflow-hidden rounded-md border border-gray-200 bg-white",
+          !isInitialized && "invisible",
+        )}
+        sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads"
+        style={{ height: INITIAL_IFRAME_HEIGHT_PX, border: 0 }}
+        title="MCP App"
+      />
+    </div>
   )
 }

--- a/apps/web-embed/src/chat/components/Spinner.tsx
+++ b/apps/web-embed/src/chat/components/Spinner.tsx
@@ -1,0 +1,21 @@
+import { cn } from "../lib/cn"
+
+export function Spinner({ className }: { className?: string }) {
+  return (
+    <svg
+      role="img"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin text-gray-400", className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  )
+}

--- a/apps/web-embed/src/chat/components/mcp-app-view.ts
+++ b/apps/web-embed/src/chat/components/mcp-app-view.ts
@@ -1,4 +1,8 @@
-import type { AgentSessionToolCallDto } from "@caseai-connect/api-contracts"
+import type {
+  AgentSessionMcpAppDto,
+  AgentSessionMcpAppHtmlDto,
+  AgentSessionToolCallDto,
+} from "@caseai-connect/api-contracts"
 
 export type McpAppViewModel = {
   html: string
@@ -6,12 +10,48 @@ export type McpAppViewModel = {
   toolResult: unknown
 }
 
+/** Whether a reply points at an MCP App card, so the card HTML is worth loading. */
+export function hasMcpAppPointer(
+  messages: { toolCalls?: AgentSessionToolCallDto[] | null }[],
+): boolean {
+  return messages.some((message) =>
+    (message.toolCalls ?? []).some((toolCall) => typeof toolCall.mcpApp?.resourceUri === "string"),
+  )
+}
+
+/**
+ * A tool call that shows an MCP App card: it points at one and has a result to hand it. Its HTML
+ * may still be loading, so this says a card belongs here, not that it can render yet.
+ */
+export function hasMcpAppCard(toolCall: AgentSessionToolCallDto): boolean {
+  return typeof toolCall.mcpApp?.resourceUri === "string" && toolCall.result !== undefined
+}
+
+/**
+ * Current HTML for a card pointer. The HTML embedded on the tool call wins (stories); otherwise
+ * the entry read from the same server, or, for a pointer recorded without a server id, the
+ * entry any server returned for that `ui://`.
+ */
+export function findMcpAppHtml(
+  mcpApp: AgentSessionMcpAppDto,
+  htmlEntries: AgentSessionMcpAppHtmlDto[],
+): string | undefined {
+  if (typeof mcpApp.html === "string" && mcpApp.html.trim().length > 0) return mcpApp.html
+  const entry = htmlEntries.find(
+    (candidate) =>
+      candidate.resourceUri === mcpApp.resourceUri &&
+      (!mcpApp.mcpServerId || candidate.mcpServerId === mcpApp.mcpServerId),
+  )
+  return entry && entry.html.trim().length > 0 ? entry.html : undefined
+}
+
 export function getRenderableMcpApp(
   toolCall: AgentSessionToolCallDto,
+  htmlEntries: AgentSessionMcpAppHtmlDto[] = [],
 ): McpAppViewModel | undefined {
-  const html = toolCall.mcpApp?.html
-  if (typeof html !== "string" || html.trim().length === 0) return undefined
-  if (toolCall.result === undefined) return undefined
+  if (!toolCall.mcpApp || toolCall.result === undefined) return undefined
+  const html = findMcpAppHtml(toolCall.mcpApp, htmlEntries)
+  if (html === undefined) return undefined
 
   return {
     html,
@@ -21,8 +61,13 @@ export function getRenderableMcpApp(
 }
 
 /** The MCP App iframe already shows the tool result, so the markdown recap is redundant. */
-export function hasRenderableMcpApp(toolCalls: AgentSessionToolCallDto[] | undefined): boolean {
-  return (toolCalls ?? []).some((toolCall) => getRenderableMcpApp(toolCall) !== undefined)
+export function hasRenderableMcpApp(
+  toolCalls: AgentSessionToolCallDto[] | undefined,
+  htmlEntries: AgentSessionMcpAppHtmlDto[] = [],
+): boolean {
+  return (toolCalls ?? []).some(
+    (toolCall) => getRenderableMcpApp(toolCall, htmlEntries) !== undefined,
+  )
 }
 
 /**

--- a/apps/web-embed/src/chat/locales/chat.en.json
+++ b/apps/web-embed/src/chat/locales/chat.en.json
@@ -10,6 +10,7 @@
     },
     "message": {
       "thinking": "Thinking…",
+      "loadingCard": "Loading interactive card…",
       "error": "Something went wrong. Please try again.",
       "copyAriaLabel": "Copy to clipboard",
       "sources_one": "{{count}} source",

--- a/apps/web-embed/src/chat/locales/chat.fr.json
+++ b/apps/web-embed/src/chat/locales/chat.fr.json
@@ -10,6 +10,7 @@
     },
     "message": {
       "thinking": "Réflexion en cours…",
+      "loadingCard": "Chargement de la carte interactive…",
       "error": "Une erreur s'est produite. Veuillez réessayer.",
       "copyAriaLabel": "Copier dans le presse-papiers",
       "sources_one": "{{count}} source",

--- a/apps/web-embed/src/hooks/usePublicChat.ts
+++ b/apps/web-embed/src/hooks/usePublicChat.ts
@@ -1,6 +1,17 @@
-import type { AgentSessionMessageDto, PublicSessionMessageDto } from "@caseai-connect/api-contracts"
+import type {
+  AgentSessionMcpAppHtmlDto,
+  AgentSessionMessageDto,
+  PublicSessionMessageDto,
+} from "@caseai-connect/api-contracts"
 import { useCallback, useEffect, useRef, useState } from "react"
-import { ApiError, createSession, getSession, streamMessages } from "../api/public-chat-api"
+import {
+  ApiError,
+  createSession,
+  getMcpAppHtml,
+  getSession,
+  streamMessages,
+} from "../api/public-chat-api"
+import { hasMcpAppPointer } from "../chat/components/mcp-app-view"
 
 // ─── Session persistence ───────────────────────────────────────────────────
 
@@ -90,9 +101,24 @@ export type PublicChatErrorKey =
   | "status.errorSessionFailed"
   | "status.errorUnknown"
 
+/**
+ * Current HTML of the MCP App cards the thread points at. Loaded after the messages, so the
+ * transcript shows at once and each card holds a placeholder until its HTML is here.
+ */
+type McpAppHtmlState = {
+  entries: AgentSessionMcpAppHtmlDto[]
+  isLoading: boolean
+}
+
+const NO_MCP_APP_HTML: McpAppHtmlState = { entries: [], isLoading: false }
+
 export type UsePublicChatResult = {
   status: PublicChatStatus
   messages: AgentSessionMessageDto[]
+  /** Current HTML of the MCP App cards in the thread, matched by server and `ui://`. */
+  mcpAppHtml: AgentSessionMcpAppHtmlDto[]
+  /** The MCP servers have not answered yet: cards without HTML show a placeholder. */
+  isMcpAppHtmlLoading: boolean
   isStreaming: boolean
   errorKey: PublicChatErrorKey | null
   send: (content: string) => void
@@ -102,6 +128,7 @@ export type UsePublicChatResult = {
 export function usePublicChat(embedToken: string): UsePublicChatResult {
   const [status, setStatus] = useState<PublicChatStatus>("initializing")
   const [messages, setMessages] = useState<AgentSessionMessageDto[]>([])
+  const [mcpAppHtml, setMcpAppHtml] = useState<McpAppHtmlState>(NO_MCP_APP_HTML)
   const [isStreaming, setIsStreaming] = useState(false)
   const [errorKey, setErrorKey] = useState<PublicChatErrorKey | null>(null)
 
@@ -110,11 +137,33 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
   const sessionRef = useRef<StoredSession | null>(null)
   const resetNonceRef = useRef(0)
 
+  /**
+   * Loads the card HTML for a thread that was just put on screen. Skipped for threads without
+   * cards so no MCP server is contacted for ordinary chats. A failed load keeps the cards
+   * already shown; only the placeholders give way to their text.
+   */
+  const loadMcpAppHtml = useCallback(
+    async (session: StoredSession, thread: PublicSessionMessageDto[], nonce: number) => {
+      if (!hasMcpAppPointer(thread)) return
+      setMcpAppHtml((prev) => ({ ...prev, isLoading: true }))
+      try {
+        const entries = await getMcpAppHtml(embedToken, session.sessionId, session.sessionToken)
+        if (resetNonceRef.current !== nonce) return
+        setMcpAppHtml({ entries, isLoading: false })
+      } catch {
+        if (resetNonceRef.current !== nonce) return
+        setMcpAppHtml((prev) => ({ ...prev, isLoading: false }))
+      }
+    },
+    [embedToken],
+  )
+
   const startFreshSession = useCallback(
     async (nonce: number) => {
       clearSession(embedToken)
       sessionRef.current = null
       setMessages([])
+      setMcpAppHtml(NO_MCP_APP_HTML)
       setErrorKey(null)
       setIsStreaming(false)
       setStatus("initializing")
@@ -161,6 +210,7 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
           sessionRef.current = stored
           setMessages(sessionData.messages.map(toDisplayMessage))
           setStatus("ready")
+          void loadMcpAppHtml(stored, sessionData.messages, nonce)
           if (hasStreamingReply(sessionData.messages)) {
             void settleStreamingReply(stored, stillCurrent, nonce)
           }
@@ -223,6 +273,7 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
             // thread replaces what the widget shows.
             if (!hasStreamingReply(sessionData.messages)) {
               setMessages(sessionData.messages.map(toDisplayMessage))
+              void loadMcpAppHtml(session, sessionData.messages, nonce)
               return
             }
           } catch (err) {
@@ -249,7 +300,7 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
     return () => {
       cancelled = true
     }
-  }, [embedToken, failInit, startFreshSession])
+  }, [embedToken, failInit, loadMcpAppHtml, startFreshSession])
 
   const reset = useCallback(() => {
     const nonce = ++resetNonceRef.current
@@ -331,9 +382,10 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
             }
           }
 
-          // Hydrate MCP App HTML only after the SSE generator's `finally` has
-          // closed the stream's MCP session. Fetching on `end` raced that close
-          // and `resources/read` often failed, so the card appeared only on reload.
+          // The stream carries no tool calls: re-read the thread so the reply gets the cards it
+          // ran, then load their HTML. Both happen only after the SSE generator's `finally` has
+          // closed the stream's MCP session: fetching on `end` raced that close and
+          // `resources/read` often failed, so the card appeared only on reload.
           if (shouldHydrate) {
             if (resetNonceRef.current !== nonce) return
             try {
@@ -344,6 +396,7 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
               )
               if (resetNonceRef.current !== nonce) return
               setMessages(sessionData.messages.map(toDisplayMessage))
+              void loadMcpAppHtml(session, sessionData.messages, nonce)
             } catch {
               // Keep streamed text if the hydrate fetch fails
             }
@@ -364,8 +417,17 @@ export function usePublicChat(embedToken: string): UsePublicChatResult {
         }
       })()
     },
-    [embedToken, isStreaming],
+    [embedToken, isStreaming, loadMcpAppHtml],
   )
 
-  return { status, messages, isStreaming, errorKey, send, reset }
+  return {
+    status,
+    messages,
+    mcpAppHtml: mcpAppHtml.entries,
+    isMcpAppHtmlLoading: mcpAppHtml.isLoading,
+    isStreaming,
+    errorKey,
+    send,
+    reset,
+  }
 }

--- a/apps/web/src/common/features/agents/agent-sessions/agent-session.factory.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/agent-session.factory.ts
@@ -6,7 +6,10 @@ import type {
   ConversationSubSession,
 } from "./conversation/conversation-agent-sessions.models"
 import type { ExtractionAgentSessionSummary } from "./extraction/extraction-agent-sessions.models"
-import type { AgentSessionMessage } from "./shared/agent-session-messages/agent-session-messages.models"
+import type {
+  AgentSessionMcpAppHtml,
+  AgentSessionMessage,
+} from "./shared/agent-session-messages/agent-session-messages.models"
 
 type SessionTransientParams = {
   agent?: Pick<Agent, "id">
@@ -103,4 +106,12 @@ export const agentSessionMessageFactory = AgentSessionMessageFactory.define(({ p
   status: params.status ?? "completed",
   agentRevision: params.agentRevision,
   toolCalls: params.toolCalls,
+}))
+
+class AgentSessionMcpAppHtmlFactory extends Factory<AgentSessionMcpAppHtml> {}
+
+export const agentSessionMcpAppHtmlFactory = AgentSessionMcpAppHtmlFactory.define(({ params }) => ({
+  mcpServerId: params.mcpServerId ?? faker.string.uuid(),
+  resourceUri: params.resourceUri ?? `ui://${faker.lorem.slug()}/mcp-app.html`,
+  html: params.html ?? "<!DOCTYPE html><html><body></body></html>",
 }))

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.middleware.spec.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.middleware.spec.ts
@@ -51,8 +51,11 @@ const completedReply: AgentSessionMessage = {
  * the production store: `RootState` is the many-scope union the listener is typed against.
  * The tester middleware is registered too, as it is the one resetting the slice on its unmount.
  */
-function buildStore(getOne: ReturnType<typeof vi.fn>) {
-  const services = { agentSessionMessages: { getOne } } as unknown as Services
+function buildStore(
+  getOne: ReturnType<typeof vi.fn>,
+  getMcpAppHtml: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue([]),
+) {
+  const services = { agentSessionMessages: { getOne, getMcpAppHtml } } as unknown as Services
   const store = configureStore({
     reducer: combineReducers({
       agentSessionMessages: agentSessionMessagesSlice.reducer,
@@ -81,6 +84,70 @@ afterEach(() => {
   reviewCampaignsTesterMiddleware.listenerMiddleware.clearListeners()
   vi.useRealTimers()
   vi.unstubAllGlobals()
+})
+
+describe("MCP App card HTML loading", () => {
+  const cardEntry = {
+    mcpServerId: "mcp-server-1",
+    resourceUri: "ui://pdf-export/mcp-app.html",
+    html: "<html>card</html>",
+  }
+  const replyWithCard: AgentSessionMessage = {
+    id: "assistant-2",
+    role: "assistant",
+    content: "",
+    status: "completed",
+    toolCalls: [
+      {
+        id: "call-1",
+        name: "export_pdf",
+        arguments: {},
+        result: { content: [{ type: "text", text: "Exported" }] },
+        mcpApp: { mcpServerId: cardEntry.mcpServerId, resourceUri: cardEntry.resourceUri },
+      },
+    ],
+  }
+
+  it("loads the card HTML after a thread that points at a card is listed", async () => {
+    // The list itself no longer carries the HTML, so the transcript shows at once and the
+    // cards fill in when the MCP servers have answered.
+    const getMcpAppHtml = vi.fn().mockResolvedValue([cardEntry])
+    const store = buildStore(vi.fn(), getMcpAppHtml)
+
+    store.dispatch(loaded([userMessage, replyWithCard]))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getMcpAppHtml).toHaveBeenCalledTimes(1)
+    expect(getMcpAppHtml).toHaveBeenCalledWith(expect.objectContaining({ agentSessionId }))
+    expect(store.getState().agentSessionMessages.mcpAppHtml.value).toEqual([cardEntry])
+  })
+
+  it("does not contact the MCP servers for a thread without cards", async () => {
+    const getMcpAppHtml = vi.fn().mockResolvedValue([])
+    const store = buildStore(vi.fn(), getMcpAppHtml)
+
+    store.dispatch(loaded([userMessage, completedReply]))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getMcpAppHtml).not.toHaveBeenCalled()
+  })
+
+  it("loads the card HTML when a reply that settled with a card is fetched", async () => {
+    // At the end of a live turn the reply is re-read from the server; a card it ran needs its
+    // HTML, which no earlier load could have known about.
+    const getOne = vi.fn().mockResolvedValue(replyWithCard)
+    const getMcpAppHtml = vi.fn().mockResolvedValue([cardEntry])
+    const store = buildStore(getOne, getMcpAppHtml)
+
+    store.dispatch(loaded([userMessage, { ...replyWithCard, status: "streaming", toolCalls: [] }]))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getMcpAppHtml).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(STREAMING_RECOVERY_POLL_INTERVAL_MS)
+
+    expect(getMcpAppHtml).toHaveBeenCalledTimes(1)
+    expect(store.getState().agentSessionMessages.mcpAppHtml.value).toEqual([cardEntry])
+  })
 })
 
 describe("streaming recovery polling", () => {

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.middleware.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.middleware.ts
@@ -2,7 +2,8 @@ import { createListenerMiddleware } from "@reduxjs/toolkit"
 import { ADS } from "@/common/store/async-data-status"
 import type { AppDispatch, RootState } from "@/common/store/types"
 import { agentSessionMessagesActions, isStreamingReply } from "./agent-session-messages.slice"
-import { getMessage, listMessages } from "./agent-session-messages.thunks"
+import { getMessage, listMcpAppHtml, listMessages } from "./agent-session-messages.thunks"
+import { hasMcpAppPointer } from "./components/mcp-app-view"
 
 export const listenerMiddleware = createListenerMiddleware<RootState, AppDispatch>()
 
@@ -34,6 +35,29 @@ const findStreamingReply = (state: RootState) => {
 }
 
 function registerListeners() {
+  // The message list is served without MCP App HTML: reading it means connecting to every MCP
+  // server the thread points at, and that wait used to hold the whole transcript behind a
+  // spinner. Load it once the messages are on screen; each card shows a placeholder meanwhile.
+  listenerMiddleware.startListening({
+    actionCreator: listMessages.fulfilled,
+    effect: async (action, listenerApi) => {
+      if (!hasMcpAppPointer(action.payload)) return
+      await listenerApi.dispatch(listMcpAppHtml(action.meta.arg))
+    },
+  })
+
+  // A reply that just settled may carry a card whose HTML is not loaded yet, either because it
+  // is the first card of the thread or because the card is new to it.
+  listenerMiddleware.startListening({
+    actionCreator: getMessage.fulfilled,
+    effect: async (action, listenerApi) => {
+      if (isStreamingReply(action.payload) || !hasMcpAppPointer([action.payload])) return
+      const agentSessionId = listenerApi.getState().currentIds.agentSessionId
+      if (!agentSessionId) return
+      await listenerApi.dispatch(listMcpAppHtml(agentSessionId))
+    },
+  })
+
   // A page refresh while the agent writes closes the SSE stream, but the server keeps writing and
   // persists the outcome. Loading such a reply used to render a spinner nothing would ever
   // resolve; instead re-fetch it until the server reports it settled.

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.models.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.models.ts
@@ -1,3 +1,9 @@
-import type { AgentSessionMessageDto } from "@caseai-connect/api-contracts"
+import type {
+  AgentSessionMcpAppHtmlDto,
+  AgentSessionMessageDto,
+} from "@caseai-connect/api-contracts"
 
 export type AgentSessionMessage = AgentSessionMessageDto
+
+/** Current HTML of one MCP App card the session points at, loaded after the transcript. */
+export type AgentSessionMcpAppHtml = AgentSessionMcpAppHtmlDto

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.selectors.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.selectors.ts
@@ -10,5 +10,8 @@ export const selectStreaming = (state: RootState) => {
   return ADS.isFulfilled(data) && hasStreamingReply(data.value)
 }
 
+/** Current HTML of the MCP App cards in the thread, loading until the MCP servers answered. */
+export const selectMcpAppHtml = (state: RootState) => state.agentSessionMessages.mcpAppHtml
+
 export const selectStreamingToolSteps = (state: RootState) =>
   state.agentSessionMessages.streamingToolSteps

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.slice.spec.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.slice.spec.ts
@@ -8,7 +8,7 @@ import {
   agentSessionMessagesInitialState,
   agentSessionMessagesSlice,
 } from "./agent-session-messages.slice"
-import { getMessage, listMessages } from "./agent-session-messages.thunks"
+import { getMessage, listMcpAppHtml, listMessages } from "./agent-session-messages.thunks"
 
 // The thunks module reaches the Auth0 client and `window.location` transitively; neither exists
 // under vitest's node environment, and the reducer under test needs only the action creators.
@@ -36,6 +36,59 @@ const completedReply: AgentSessionMessage = {
 }
 
 describe("agentSessionMessages slice", () => {
+  describe("listMcpAppHtml", () => {
+    const entry = {
+      mcpServerId: "mcp-server-1",
+      resourceUri: "ui://pdf-export/mcp-app.html",
+      html: "<html>card</html>",
+    }
+
+    it("reports the cards loading until the MCP servers answered", () => {
+      const state = reducer(
+        agentSessionMessagesInitialState,
+        listMcpAppHtml.pending("request-1", "session-1"),
+      )
+
+      expect(ADS.isLoading(state.mcpAppHtml)).toBe(true)
+    })
+
+    it("stores the HTML of every card once loaded", () => {
+      const state = reducer(
+        agentSessionMessagesInitialState,
+        listMcpAppHtml.fulfilled([entry], "request-1", "session-1"),
+      )
+
+      expect(state.mcpAppHtml).toEqual({ status: ADS.Fulfilled, error: null, value: [entry] })
+    })
+
+    it("keeps the cards already shown while a refresh runs or fails", () => {
+      // Reloading the thread must not swap a working card for its placeholder, nor drop it
+      // because the MCP server was unreachable this time.
+      const loadedState = reducer(
+        agentSessionMessagesInitialState,
+        listMcpAppHtml.fulfilled([entry], "request-1", "session-1"),
+      )
+
+      const refreshing = reducer(loadedState, listMcpAppHtml.pending("request-2", "session-1"))
+      expect(refreshing.mcpAppHtml.value).toEqual([entry])
+
+      const failed = reducer(
+        refreshing,
+        listMcpAppHtml.rejected(new Error("MCP server unreachable"), "request-2", "session-1"),
+      )
+      expect(failed.mcpAppHtml.value).toEqual([entry])
+    })
+
+    it("gives the placeholders up when the first load fails", () => {
+      const state = reducer(
+        reducer(agentSessionMessagesInitialState, listMcpAppHtml.pending("request-1", "session-1")),
+        listMcpAppHtml.rejected(new Error("MCP server unreachable"), "request-1", "session-1"),
+      )
+
+      expect(ADS.isError(state.mcpAppHtml)).toBe(true)
+    })
+  })
+
   describe("listMessages.fulfilled", () => {
     it("treats a reply that is still streaming server-side as streaming", () => {
       // After a page refresh the persisted reply can still be "streaming": the server keeps

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.slice.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.slice.ts
@@ -2,8 +2,8 @@ import type { AgentSessionToolName } from "@caseai-connect/api-contracts"
 import { createSlice, isAnyOf, type PayloadAction } from "@reduxjs/toolkit"
 import { ADS, type AsyncData, defaultAsyncData } from "@/common/store/async-data-status"
 import { conversationAgentSessionsActions } from "../../conversation/conversation-agent-sessions.slice"
-import type { AgentSessionMessage } from "./agent-session-messages.models"
-import { getMessage, listMessages } from "./agent-session-messages.thunks"
+import type { AgentSessionMcpAppHtml, AgentSessionMessage } from "./agent-session-messages.models"
+import { getMessage, listMcpAppHtml, listMessages } from "./agent-session-messages.thunks"
 
 /**
  * Whether a reply is being written is not stored: it is read off the messages (see
@@ -11,12 +11,18 @@ import { getMessage, listMessages } from "./agent-session-messages.thunks"
  */
 type State = {
   data: AsyncData<AgentSessionMessage[]>
+  /**
+   * Current HTML of the MCP App cards the thread points at. Loaded after the messages, so the
+   * transcript shows at once and each card holds a placeholder until its HTML is here.
+   */
+  mcpAppHtml: AsyncData<AgentSessionMcpAppHtml[]>
   /** Ordered tools the agent has run during the current streaming turn, driving the status timeline. */
   streamingToolSteps: AgentSessionToolName[]
 }
 
 const initialState: State = {
   data: defaultAsyncData,
+  mcpAppHtml: defaultAsyncData,
   streamingToolSteps: [],
 }
 
@@ -151,6 +157,26 @@ const slice = createSlice({
       .addCase(listMessages.rejected, (state, action) => {
         state.data.status = ADS.Error
         state.data.error = action.error.message || "Failed to load session messages"
+      })
+
+    builder
+      .addCase(listMcpAppHtml.pending, (state) => {
+        // HTML already shown stays on screen while a refresh runs: a card must not fall back to
+        // its placeholder every time the thread is reloaded.
+        if (!ADS.isFulfilled(state.mcpAppHtml)) state.mcpAppHtml.status = ADS.Loading
+        state.mcpAppHtml.error = null
+      })
+      .addCase(listMcpAppHtml.fulfilled, (state, action) => {
+        state.mcpAppHtml = { value: action.payload, status: ADS.Fulfilled, error: null }
+      })
+      .addCase(listMcpAppHtml.rejected, (state, action) => {
+        // Cards already loaded keep rendering; only the placeholders give way to their text.
+        if (ADS.isFulfilled(state.mcpAppHtml)) return
+        state.mcpAppHtml = {
+          value: null,
+          status: ADS.Error,
+          error: action.error.message || "Failed to load MCP App cards",
+        }
       })
 
     builder.addCase(getMessage.fulfilled, (state, action) => {

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.spi.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.spi.ts
@@ -2,7 +2,7 @@ import type {
   BaseAgentSessionTypeDto,
   PresignAgentSessionMessageAttachmentDocumentResponseDto,
 } from "@caseai-connect/api-contracts"
-import type { AgentSessionMessage } from "./agent-session-messages.models"
+import type { AgentSessionMcpAppHtml, AgentSessionMessage } from "./agent-session-messages.models"
 
 type BaseParams = {
   organizationId: string
@@ -17,6 +17,9 @@ export interface IAgentSessionMessagesSpi {
   getOne: (
     params: BaseParams & { messageId: string } & { payload: { type: BaseAgentSessionTypeDto } },
   ) => Promise<AgentSessionMessage>
+  getMcpAppHtml: (
+    params: BaseParams & { payload: { type: BaseAgentSessionTypeDto } },
+  ) => Promise<AgentSessionMcpAppHtml[]>
   uploadAttachmentDocument: (
     params: BaseParams & { file: File; payload: { type: BaseAgentSessionTypeDto } },
   ) => Promise<

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.thunks.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.thunks.ts
@@ -7,7 +7,7 @@ import { generateId } from "@/common/utils/generate-id"
 import type { ConversationAgentSession } from "../../conversation/conversation-agent-sessions.models"
 import { conversationAgentSessionsActions } from "../../conversation/conversation-agent-sessions.slice"
 import { buildType } from "../base-agent-session/base-agent-sessions.thunks"
-import type { AgentSessionMessage } from "./agent-session-messages.models"
+import type { AgentSessionMcpAppHtml, AgentSessionMessage } from "./agent-session-messages.models"
 import { selectStreaming } from "./agent-session-messages.selectors"
 import { agentSessionMessagesActions } from "./agent-session-messages.slice"
 import { streamChatResponse } from "./external/agent-session-messages-streaming"
@@ -42,6 +42,27 @@ export const getMessage = createAsyncThunk<AgentSessionMessage, string, ThunkCon
     return services.agentSessionMessages.getOne({
       ...params,
       messageId,
+      payload: { type: buildType() },
+    })
+  },
+)
+
+/**
+ * Current HTML of the MCP App cards the thread points at. Loaded after the transcript so a slow
+ * MCP server only delays the cards, which show a placeholder meanwhile.
+ */
+export const listMcpAppHtml = createAsyncThunk<AgentSessionMcpAppHtml[], string, ThunkConfig>(
+  "agentSessionMessages/listMcpAppHtml",
+  async (agentSessionId, { extra: { services }, getState }) => {
+    const state = getState()
+    const organizationId = getCurrentId({ state, name: "organizationId" })
+    const projectId = getCurrentId({ state, name: "projectId" })
+    const agentId = getCurrentId({ state, name: "agentId" })
+    return services.agentSessionMessages.getMcpAppHtml({
+      organizationId,
+      projectId,
+      agentId,
+      agentSessionId,
       payload: { type: buildType() },
     })
   },

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
@@ -18,14 +18,15 @@ import { RestrictedFeature } from "@/common/components/RestrictedFeature"
 import { FormResultSheet } from "@/common/features/agents/agent-sessions/conversation/components/FormResultSheet"
 import type { AgentSessionMessage as AgentSessionMessageType } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.models"
 import { useCopyToClipboard } from "@/common/hooks/use-copy-to-clipboard"
+import { ADS } from "@/common/store/async-data-status"
 import { useAppSelector } from "@/common/store/hooks"
-import { selectStreamingToolSteps } from "../agent-session-messages.selectors"
+import { selectMcpAppHtml, selectStreamingToolSteps } from "../agent-session-messages.selectors"
 import { Attachment } from "./Attachment"
 import { useFormResult } from "./form-result-context"
 import { useFormSubSessions } from "./form-sub-sessions-context"
 import { MarkdownWrapper } from "./MarkdownWrapper"
-import { McpAppView } from "./McpAppView"
-import { getFailedMcpAppFallbackText, getRenderableMcpApp } from "./mcp-app-view"
+import { McpAppPlaceholder, McpAppView } from "./McpAppView"
+import { getFailedMcpAppFallbackText, getRenderableMcpApp, hasMcpAppCard } from "./mcp-app-view"
 import { SourcesTool } from "./SourcesTool"
 import { SubAgentFormResultSheet } from "./SubAgentFormResultSheet"
 import { SurfaceResourcesTool } from "./SurfaceResourcesTool"
@@ -43,6 +44,11 @@ export function AgentSessionMessage({
   const { t } = useTranslation()
   const formSubSessions = useFormSubSessions()
   const formResult = useFormResult()
+  // Card HTML is loaded after the transcript so a slow MCP server never delays the messages;
+  // until it lands, each card holds its place with a placeholder.
+  const mcpAppHtml = useAppSelector(selectMcpAppHtml)
+  const mcpAppHtmlEntries = ADS.isFulfilled(mcpAppHtml) ? mcpAppHtml.value : []
+  const isMcpAppHtmlPending = !ADS.isFulfilled(mcpAppHtml) && !ADS.isError(mcpAppHtml)
   // MCP App cards that gave up rendering; their reply text is shown instead.
   const [failedMcpAppToolCallIds, setFailedMcpAppToolCallIds] = useState<string[]>([])
 
@@ -59,19 +65,27 @@ export function AgentSessionMessage({
       const surfaceResourcesTool = message.toolCalls?.find(
         (call) => call.name === ToolName.SurfaceResources,
       )
-      const mcpAppViews = (message.toolCalls ?? []).flatMap((toolCall) => {
-        const view = getRenderableMcpApp(toolCall)
-        return view ? [{ toolCall, view }] : []
-      })
+      // Every card this reply shows, with its view once the HTML is here. A card without a view
+      // is either still loading (placeholder) or unavailable (its text stands in).
+      const mcpAppCards = (message.toolCalls ?? [])
+        .filter(hasMcpAppCard)
+        .map((toolCall) => ({ toolCall, view: getRenderableMcpApp(toolCall, mcpAppHtmlEntries) }))
+      // Cards whose HTML never came, or that gave up rendering: their reply text is shown instead.
+      const unavailableMcpAppToolCallIds = [
+        ...failedMcpAppToolCallIds,
+        ...mcpAppCards
+          .filter(({ view }) => view === undefined && !isMcpAppHtmlPending)
+          .map(({ toolCall }) => toolCall.id),
+      ]
       // A card that failed to render must not take the reply text down with it.
       const hideMarkdownRecap =
         !isStreaming &&
-        mcpAppViews.some(({ toolCall }) => !failedMcpAppToolCallIds.includes(toolCall.id))
+        mcpAppCards.some(({ toolCall }) => !unavailableMcpAppToolCallIds.includes(toolCall.id))
       // The model may have written nothing because it expected the card to speak for the tool:
       // once the card gave up, the tool result text stands in for the reply.
       const failedMcpAppFallbackText = hasContent
         ? ""
-        : getFailedMcpAppFallbackText(message.toolCalls, failedMcpAppToolCallIds)
+        : getFailedMcpAppFallbackText(message.toolCalls, unavailableMcpAppToolCallIds)
       const bubbleContent =
         hasContent && !hideMarkdownRecap ? message.content : failedMcpAppFallbackText
       // Tool names this message delegated to that resolved to a form sub-session,
@@ -117,19 +131,23 @@ export function AgentSessionMessage({
             )}
 
             {!isStreaming &&
-              mcpAppViews.map(({ toolCall, view }) => (
-                <McpAppView
-                  key={toolCall.id}
-                  html={view.html}
-                  toolInput={view.toolInput}
-                  toolResult={view.toolResult}
-                  onRenderFailed={() =>
-                    setFailedMcpAppToolCallIds((previous) =>
-                      previous.includes(toolCall.id) ? previous : [...previous, toolCall.id],
-                    )
-                  }
-                />
-              ))}
+              mcpAppCards.map(({ toolCall, view }) =>
+                view ? (
+                  <McpAppView
+                    key={toolCall.id}
+                    html={view.html}
+                    toolInput={view.toolInput}
+                    toolResult={view.toolResult}
+                    onRenderFailed={() =>
+                      setFailedMcpAppToolCallIds((previous) =>
+                        previous.includes(toolCall.id) ? previous : [...previous, toolCall.id],
+                      )
+                    }
+                  />
+                ) : (
+                  isMcpAppHtmlPending && <McpAppPlaceholder key={toolCall.id} className="mt-2" />
+                ),
+              )}
 
             {!isStreaming && (
               <MessageFooter className="gap-0 px-1">

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/McpAppView.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/McpAppView.tsx
@@ -1,7 +1,10 @@
+import { Spinner } from "@caseai-connect/ui/shad/spinner"
+import { cn } from "@caseai-connect/ui/utils"
 import { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js"
 import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { isOpenableLink } from "./mcp-app-view"
 
 const HOST_INFO = { name: "caseai-connect", version: "1.0.0" }
@@ -161,6 +164,29 @@ class SandboxedPostMessageTransport implements Transport {
 }
 
 /**
+ * Holds a card's place while it cannot show yet: its HTML is still being read from the MCP
+ * server, or the iframe has not finished its handshake. Sized like the empty iframe so the
+ * reply does not jump when the card takes over.
+ */
+export function McpAppPlaceholder({ className }: { className?: string }) {
+  const { t } = useTranslation("agentSessionMessage")
+  return (
+    <div
+      aria-live="polite"
+      aria-busy="true"
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md border bg-muted/40 px-4 text-sm text-muted-foreground",
+        className,
+      )}
+      style={{ minHeight: INITIAL_IFRAME_HEIGHT_PX }}
+    >
+      <Spinner />
+      <span className="animate-pulse">{t("mcpApp.loading")}</span>
+    </div>
+  )
+}
+
+/**
  * POC host: double iframe without a second domain.
  * Outer frame is sandboxed unique-origin; inner frame loads the MCP App HTML.
  */
@@ -178,6 +204,8 @@ export function McpAppView({
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [hasFailed, setHasFailed] = useState(false)
+  // The guest completed `ui/initialize`: until then the frame is blank and a placeholder covers it.
+  const [isInitialized, setIsInitialized] = useState(false)
   // Parents pass an inline arrow that changes identity when any sibling card
   // fails. Reading it through a ref keeps it out of the render effect deps, so
   // a sibling failure does not tear down and re-handshake this card.
@@ -190,6 +218,7 @@ export function McpAppView({
     const iframe = iframeRef.current
     if (!iframe) return
 
+    setIsInitialized(false)
     const sandboxId = crypto.randomUUID()
     let cancelled = false
     let attempt = 0
@@ -262,6 +291,7 @@ export function McpAppView({
         if (thisAttempt !== attempt || cancelled) return
 
         console.debug("MCP App initialized")
+        setIsInitialized(true)
         // Apps often register `ontoolresult` after `connect()`, so the first
         // notification is dropped and the UI stays on its loading shell.
         resendOnNextSizeChange = true
@@ -324,13 +354,21 @@ export function McpAppView({
 
   if (hasFailed) return null
 
+  // The frame stays laid out (not hidden) while it initializes so the guest measures a real
+  // width and reports a usable height; the placeholder simply covers it until then.
   return (
-    <iframe
-      ref={iframeRef}
-      className="mt-2 w-full overflow-hidden rounded-md border bg-background"
-      sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads"
-      style={{ height: INITIAL_IFRAME_HEIGHT_PX, border: 0 }}
-      title="MCP App"
-    />
+    <div className="relative mt-2">
+      {!isInitialized && <McpAppPlaceholder className="absolute inset-0" />}
+      <iframe
+        ref={iframeRef}
+        className={cn(
+          "block w-full overflow-hidden rounded-md border bg-background",
+          !isInitialized && "invisible",
+        )}
+        sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads"
+        style={{ height: INITIAL_IFRAME_HEIGHT_PX, border: 0 }}
+        title="MCP App"
+      />
+    </div>
   )
 }

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.spec.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.spec.ts
@@ -1,9 +1,12 @@
 import type { AgentSessionToolCallDto } from "@caseai-connect/api-contracts"
 import { describe, expect, it } from "vitest"
 import {
+  findMcpAppHtml,
   getFailedMcpAppFallbackText,
   getMcpAppToolResultText,
   getRenderableMcpApp,
+  hasMcpAppCard,
+  hasMcpAppPointer,
   hasRenderableMcpApp,
   isOpenableLink,
 } from "./mcp-app-view"
@@ -14,9 +17,67 @@ const baseToolCall: AgentSessionToolCallDto = {
   arguments: { query: "hello" },
 }
 
+const pointer = { mcpServerId: "mcp-server-1", resourceUri: "ui://pdf-export/mcp-app.html" }
+const cardToolCall: AgentSessionToolCallDto = {
+  ...baseToolCall,
+  name: "export_pdf",
+  result: { content: [{ type: "text", text: "Exported" }] },
+  mcpApp: pointer,
+}
+
+describe("hasMcpAppPointer", () => {
+  it("is true when a reply points at a card, even before its HTML is loaded", () => {
+    expect(hasMcpAppPointer([{ toolCalls: [cardToolCall] }])).toBe(true)
+  })
+
+  it("is false for a thread with only ordinary tool calls", () => {
+    expect(hasMcpAppPointer([{ toolCalls: [baseToolCall] }, { toolCalls: undefined }])).toBe(false)
+  })
+})
+
+describe("hasMcpAppCard", () => {
+  it("needs both a pointer and a result to hand the card", () => {
+    expect(hasMcpAppCard(cardToolCall)).toBe(true)
+    expect(hasMcpAppCard({ ...cardToolCall, result: undefined })).toBe(false)
+    expect(hasMcpAppCard(baseToolCall)).toBe(false)
+  })
+})
+
+describe("findMcpAppHtml", () => {
+  const entries = [{ ...pointer, html: "<html>live</html>" }]
+
+  it("prefers the HTML embedded on the tool call", () => {
+    expect(findMcpAppHtml({ ...pointer, html: "<html>inline</html>" }, entries)).toBe(
+      "<html>inline</html>",
+    )
+  })
+
+  it("resolves the pointer against the entry read from the same server", () => {
+    expect(findMcpAppHtml(pointer, entries)).toBe("<html>live</html>")
+    expect(findMcpAppHtml({ ...pointer, mcpServerId: "other-server" }, entries)).toBeUndefined()
+  })
+
+  it("accepts any server's entry for a pointer recorded without a server id", () => {
+    expect(findMcpAppHtml({ ...pointer, mcpServerId: "" }, entries)).toBe("<html>live</html>")
+  })
+
+  it("is undefined while nothing has been loaded", () => {
+    expect(findMcpAppHtml(pointer, [])).toBeUndefined()
+  })
+})
+
 describe("getRenderableMcpApp", () => {
   it("returns nothing for a normal tool call without MCP App metadata", () => {
     expect(getRenderableMcpApp(baseToolCall)).toBeUndefined()
+  })
+
+  it("renders a card whose HTML arrived through the separate load", () => {
+    expect(getRenderableMcpApp(cardToolCall, [{ ...pointer, html: "<html>live</html>" }])).toEqual({
+      html: "<html>live</html>",
+      toolInput: cardToolCall.arguments,
+      toolResult: cardToolCall.result,
+    })
+    expect(getRenderableMcpApp(cardToolCall, [])).toBeUndefined()
   })
 
   it("returns view props when HTML and the tool result are present", () => {

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.ts
@@ -1,4 +1,5 @@
-import type { AgentSessionToolCallDto } from "@caseai-connect/api-contracts"
+import type { AgentSessionMcpAppDto, AgentSessionToolCallDto } from "@caseai-connect/api-contracts"
+import type { AgentSessionMcpAppHtml, AgentSessionMessage } from "../agent-session-messages.models"
 
 export type McpAppViewModel = {
   html: string
@@ -6,12 +7,46 @@ export type McpAppViewModel = {
   toolResult: unknown
 }
 
+/** Whether a reply points at an MCP App card, so the card HTML is worth loading. */
+export function hasMcpAppPointer(messages: Pick<AgentSessionMessage, "toolCalls">[]): boolean {
+  return messages.some((message) =>
+    (message.toolCalls ?? []).some((toolCall) => typeof toolCall.mcpApp?.resourceUri === "string"),
+  )
+}
+
+/**
+ * A tool call that shows an MCP App card: it points at one and has a result to hand it. Its HTML
+ * may still be loading, so this says a card belongs here, not that it can render yet.
+ */
+export function hasMcpAppCard(toolCall: AgentSessionToolCallDto): boolean {
+  return typeof toolCall.mcpApp?.resourceUri === "string" && toolCall.result !== undefined
+}
+
+/**
+ * Current HTML for a card pointer. The HTML embedded on the tool call wins (public chat, stories);
+ * otherwise the entry read from the same server, or, for a pointer recorded without a server id,
+ * the entry any server returned for that `ui://`.
+ */
+export function findMcpAppHtml(
+  mcpApp: AgentSessionMcpAppDto,
+  htmlEntries: AgentSessionMcpAppHtml[],
+): string | undefined {
+  if (typeof mcpApp.html === "string" && mcpApp.html.trim().length > 0) return mcpApp.html
+  const entry = htmlEntries.find(
+    (candidate) =>
+      candidate.resourceUri === mcpApp.resourceUri &&
+      (!mcpApp.mcpServerId || candidate.mcpServerId === mcpApp.mcpServerId),
+  )
+  return entry && entry.html.trim().length > 0 ? entry.html : undefined
+}
+
 export function getRenderableMcpApp(
   toolCall: AgentSessionToolCallDto,
+  htmlEntries: AgentSessionMcpAppHtml[] = [],
 ): McpAppViewModel | undefined {
-  const html = toolCall.mcpApp?.html
-  if (typeof html !== "string" || html.trim().length === 0) return undefined
-  if (toolCall.result === undefined) return undefined
+  if (!toolCall.mcpApp || toolCall.result === undefined) return undefined
+  const html = findMcpAppHtml(toolCall.mcpApp, htmlEntries)
+  if (html === undefined) return undefined
 
   return {
     html,
@@ -21,8 +56,13 @@ export function getRenderableMcpApp(
 }
 
 /** The MCP App iframe already shows the tool result, so the markdown recap is redundant. */
-export function hasRenderableMcpApp(toolCalls: AgentSessionToolCallDto[] | undefined): boolean {
-  return (toolCalls ?? []).some((toolCall) => getRenderableMcpApp(toolCall) !== undefined)
+export function hasRenderableMcpApp(
+  toolCalls: AgentSessionToolCallDto[] | undefined,
+  htmlEntries: AgentSessionMcpAppHtml[] = [],
+): boolean {
+  return (toolCalls ?? []).some(
+    (toolCall) => getRenderableMcpApp(toolCall, htmlEntries) !== undefined,
+  )
 }
 
 /**

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages.api.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages.api.ts
@@ -24,6 +24,14 @@ export default {
     )
     return fromDto(response.data.data)
   },
+  getMcpAppHtml: async ({ payload, ...params }) => {
+    const axios = getAxiosInstance()
+    const response = await axios.post<typeof AgentSessionMessagesRoutes.getMcpAppHtml.response>(
+      AgentSessionMessagesRoutes.getMcpAppHtml.getPath(params),
+      { payload } satisfies typeof AgentSessionMessagesRoutes.getMcpAppHtml.request,
+    )
+    return response.data.data
+  },
   uploadAttachmentDocument: async ({ file, payload, ...params }) => {
     const axios = getAxiosInstance()
     const response = await axios.post<

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/locales/agent-session-message.en.json
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/locales/agent-session-message.en.json
@@ -16,6 +16,9 @@
       "Starting to write…"
     ],
     "interrupted": "This reply was interrupted before it finished.",
+    "mcpApp": {
+      "loading": "Loading interactive card…"
+    },
     "steps": {
       "working_one": "Working through {{count}} step",
       "working_other": "Working through {{count}} steps",

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/locales/agent-session-message.fr.json
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/locales/agent-session-message.fr.json
@@ -16,6 +16,9 @@
       "Rédaction en cours…"
     ],
     "interrupted": "Cette réponse a été interrompue avant la fin.",
+    "mcpApp": {
+      "loading": "Chargement de la carte interactive…"
+    },
     "steps": {
       "working_one": "{{count}} étape en cours",
       "working_other": "{{count}} étapes en cours",

--- a/apps/web/src/stories/routes/Chat.stories.tsx
+++ b/apps/web/src/stories/routes/Chat.stories.tsx
@@ -19,7 +19,7 @@ import { organizationFactory } from "@/common/features/organizations/organizatio
 import { projectFactory } from "@/common/features/projects/projects.factory"
 import { DotsBackground } from "@/studio/components/DotsBackground"
 import { withRedux } from "../decorators"
-import { seed } from "../seed"
+import { mergeSeeds, seed } from "../seed"
 
 type StoryArgs = {
   messages: AgentSessionMessage[]
@@ -156,6 +156,45 @@ export const InterruptedReply: Story = {
     messages: [
       agentSessionMessageFactory.build({ role: "user", content: "What can you do?" }),
       agentSessionMessageFactory.build({ role: "assistant", content: "", status: "aborted" }),
+    ],
+  },
+}
+
+/**
+ * A reply whose MCP App card HTML is still being read from the MCP server: the transcript is on
+ * screen and the card holds its place with a placeholder.
+ */
+export const LoadingMcpAppCard: Story = {
+  ...Default,
+  decorators: [
+    withRedux({
+      state: mergeSeeds(
+        seed.currentProject(
+          projectFactory.transient({ organization: organizationFactory.build() }).build(),
+        ),
+        seed.agentSessionMcpAppHtml(undefined),
+      ),
+    }),
+  ],
+  args: {
+    messages: [
+      agentSessionMessageFactory.build({ role: "user", content: "Export these notes as a PDF." }),
+      agentSessionMessageFactory.build({
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call-pdf-export",
+            name: "export_pdf",
+            arguments: { markdown: "# Notes" },
+            result: {
+              content: [{ type: "text", text: "Created Notes.pdf (2 pages)." }],
+              structuredContent: { fileName: "Notes.pdf" },
+            },
+            mcpApp: { mcpServerId: "mcp-server-1", resourceUri: "ui://pdf-export/mcp-app.html" },
+          },
+        ],
+      }),
     ],
   },
 }

--- a/apps/web/src/stories/seed.ts
+++ b/apps/web/src/stories/seed.ts
@@ -12,7 +12,10 @@ import type {
   ConversationSubSession,
 } from "@/common/features/agents/agent-sessions/conversation/conversation-agent-sessions.models"
 import type { ExtractionAgentSessions } from "@/common/features/agents/agent-sessions/extraction/extraction-agent-sessions.models"
-import type { AgentSessionMessage } from "@/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.models"
+import type {
+  AgentSessionMcpAppHtml,
+  AgentSessionMessage,
+} from "@/common/features/agents/agent-sessions/shared/agent-session-messages/agent-session-messages.models"
 import type { AgentSettings } from "@/common/features/agents/agent-settings/agent-settings.models"
 import type { Agent } from "@/common/features/agents/agents.models"
 import type { User } from "@/common/features/me/me.models"
@@ -270,6 +273,14 @@ export const seed = {
 
   agentSessionMessages(messages: AgentSessionMessage[]): StoryPreloadedState {
     return { agentSessionMessages: { data: ads.fulfilled(messages) } }
+  },
+
+  /** Loaded MCP App card HTML; pass `undefined` to show the cards still loading. */
+  agentSessionMcpAppHtml(entries: AgentSessionMcpAppHtml[] | undefined): StoryPreloadedState {
+    if (entries === undefined) {
+      return { agentSessionMessages: { mcpAppHtml: ads.loading<AgentSessionMcpAppHtml[]>() } }
+    }
+    return { agentSessionMessages: { mcpAppHtml: ads.fulfilled(entries) } }
   },
 
   studio: {

--- a/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.dto.ts
+++ b/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.dto.ts
@@ -21,13 +21,22 @@ export type AgentSessionToolName = ToolName | (string & {})
 
 /**
  * MCP App attached to a tool. The `ui://` pointer is persisted; `html` is the
- * current `resources/read` result, hydrated when messages are loaded so card
- * UI updates apply to old conversations.
+ * current `resources/read` result so card UI updates apply to old conversations.
+ * Authenticated sessions leave it out of the message list and load it through
+ * `getMcpAppHtml`, so a slow MCP server never delays the transcript. The public
+ * chat still hydrates it inline.
  */
 export type AgentSessionMcpAppDto = {
   mcpServerId: string
   resourceUri: string
   html?: string
+}
+
+/** Current HTML of one MCP App card used in a session, keyed by the server that serves it. */
+export type AgentSessionMcpAppHtmlDto = {
+  mcpServerId: string
+  resourceUri: string
+  html: string
 }
 
 export type AgentSessionToolCallDto = {

--- a/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.dto.ts
+++ b/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.dto.ts
@@ -22,9 +22,8 @@ export type AgentSessionToolName = ToolName | (string & {})
 /**
  * MCP App attached to a tool. The `ui://` pointer is persisted; `html` is the
  * current `resources/read` result so card UI updates apply to old conversations.
- * Authenticated sessions leave it out of the message list and load it through
- * `getMcpAppHtml`, so a slow MCP server never delays the transcript. The public
- * chat still hydrates it inline.
+ * Message lists leave it out and clients load it through their `getMcpAppHtml`
+ * route, so a slow MCP server never delays the transcript.
  */
 export type AgentSessionMcpAppDto = {
   mcpServerId: string

--- a/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.routes.ts
+++ b/packages/api-contracts/src/agents/shared/agent-session-messages/agent-session-messages.routes.ts
@@ -2,6 +2,7 @@ import type { RequestPayload, ResponseData } from "../../../generic"
 import { defineRoute } from "../../../helpers"
 import type { BaseAgentSessionTypeDto } from "../../conversation-agent-sessions/conversation-agent-sessions.dto"
 import type {
+  AgentSessionMcpAppHtmlDto,
   AgentSessionMessageDto,
   PresignAgentSessionMessageAttachmentDocumentRequestDto,
   PresignAgentSessionMessageAttachmentDocumentResponseDto,
@@ -27,6 +28,18 @@ export const AgentSessionMessagesRoutes = {
   >({
     method: "post",
     path: `${basePath}/messages/:messageId`,
+  }),
+  /**
+   * Current HTML of every MCP App card the session's replies point at. Reading it means
+   * connecting to each MCP server, so it is separate from `getAll` and loaded once the
+   * transcript is already on screen.
+   */
+  getMcpAppHtml: defineRoute<
+    ResponseData<AgentSessionMcpAppHtmlDto[]>,
+    RequestPayload<{ type: BaseAgentSessionTypeDto }>
+  >({
+    method: "post",
+    path: `${basePath}/messages/mcp-app-html`,
   }),
   presignAttachmentDocument: defineRoute<
     ResponseData<PresignAgentSessionMessageAttachmentDocumentResponseDto>,

--- a/packages/api-contracts/src/public-chat/public-chat.dto.ts
+++ b/packages/api-contracts/src/public-chat/public-chat.dto.ts
@@ -7,7 +7,10 @@ export type PublicSessionMessageDto = {
   content: string
   status?: "streaming" | "completed" | "aborted" | "error"
   createdAt: TimeType
-  /** Present when the turn ran tools. MCP Apps include a hydrated `ui://` card. */
+  /**
+   * Present when the turn ran tools. MCP Apps carry their `ui://` card pointer; the card HTML
+   * is served by `getMcpAppHtml`.
+   */
   toolCalls?: AgentSessionToolCallDto[]
 }
 

--- a/packages/api-contracts/src/public-chat/public-chat.routes.ts
+++ b/packages/api-contracts/src/public-chat/public-chat.routes.ts
@@ -1,4 +1,5 @@
 import type { EmbedPublicConfigDto } from "../agent-embed-configs/agent-embed-configs.dto"
+import type { AgentSessionMcpAppHtmlDto } from "../agents/shared/agent-session-messages/agent-session-messages.dto"
 import type { RequestPayload, ResponseData } from "../generic"
 import { defineRoute } from "../helpers"
 import type {
@@ -38,6 +39,16 @@ export const PublicChatRoutes = {
   getSession: defineRoute<ResponseData<PublicAgentSessionDto>>({
     method: "get",
     path: sessionBasePath,
+  }),
+
+  /**
+   * Current HTML of every MCP App card the session's replies point at. Separate from
+   * `getSession` because reading it connects to each MCP server, which must not delay the
+   * transcript; the widget loads it once the messages are on screen.
+   */
+  getMcpAppHtml: defineRoute<ResponseData<AgentSessionMcpAppHtmlDto[]>>({
+    method: "get",
+    path: `${sessionBasePath}/mcp-app-html`,
   }),
 
   streamMessages: defineRoute<


### PR DESCRIPTION
## Why

Opening a conversation that contains an MCP App card took a long time, in the app and in the embed widget. The session endpoints connected to every MCP server the thread points at and read each `ui://` resource before returning a single message, so a slow server held the whole transcript behind the loader.

## What changes

**API**
- Session message reads (`getAll`, `getOne` on agent sessions, `getSession` on the public chat) return the persisted card pointer (`mcpServerId`, `resourceUri`) without HTML, so they no longer touch any MCP server.
- Two new routes read the current HTML of every card a session points at and return one entry per server and URI: `AgentSessionMessagesRoutes.getMcpAppHtml` for authenticated sessions, `PublicChatRoutes.getMcpAppHtml` for the embed, behind the same session token guard as `getSession`.

**Web app**
- The messages middleware loads the card HTML right after the transcript lands, and again when a reply that ran a card settles at the end of a live turn.
- The slice keeps that HTML next to the messages. A refresh or a failed reload never swaps a working card for its placeholder.
- Each message with a card shows a placeholder while the HTML is loading, and the card iframe stays covered by the same placeholder until the guest finished `ui/initialize`, so the reply no longer shows a blank frame during the handshake.
- When the HTML never comes, the reply falls back to the tool result text, the same way a card that failed its handshake already did.
- New Storybook state `components/Chat › LoadingMcpAppCard`.

**Embed widget**
- `usePublicChat` loads the card HTML after a session restore, after a recovered reply settles, and after each finished turn, through the new public route. A reset clears it.
- `ChatMessage` and `McpAppView` get the same placeholder and handshake overlay as the app.
- New Storybook state `Embed/EmbedChat › MCP App card loading`.

## Verification

- `npm run biome:check`, `npm run typecheck`: clean.
- Web: 17 files, 160 tests pass, including new slice, middleware and helper cases.
- API: helpers, MCP App HTML service, messages e2e (list, get one, new get-mcp-app-html), public chat service, public chat e2e (auth, get-session, new get-mcp-app-html) pass. `check:boundaries` clean.
- Not run: the full API `test:parallel` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
