### PR TITLE
fix(web): keep the reply text on screen next to an MCP App card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.
 - (beta) PDF export: the built-in server disappears from workspaces when the export feature is turned off.
 - (beta) MCP App cards no longer reload when a sibling card in the same reply fails to render.

--- a/apps/web-embed/src/chat/EmbedChat.stories.tsx
+++ b/apps/web-embed/src/chat/EmbedChat.stories.tsx
@@ -11,6 +11,7 @@ import {
   resourceCardsOnlyConversation,
   shortConversation,
   sourcesConversation,
+  textWithMcpAppCardConversation,
 } from "./chat.factory"
 import { EmbedChat } from "./EmbedChat"
 
@@ -116,6 +117,13 @@ export const LoadingMcpAppCard: Story = {
   args: {
     messages: loadingMcpAppCardConversation,
     isMcpAppHtmlLoading: true,
+  },
+}
+
+export const TextWithMcpAppCard: Story = {
+  name: "MCP App card with reply text",
+  args: {
+    messages: textWithMcpAppCardConversation,
   },
 }
 

--- a/apps/web-embed/src/chat/chat.factory.ts
+++ b/apps/web-embed/src/chat/chat.factory.ts
@@ -1,4 +1,5 @@
 import { type AgentSessionMessageDto, ToolName } from "@caseai-connect/api-contracts"
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/ext-apps"
 
 let idCounter = 1
 function nextId() {
@@ -186,6 +187,80 @@ export const loadingMcpAppCardConversation: AgentSessionMessageDto[] = [
           structuredContent: { fileName: "Notes.pdf" },
         },
         mcpApp: { mcpServerId: "mcp-server-1", resourceUri: "ui://pdf-export/mcp-app.html" },
+      },
+    ],
+  }),
+]
+
+/**
+ * Minimal MCP App guest for stories only: it completes the `ui/initialize` handshake and shows the
+ * tool result's file name. Not the card served by the PDF export server.
+ */
+const SAMPLE_CARD_HTML = `<!DOCTYPE html>
+<html>
+  <body style="font: 13px sans-serif; margin: 8px;">
+    <div id="root">Loading…</div>
+    <script>
+      (function () {
+        function send(message) {
+          window.parent.postMessage(Object.assign({ jsonrpc: "2.0" }, message), "*")
+        }
+        function notifySize() {
+          send({
+            method: "ui/notifications/size-changed",
+            params: { height: document.documentElement.getBoundingClientRect().height },
+          })
+        }
+        window.addEventListener("message", function (event) {
+          if (event.source !== window.parent) return
+          var message = event.data
+          if (!message || message.jsonrpc !== "2.0") return
+          if (message.method === "ui/notifications/tool-result") {
+            var structuredContent = (message.params && message.params.structuredContent) || {}
+            document.getElementById("root").textContent = structuredContent.fileName || "document.pdf"
+            notifySize()
+            return
+          }
+          if (message.id === 1 && message.result) {
+            send({ method: "ui/notifications/initialized" })
+          }
+        })
+        send({
+          id: 1,
+          method: "ui/initialize",
+          params: {
+            appInfo: { name: "sample", version: "0" },
+            appCapabilities: {},
+            protocolVersion: "${LATEST_PROTOCOL_VERSION}",
+          },
+        })
+        notifySize()
+      })()
+    </script>
+  </body>
+</html>`
+
+/**
+ * A reply with prose and a rendered MCP App card: the text stays in its bubble above the card,
+ * the card shows the tool result below it.
+ */
+export const textWithMcpAppCardConversation: AgentSessionMessageDto[] = [
+  buildUserMessage("Export these notes as a PDF."),
+  buildAssistantMessage("Done! You can download the PDF from the card below.\n\nAnything else?", {
+    toolCalls: [
+      {
+        id: "call-pdf-export",
+        name: "export_pdf",
+        arguments: { markdown: "# Notes" },
+        result: {
+          content: [{ type: "text", text: "Created Notes.pdf (2 pages)." }],
+          structuredContent: { fileName: "Notes.pdf" },
+        },
+        mcpApp: {
+          mcpServerId: "mcp-server-1",
+          resourceUri: "ui://pdf-export/mcp-app.html",
+          html: SAMPLE_CARD_HTML,
+        },
       },
     ],
   }),

--- a/apps/web-embed/src/chat/components/ChatMessage.tsx
+++ b/apps/web-embed/src/chat/components/ChatMessage.tsx
@@ -9,7 +9,7 @@ import { cn } from "../lib/cn"
 import { ChatBotMessage, ChatUserMessage } from "./index"
 import { MarkdownWrapper } from "./MarkdownWrapper"
 import { McpAppPlaceholder, McpAppView } from "./McpAppView"
-import { getFailedMcpAppFallbackText, getRenderableMcpApp, hasMcpAppCard } from "./mcp-app-view"
+import { getRenderableMcpApp, getReplyBubbleText, hasMcpAppCard } from "./mcp-app-view"
 import { findSourcesTool, SourcesTool } from "./SourcesTool"
 import { Spinner } from "./Spinner"
 import {
@@ -47,18 +47,14 @@ export function ChatMessage({
           .filter(({ view }) => view === undefined && !isMcpAppHtmlLoading)
           .map(({ toolCall }) => toolCall.id),
       ]
-      const hasContent = message.content.trim().length > 0
-      // A card that failed to render must not take the reply text down with it.
-      const hideMarkdownRecap =
-        !isStreaming &&
-        mcpAppCards.some(({ toolCall }) => !unavailableMcpAppToolCallIds.includes(toolCall.id))
-      // The model may have written nothing because it expected the card to speak for the tool:
-      // once the card gave up, the tool result text stands in for the reply.
-      const failedMcpAppFallbackText = hasContent
-        ? ""
-        : getFailedMcpAppFallbackText(message.toolCalls, unavailableMcpAppToolCallIds)
-      const bubbleContent =
-        hasContent && !hideMarkdownRecap ? message.content : failedMcpAppFallbackText
+      // The reply text stays on screen next to its cards. The model may have written nothing
+      // because it expected the card to speak for the tool: once the card gave up, the tool
+      // result text stands in for the reply.
+      const bubbleContent = getReplyBubbleText(
+        message.content,
+        message.toolCalls,
+        unavailableMcpAppToolCallIds,
+      )
       const surfaceResourcesTool = findSurfaceResourcesTool(message.toolCalls)
       const sourcesTool = findSourcesTool(message.toolCalls)
       // A card on screen, loading or rendered even if it later gave up, means the reply is not
@@ -67,10 +63,9 @@ export function ChatMessage({
         ({ view }) => view !== undefined || isMcpAppHtmlLoading,
       )
       const isEmpty =
-        !hasContent &&
         message.status === "completed" &&
         !hasCardOnScreen &&
-        failedMcpAppFallbackText.length === 0 &&
+        bubbleContent.length === 0 &&
         !hasSurfacedResources(message.toolCalls)
       // "aborted": the stream died with the server before anything was written.
       const isError = message.status === "error" || message.status === "aborted" || isEmpty

--- a/apps/web-embed/src/chat/components/mcp-app-view.ts
+++ b/apps/web-embed/src/chat/components/mcp-app-view.ts
@@ -60,14 +60,18 @@ export function getRenderableMcpApp(
   }
 }
 
-/** The MCP App iframe already shows the tool result, so the markdown recap is redundant. */
-export function hasRenderableMcpApp(
+/**
+ * Text of the reply bubble. What the model wrote always stands, next to its MCP App cards: the
+ * card shows the tool result, the text carries what the model said about it. Only when the model
+ * wrote nothing does the text of a card that gave up rendering stand in for the reply.
+ */
+export function getReplyBubbleText(
+  content: string,
   toolCalls: AgentSessionToolCallDto[] | undefined,
-  htmlEntries: AgentSessionMcpAppHtmlDto[] = [],
-): boolean {
-  return (toolCalls ?? []).some(
-    (toolCall) => getRenderableMcpApp(toolCall, htmlEntries) !== undefined,
-  )
+  unavailableMcpAppToolCallIds: string[],
+): string {
+  if (content.trim().length > 0) return content
+  return getFailedMcpAppFallbackText(toolCalls, unavailableMcpAppToolCallIds)
 }
 
 /**

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/AgentSessionMessage.tsx
@@ -26,7 +26,7 @@ import { useFormResult } from "./form-result-context"
 import { useFormSubSessions } from "./form-sub-sessions-context"
 import { MarkdownWrapper } from "./MarkdownWrapper"
 import { McpAppPlaceholder, McpAppView } from "./McpAppView"
-import { getFailedMcpAppFallbackText, getRenderableMcpApp, hasMcpAppCard } from "./mcp-app-view"
+import { getRenderableMcpApp, getReplyBubbleText, hasMcpAppCard } from "./mcp-app-view"
 import { SourcesTool } from "./SourcesTool"
 import { SubAgentFormResultSheet } from "./SubAgentFormResultSheet"
 import { SurfaceResourcesTool } from "./SurfaceResourcesTool"
@@ -55,7 +55,6 @@ export function AgentSessionMessage({
   switch (message.role) {
     case "assistant": {
       const isStreaming = message.status === "streaming"
-      const hasContent = message.content.trim().length > 0
       const isError = message.status === "error"
       // The stream died with the server (typically a deploy mid-reply): nothing was written.
       const isInterrupted = message.status === "aborted"
@@ -77,17 +76,14 @@ export function AgentSessionMessage({
           .filter(({ view }) => view === undefined && !isMcpAppHtmlPending)
           .map(({ toolCall }) => toolCall.id),
       ]
-      // A card that failed to render must not take the reply text down with it.
-      const hideMarkdownRecap =
-        !isStreaming &&
-        mcpAppCards.some(({ toolCall }) => !unavailableMcpAppToolCallIds.includes(toolCall.id))
-      // The model may have written nothing because it expected the card to speak for the tool:
-      // once the card gave up, the tool result text stands in for the reply.
-      const failedMcpAppFallbackText = hasContent
-        ? ""
-        : getFailedMcpAppFallbackText(message.toolCalls, unavailableMcpAppToolCallIds)
-      const bubbleContent =
-        hasContent && !hideMarkdownRecap ? message.content : failedMcpAppFallbackText
+      // The reply text stays on screen next to its cards. The model may have written nothing
+      // because it expected the card to speak for the tool: once the card gave up, the tool
+      // result text stands in for the reply.
+      const bubbleContent = getReplyBubbleText(
+        message.content,
+        message.toolCalls,
+        unavailableMcpAppToolCallIds,
+      )
       // Tool names this message delegated to that resolved to a form sub-session,
       // deduplicated so a sub-agent invoked twice shows a single affordance.
       const delegatedToolNames = [

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.spec.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.spec.ts
@@ -5,9 +5,9 @@ import {
   getFailedMcpAppFallbackText,
   getMcpAppToolResultText,
   getRenderableMcpApp,
+  getReplyBubbleText,
   hasMcpAppCard,
   hasMcpAppPointer,
-  hasRenderableMcpApp,
   isOpenableLink,
 } from "./mcp-app-view"
 
@@ -115,28 +115,33 @@ describe("getRenderableMcpApp", () => {
   })
 })
 
-describe("hasRenderableMcpApp", () => {
-  it("is false for ordinary tool calls", () => {
-    expect(hasRenderableMcpApp([baseToolCall])).toBe(false)
+describe("getReplyBubbleText", () => {
+  const renderedCardToolCall: AgentSessionToolCallDto = {
+    ...cardToolCall,
+    id: "call-2",
+    result: { content: [{ type: "text", text: "Created Notes.pdf (2 pages)." }] },
+    mcpApp: { ...pointer, html: "<html><body>Card</body></html>" },
+  }
+
+  it("keeps the reply text next to a rendered card", () => {
+    // The card shows the tool result, the text carries what the model said about it.
+    expect(
+      getReplyBubbleText("Done! Download it from the card below.", [renderedCardToolCall], []),
+    ).toBe("Done! Download it from the card below.")
   })
 
-  it("is true when at least one tool call has MCP App HTML and a result", () => {
-    expect(
-      hasRenderableMcpApp([
-        baseToolCall,
-        {
-          ...baseToolCall,
-          id: "call-2",
-          name: "get_patient",
-          result: { structuredContent: { title: "Ada" } },
-          mcpApp: {
-            mcpServerId: "mcp-server-1",
-            resourceUri: "ui://patient-summary/mcp-app.html",
-            html: "<html><body>Patient</body></html>",
-          },
-        },
-      ]),
-    ).toBe(true)
+  it("keeps the reply text when a card gave up rendering", () => {
+    expect(getReplyBubbleText("Done!", [renderedCardToolCall], ["call-2"])).toBe("Done!")
+  })
+
+  it("says nothing when the model wrote nothing and the card is on screen", () => {
+    expect(getReplyBubbleText("  ", [renderedCardToolCall], [])).toBe("")
+  })
+
+  it("lets the tool result text stand in when the model wrote nothing and the card gave up", () => {
+    expect(getReplyBubbleText("", [renderedCardToolCall], ["call-2"])).toBe(
+      "Created Notes.pdf (2 pages).",
+    )
   })
 })
 

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/components/mcp-app-view.ts
@@ -55,14 +55,18 @@ export function getRenderableMcpApp(
   }
 }
 
-/** The MCP App iframe already shows the tool result, so the markdown recap is redundant. */
-export function hasRenderableMcpApp(
+/**
+ * Text of the reply bubble. What the model wrote always stands, next to its MCP App cards: the
+ * card shows the tool result, the text carries what the model said about it. Only when the model
+ * wrote nothing does the text of a card that gave up rendering stand in for the reply.
+ */
+export function getReplyBubbleText(
+  content: string,
   toolCalls: AgentSessionToolCallDto[] | undefined,
-  htmlEntries: AgentSessionMcpAppHtml[] = [],
-): boolean {
-  return (toolCalls ?? []).some(
-    (toolCall) => getRenderableMcpApp(toolCall, htmlEntries) !== undefined,
-  )
+  unavailableMcpAppToolCallIds: string[],
+): string {
+  if (content.trim().length > 0) return content
+  return getFailedMcpAppFallbackText(toolCalls, unavailableMcpAppToolCallIds)
 }
 
 /**

--- a/apps/web/src/stories/common/McpAppView.stories.tsx
+++ b/apps/web/src/stories/common/McpAppView.stories.tsx
@@ -11,7 +11,7 @@ import { McpAppView } from "@/common/features/agents/agent-sessions/shared/agent
  * iframe, which only succeeds because of the `allow-popups allow-popups-to-escape-sandbox`
  * sandbox flags on both the outer and inner iframes.
  */
-const SAMPLE_CARD_HTML = `<!DOCTYPE html>
+export const SAMPLE_CARD_HTML = `<!DOCTYPE html>
 <html>
   <body style="font: 13px sans-serif; margin: 8px;">
     <div id="root">Loading…</div>

--- a/apps/web/src/stories/routes/Chat.stories.tsx
+++ b/apps/web/src/stories/routes/Chat.stories.tsx
@@ -18,6 +18,7 @@ import {
 import { organizationFactory } from "@/common/features/organizations/organization.factory"
 import { projectFactory } from "@/common/features/projects/projects.factory"
 import { DotsBackground } from "@/studio/components/DotsBackground"
+import { SAMPLE_CARD_HTML } from "../common/McpAppView.stories"
 import { withRedux } from "../decorators"
 import { mergeSeeds, seed } from "../seed"
 
@@ -192,6 +193,43 @@ export const LoadingMcpAppCard: Story = {
               structuredContent: { fileName: "Notes.pdf" },
             },
             mcpApp: { mcpServerId: "mcp-server-1", resourceUri: "ui://pdf-export/mcp-app.html" },
+          },
+        ],
+      }),
+    ],
+  },
+}
+
+/**
+ * A reply with prose and a rendered MCP App card: the text stays in its bubble above the card,
+ * the card shows the tool result below it.
+ */
+export const TextWithMcpAppCard: Story = {
+  ...Default,
+  args: {
+    messages: [
+      agentSessionMessageFactory.build({ role: "user", content: "Export these notes as a PDF." }),
+      agentSessionMessageFactory.build({
+        role: "assistant",
+        content: "Done! You can download the PDF from the card below.\n\nAnything else?",
+        toolCalls: [
+          {
+            id: "call-pdf-export",
+            name: "export_pdf",
+            arguments: { markdown: "# Notes" },
+            result: {
+              content: [{ type: "text", text: "Created Notes.pdf (2 pages)." }],
+              structuredContent: {
+                fileName: "Notes.pdf",
+                downloadUrl: "https://example.com/notes.pdf",
+                expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+              },
+            },
+            mcpApp: {
+              mcpServerId: "mcp-server-1",
+              resourceUri: "ui://pdf-export/mcp-app.html",
+              html: SAMPLE_CARD_HTML,
+            },
           },
         ],
       }),


### PR DESCRIPTION
## Why

In the chat, a reply such as *"C'est fait ! Vous pouvez télécharger le récapitulatif ... via la carte qui vient de s'afficher. Souhaitez-vous autre chose ?"* showed for about a second while streaming, then vanished as soon as the PDF export card rendered.

Root cause: since #657 the message component treated the reply text as a redundant recap of the card and hid it once streaming ended and a card was renderable (`hideMarkdownRecap`). The prompt already tells the model not to recap the card, so what it writes is not a recap but its own words about the tool, and losing them also loses the follow-up question and the copy button.

## What changes

- The reply text always stays in its bubble, above the card, in the web app and the embed widget.
- The tool result text still stands in when the model wrote nothing and the card gave up rendering.
- The decision is extracted into a small `getReplyBubbleText` helper with unit tests. The unused `hasRenderableMcpApp` is gone.
- New stories `TextWithMcpAppCard` (web Chat and embed) show text and a rendered card together.
- Changelog entry.

## Checks

- `npm run biome:check` passes
- web and web-embed `typecheck` pass
- web vitest suite passes (162 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
