### PR TITLE
feat(web): runtime configuration and an app-runtime image (front + API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 
 ### Added
 
+- Self-hosting: one Docker image can serve the web app and the API together, configured by environment variables.
 - (beta) Priority calls: agents on Gemini 3.x models can now enable the priority tier from the Model tab.
 - Agents can run on gemini-3.7-flash and gemini-3.8-flash.
 - Public agent banner: an optional notice pinned above the conversation on the public page and in the widget.

--- a/apps/api/.env-example
+++ b/apps/api/.env-example
@@ -131,3 +131,18 @@ VLLM_xxx_API="<not used>"
 # PDF_EXPORT_TMP_PREFIX=tmp/pdf-exports/
 # Required by every worker process (no default in code); must match the name listed in WORKER_QUEUE_NAMES.
 PDF_EXPORTS_SWEEP_QUEUE_NAME=pdf-exports-sweep
+
+# Web front served by the API (app-runtime image only). Unset locally: `vite dev` serves the front.
+# WEB_APP_DIST_DIR=/app/apps/web/dist
+# Browser configuration injected into index.html as window.__CONFIG__ (public values only).
+# Defaults: same origin for the API, Auth0 domain/audience/organization taken from the AUTH0_* values above.
+# WEB_AUTH0_CLIENT_ID=XXX            # required: the SPA application, not the API one
+# WEB_API_URL=                       # empty = same origin
+# WEB_APP_TITLE=AgentStudio
+# WEB_HELP_CENTER_URL=
+# WEB_AGENT_EMBED_URL=
+# WEB_HELP_AGENT_EMBED_TOKEN=
+# WEB_HELP_AGENT_EMBED_COLOR=
+# WEB_HELP_AGENT_EMBED_HINT=
+# WEB_API_TIMEOUT_MS=10000
+# WEB_DEFAULT_CONVERSATION_AGENT_PROMPT= (base64, same as the VITE_DEFAULT_* values of apps/web)

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -41,6 +41,30 @@ RUN rm -rf node_modules/next node_modules/sharp node_modules/@img
 RUN mkdir -p /app/apps/api/node_modules
 
 #
+# 🌐 Web front build (only used by the app-runtime target)
+#
+# Builds apps/web with `/app/` as public path: the API serves the result under
+# /app (see apps/api/src/common/web-app). No VITE_* tenant value is baked in:
+# the API injects the runtime configuration into index.html from its own
+# environment, so one image serves every tenant.
+#
+FROM node:24.20.0-bookworm-slim AS web-build
+
+WORKDIR /app
+COPY apps/web ./apps/web
+COPY ./packages ./packages
+COPY package-lock.json ./
+COPY package.json ./
+
+RUN npm ci \
+    --workspace=@caseai-connect/web \
+    --workspace=@caseai-connect/ui \
+    --workspace=@caseai-connect/api-contracts \
+    --include-workspace-root
+ENV VITE_BASE_PATH=/app/
+RUN cd apps/web && npm run build
+
+#
 # 🚀 Runtime Base (shared)
 #
 FROM node:24.20.0-bookworm-slim AS runtime-base
@@ -63,6 +87,17 @@ COPY --from=build /app/node_modules node_modules
 FROM runtime-base AS api-runtime
 
 CMD ["node", "--enable-source-maps", "/app/apps/api/dist/main.js"]
+
+#
+# 🚀 App Runtime: API + web front in one image
+#
+# Same process as api-runtime, plus the built web front served under /app.
+# WEB_APP_DIST_DIR switches the serving on; the API image stays API-only.
+#
+FROM api-runtime AS app-runtime
+
+COPY --from=web-build /app/apps/web/dist /app/apps/web/dist
+ENV WEB_APP_DIST_DIR=/app/apps/web/dist
 
 #
 # 🚀 CPU Workers Runtime (no Docling)

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { BullBoardAdminModule } from "./common/bull-board/bull-board-admin.modul
 import { DiagnosticsModule } from "./common/diagnostics/diagnostics.module"
 import { RequestLoggerMiddleware } from "./common/middleware/request-logger.middleware"
 import { TransactionModule } from "./common/transaction/transaction.module"
+import { WebAppModule } from "./common/web-app/web-app.module"
 import typeorm from "./config/typeorm"
 import { AgentsModule } from "./domains/agents/agents.module"
 import { ConversationAgentSessionsModule } from "./domains/agents/conversation-agent-sessions/conversation-agent-sessions.module"
@@ -50,6 +51,7 @@ import { UsersModule } from "./domains/users/users.module"
       useFactory: async (configService: ConfigService) => configService.get("typeorm")(),
     }),
     TransactionModule,
+    WebAppModule.register(),
     AgentEmbedConfigsManagementModule,
     AgentMessageFeedbackModule,
     AgentsAnalyticsModule,

--- a/apps/api/src/common/web-app/web-app-config.spec.ts
+++ b/apps/api/src/common/web-app/web-app-config.spec.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildWebAppRuntimeConfig, getWebAppSettings } from "./web-app-config"
+
+describe("getWebAppSettings", () => {
+  it("is disabled when WEB_APP_DIST_DIR is unset", () => {
+    expect(getWebAppSettings({})).toBeNull()
+  })
+
+  it("is disabled when the folder has no index.html", () => {
+    const distDir = mkdtempSync(join(tmpdir(), "web-app-"))
+    expect(getWebAppSettings({ WEB_APP_DIST_DIR: distDir })).toBeNull()
+  })
+
+  it("points to index.html when the build is present", () => {
+    const distDir = mkdtempSync(join(tmpdir(), "web-app-"))
+    writeFileSync(join(distDir, "index.html"), "<html></html>")
+    expect(getWebAppSettings({ WEB_APP_DIST_DIR: distDir })).toEqual({
+      distDir,
+      indexHtmlPath: join(distDir, "index.html"),
+    })
+  })
+})
+
+describe("buildWebAppRuntimeConfig", () => {
+  it("defaults to the same origin and the Auth0 tenant the API validates", () => {
+    const config = buildWebAppRuntimeConfig({
+      AUTH0_ISSUER_URL: "https://tenant.eu.auth0.com/",
+      AUTH0_AUDIENCE: "https://tenant.eu.auth0.com/api/v2/",
+      AUTH0_ORGANIZATION_ID: "org_123",
+    })
+    expect(config).toEqual({
+      apiUrl: "",
+      auth0Domain: "tenant.eu.auth0.com",
+      auth0Audience: "https://tenant.eu.auth0.com/api/v2/",
+      auth0OrganizationId: "org_123",
+    })
+  })
+
+  it("maps WEB_* variables and lets them override the defaults", () => {
+    const config = buildWebAppRuntimeConfig({
+      AUTH0_ISSUER_URL: "https://tenant.eu.auth0.com/",
+      WEB_AUTH0_DOMAIN: "login.example.org",
+      WEB_AUTH0_CLIENT_ID: "spa-client",
+      WEB_API_URL: "https://api.example.org",
+      WEB_APP_TITLE: "Acme",
+      WEB_HELP_AGENT_EMBED_HINT: '{"en":"Need help?"}',
+    })
+    expect(config.auth0Domain).toBe("login.example.org")
+    expect(config.auth0ClientId).toBe("spa-client")
+    expect(config.apiUrl).toBe("https://api.example.org")
+    expect(config.appTitle).toBe("Acme")
+    expect(config.helpAgentEmbedHint).toBe('{"en":"Need help?"}')
+  })
+
+  it("never copies unrelated environment variables", () => {
+    const config = buildWebAppRuntimeConfig({ AUTH0_CLIENT_SECRET: "secret", DATABASE_URL: "x" })
+    expect(Object.values(config)).not.toContain("secret")
+    expect(Object.values(config)).not.toContain("x")
+  })
+})

--- a/apps/api/src/common/web-app/web-app-config.ts
+++ b/apps/api/src/common/web-app/web-app-config.ts
@@ -1,0 +1,91 @@
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+
+/**
+ * The web front (apps/web) served by the API, from the `app-runtime` image.
+ *
+ * Enabled when WEB_APP_DIST_DIR points to a built `apps/web/dist` folder. The
+ * image sets it; the plain `api-runtime` image and local development do not,
+ * so the API stays API-only there.
+ *
+ * The SPA lives under /app. The API routes stay at the root, so a browser
+ * reload on a SPA route never hits an API route by accident.
+ */
+export const WEB_APP_PREFIX = "/app"
+
+export type WebAppSettings = {
+  distDir: string
+  indexHtmlPath: string
+}
+
+/** DI token of the WebAppSettings value (a plain object, so no class to inject by type). */
+export const WEB_APP_SETTINGS = "WEB_APP_SETTINGS"
+
+export function getWebAppSettings(env: NodeJS.ProcessEnv = process.env): WebAppSettings | null {
+  const distDir = env.WEB_APP_DIST_DIR?.trim()
+  if (!distDir) return null
+  const indexHtmlPath = join(distDir, "index.html")
+  if (!existsSync(indexHtmlPath)) return null
+  return { distDir, indexHtmlPath }
+}
+
+/**
+ * Runtime configuration handed to the browser as `window.__CONFIG__`.
+ * Keys match `RuntimeConfig` in apps/web/src/config/runtime-config.ts.
+ * Public by construction: never put a secret here.
+ */
+export type WebAppRuntimeConfig = Record<string, string>
+
+const ENV_TO_CONFIG_KEY: Record<string, string> = {
+  WEB_API_URL: "apiUrl",
+  WEB_API_TIMEOUT_MS: "apiTimeoutMs",
+  WEB_APP_TITLE: "appTitle",
+  WEB_AGENT_EMBED_URL: "agentEmbedUrl",
+  WEB_HELP_CENTER_URL: "helpCenterUrl",
+  WEB_HELP_AGENT_EMBED_TOKEN: "helpAgentEmbedToken",
+  WEB_HELP_AGENT_EMBED_COLOR: "helpAgentEmbedColor",
+  WEB_HELP_AGENT_EMBED_HINT: "helpAgentEmbedHint",
+  WEB_AUTH0_DOMAIN: "auth0Domain",
+  WEB_AUTH0_CLIENT_ID: "auth0ClientId",
+  WEB_AUTH0_AUDIENCE: "auth0Audience",
+  WEB_AUTH0_ORGANIZATION_ID: "auth0OrganizationId",
+  WEB_DEFAULT_CONVERSATION_AGENT_PROMPT: "defaultConversationAgentPrompt",
+  WEB_DEFAULT_FORM_AGENT_PROMPT: "defaultFormAgentPrompt",
+  WEB_DEFAULT_FORM_AGENT_SCHEMA: "defaultFormAgentSchema",
+  WEB_DEFAULT_EXTRACTION_AGENT_PROMPT: "defaultExtractionAgentPrompt",
+  WEB_DEFAULT_EXTRACTION_AGENT_SCHEMA: "defaultExtractionAgentSchema",
+}
+
+/**
+ * Builds the browser configuration from the environment.
+ *
+ * Defaults keep the Helm values short: the API URL is the page origin (same
+ * image, same host), and the Auth0 tenant, audience and organization are
+ * those the API already validates tokens against. The SPA client id has no
+ * API-side counterpart (AUTH0_CLIENT_ID is a different application), so
+ * WEB_AUTH0_CLIENT_ID is always required.
+ */
+export function buildWebAppRuntimeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): WebAppRuntimeConfig {
+  const config: WebAppRuntimeConfig = {
+    apiUrl: "",
+    auth0Domain: auth0DomainFromIssuerUrl(env.AUTH0_ISSUER_URL) ?? "",
+    auth0Audience: env.AUTH0_AUDIENCE ?? "",
+    auth0OrganizationId: env.AUTH0_ORGANIZATION_ID ?? "",
+  }
+  for (const [envName, configKey] of Object.entries(ENV_TO_CONFIG_KEY)) {
+    const value = env[envName]
+    if (value !== undefined) config[configKey] = value
+  }
+  return config
+}
+
+function auth0DomainFromIssuerUrl(issuerUrl: string | undefined): string | undefined {
+  if (!issuerUrl) return undefined
+  try {
+    return new URL(issuerUrl).host
+  } catch {
+    return undefined
+  }
+}

--- a/apps/api/src/common/web-app/web-app-html.spec.ts
+++ b/apps/api/src/common/web-app/web-app-html.spec.ts
@@ -1,0 +1,39 @@
+import { renderIndexHtml, serializeForInlineScript } from "./web-app-html"
+
+const template = `<!doctype html>
+<html>
+  <head>
+    <title>AgentStudio</title>
+  </head>
+  <body><div id="root"></div></body>
+</html>`
+
+describe("serializeForInlineScript", () => {
+  it("keeps a script-closing tag inside a value inert", () => {
+    const serialized = serializeForInlineScript({ appTitle: "</script><script>alert(1)" })
+    expect(serialized).not.toContain("</script>")
+    expect(JSON.parse(serialized)).toEqual({ appTitle: "</script><script>alert(1)" })
+  })
+})
+
+describe("renderIndexHtml", () => {
+  it("injects window.__CONFIG__ before </head>", () => {
+    const html = renderIndexHtml(template, { apiUrl: "", auth0Domain: "tenant.auth0.com" })
+    const headEnd = html.indexOf("</head>")
+    const scriptIndex = html.indexOf(
+      '<script>window.__CONFIG__={"apiUrl":"","auth0Domain":"tenant.auth0.com"}</script>',
+    )
+    expect(scriptIndex).toBeGreaterThan(-1)
+    expect(scriptIndex).toBeLessThan(headEnd)
+  })
+
+  it("keeps the built title when the tenant sets none", () => {
+    expect(renderIndexHtml(template, { apiUrl: "" })).toContain("<title>AgentStudio</title>")
+  })
+
+  it("replaces the title with an escaped tenant title", () => {
+    const html = renderIndexHtml(template, { apiUrl: "", appTitle: "Acme <Health> & Co" })
+    expect(html).toContain("<title>Acme &lt;Health&gt; &amp; Co</title>")
+    expect(html).not.toContain("<title>AgentStudio</title>")
+  })
+})

--- a/apps/api/src/common/web-app/web-app-html.ts
+++ b/apps/api/src/common/web-app/web-app-html.ts
@@ -1,0 +1,43 @@
+import type { WebAppRuntimeConfig } from "./web-app-config"
+
+const CONFIG_SCRIPT_MARKER = "</head>"
+const TITLE_PATTERN = /<title>[^<]*<\/title>/
+
+/**
+ * Serializes the configuration for inline use inside a <script> tag. JSON is
+ * not HTML-safe on its own: `</script>` inside a value would end the tag.
+ * Escaping `<`, `>` and `&` as unicode escapes keeps the payload valid JSON
+ * and inert as HTML. U+2028 and U+2029 are line terminators in old JS engines.
+ */
+export function serializeForInlineScript(config: WebAppRuntimeConfig): string {
+  return JSON.stringify(config)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+}
+
+/**
+ * Renders the SPA entry page: the built `index.html` with the runtime
+ * configuration injected before `</head>`, so `window.__CONFIG__` exists
+ * before the app bundle runs. The title is replaced when the tenant sets one
+ * (the build leaves the default in place).
+ */
+export function renderIndexHtml(template: string, config: WebAppRuntimeConfig): string {
+  const script = `<script>window.__CONFIG__=${serializeForInlineScript(config)}</script>`
+  const withConfig = template.includes(CONFIG_SCRIPT_MARKER)
+    ? template.replace(CONFIG_SCRIPT_MARKER, `${script}\n  ${CONFIG_SCRIPT_MARKER}`)
+    : `${script}\n${template}`
+  const appTitle = config.appTitle?.trim()
+  if (!appTitle) return withConfig
+  return withConfig.replace(TITLE_PATTERN, `<title>${escapeHtml(appTitle)}</title>`)
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}

--- a/apps/api/src/common/web-app/web-app.controller.spec.ts
+++ b/apps/api/src/common/web-app/web-app.controller.spec.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { NestExpressApplication } from "@nestjs/platform-express"
+import { Test } from "@nestjs/testing"
+import request from "supertest"
+import { registerWebAppStaticAssets, WebAppModule } from "./web-app.module"
+import { getWebAppSettings } from "./web-app-config"
+
+function buildDist(): string {
+  const distDir = mkdtempSync(join(tmpdir(), "web-app-dist-"))
+  mkdirSync(join(distDir, "assets"))
+  mkdirSync(join(distDir, "theme"))
+  writeFileSync(
+    join(distDir, "index.html"),
+    "<html><head><title>AgentStudio</title></head><body></body></html>",
+  )
+  writeFileSync(join(distDir, "assets", "index-abc123.js"), "console.log(1)")
+  writeFileSync(join(distDir, "theme", "logo.svg"), "<svg></svg>")
+  return distDir
+}
+
+async function createApp(distDir: string): Promise<NestExpressApplication> {
+  const settings = getWebAppSettings({ WEB_APP_DIST_DIR: distDir })
+  const module = await Test.createTestingModule({
+    imports: [WebAppModule.register(settings)],
+  }).compile()
+  const app = module.createNestApplication<NestExpressApplication>()
+  registerWebAppStaticAssets(app, settings)
+  await app.init()
+  return app
+}
+
+describe("WebAppController", () => {
+  const previousEnv = { ...process.env }
+  let app: NestExpressApplication
+
+  beforeAll(async () => {
+    process.env.WEB_APP_TITLE = "Acme Platform"
+    process.env.WEB_AUTH0_CLIENT_ID = "spa-client"
+    app = await createApp(buildDist())
+  })
+
+  afterAll(async () => {
+    process.env = previousEnv
+    await app.close()
+  })
+
+  it("serves the entry page with the injected configuration under /app", async () => {
+    const response = await request(app.getHttpServer()).get("/app")
+    expect(response.status).toBe(200)
+    expect(response.headers["content-type"]).toMatch(/text\/html/)
+    expect(response.headers["cache-control"]).toBe("no-store")
+    expect(response.headers["permissions-policy"]).toBe("microphone=(self)")
+    expect(response.text).toContain('"auth0ClientId":"spa-client"')
+    expect(response.text).toContain("<title>Acme Platform</title>")
+  })
+
+  it("serves the entry page for every client route", async () => {
+    const response = await request(app.getHttpServer()).get("/app/studio/agents/42/settings")
+    expect(response.status).toBe(200)
+    expect(response.text).toContain("window.__CONFIG__")
+  })
+
+  it("serves hashed assets as immutable", async () => {
+    const response = await request(app.getHttpServer()).get("/app/assets/index-abc123.js")
+    expect(response.status).toBe(200)
+    expect(response.headers["cache-control"]).toBe("public, max-age=31536000, immutable")
+    expect(response.text).toBe("console.log(1)")
+  })
+
+  it("serves theme files with a short cache", async () => {
+    const response = await request(app.getHttpServer()).get("/app/theme/logo.svg")
+    expect(response.status).toBe(200)
+    expect(response.headers["cache-control"]).toBe("public, max-age=300")
+  })
+
+  it("redirects the root to the SPA", async () => {
+    const response = await request(app.getHttpServer()).get("/")
+    expect(response.status).toBe(302)
+    expect(response.headers.location).toBe("/app/")
+  })
+})
+
+describe("WebAppModule without WEB_APP_DIST_DIR", () => {
+  it("registers no route", async () => {
+    const module = await Test.createTestingModule({
+      imports: [WebAppModule.register(null)],
+    }).compile()
+    const app = module.createNestApplication<NestExpressApplication>()
+    registerWebAppStaticAssets(app, null)
+    await app.init()
+    expect((await request(app.getHttpServer()).get("/app")).status).toBe(404)
+    expect((await request(app.getHttpServer()).get("/")).status).toBe(404)
+    await app.close()
+  })
+})

--- a/apps/api/src/common/web-app/web-app.controller.ts
+++ b/apps/api/src/common/web-app/web-app.controller.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs"
+import { Controller, Get, Header, Inject, Redirect } from "@nestjs/common"
+import {
+  buildWebAppRuntimeConfig,
+  WEB_APP_PREFIX,
+  WEB_APP_SETTINGS,
+  type WebAppSettings,
+} from "./web-app-config"
+import { renderIndexHtml } from "./web-app-html"
+
+/**
+ * Serves the SPA entry page for `/app` and every route under it. The hashed
+ * assets are served by express.static (see registerWebAppStaticAssets), so a
+ * request that reaches this controller is a browser navigation: it gets the
+ * entry page and the client router takes over.
+ */
+@Controller(WEB_APP_PREFIX.slice(1))
+export class WebAppController {
+  private readonly html: string
+
+  constructor(@Inject(WEB_APP_SETTINGS) settings: WebAppSettings) {
+    const template = readFileSync(settings.indexHtmlPath, "utf8")
+    this.html = renderIndexHtml(template, buildWebAppRuntimeConfig())
+  }
+
+  @Get(["", "{*path}"])
+  @Header("Content-Type", "text/html; charset=utf-8")
+  @Header("Cache-Control", "no-store")
+  @Header("Permissions-Policy", "microphone=(self)")
+  @Header("X-Content-Type-Options", "nosniff")
+  index(): string {
+    return this.html
+  }
+}
+
+/** `/` goes to the SPA: the API has no page of its own at the root. */
+@Controller()
+export class WebAppRootController {
+  @Get()
+  @Redirect(`${WEB_APP_PREFIX}/`, 302)
+  root(): void {
+    // The @Redirect decorator sends the response.
+  }
+}

--- a/apps/api/src/common/web-app/web-app.module.ts
+++ b/apps/api/src/common/web-app/web-app.module.ts
@@ -1,0 +1,56 @@
+import { relative } from "node:path"
+import { type DynamicModule, Logger, Module } from "@nestjs/common"
+import type { NestExpressApplication } from "@nestjs/platform-express"
+import { WebAppController, WebAppRootController } from "./web-app.controller"
+import {
+  getWebAppSettings,
+  WEB_APP_PREFIX,
+  WEB_APP_SETTINGS,
+  type WebAppSettings,
+} from "./web-app-config"
+
+const logger = new Logger("WebApp")
+
+/**
+ * Serves the built web front from the API process when WEB_APP_DIST_DIR is
+ * set (the `app-runtime` image). Registers nothing otherwise, so the
+ * `api-runtime` image and local development are unchanged.
+ */
+@Module({})
+// biome-ignore lint/complexity/noStaticOnlyClass: NestJS dynamic module pattern (`register`)
+export class WebAppModule {
+  static register(settings: WebAppSettings | null = getWebAppSettings()): DynamicModule {
+    if (!settings) return { module: WebAppModule }
+    logger.log(`Serving the web front from ${settings.distDir} under ${WEB_APP_PREFIX}`)
+    return {
+      module: WebAppModule,
+      controllers: [WebAppController, WebAppRootController],
+      providers: [{ provide: WEB_APP_SETTINGS, useValue: settings }],
+    }
+  }
+}
+
+/**
+ * Static files of the SPA under /app: hashed assets are immutable, the rest
+ * (theme files, manifest) is short-lived so a tenant can swap them. The entry
+ * page is never served from here (`index: false`): WebAppController renders
+ * it with the runtime configuration.
+ */
+export function registerWebAppStaticAssets(
+  app: NestExpressApplication,
+  settings: WebAppSettings | null = getWebAppSettings(),
+): void {
+  if (!settings) return
+  app.useStaticAssets(settings.distDir, {
+    prefix: WEB_APP_PREFIX,
+    index: false,
+    redirect: false,
+    setHeaders: (response, filePath) => {
+      const isHashedAsset = relative(settings.distDir, filePath).startsWith("assets/")
+      const cacheControl = isHashedAsset
+        ? "public, max-age=31536000, immutable"
+        : "public, max-age=300"
+      response.setHeader("Cache-Control", cacheControl)
+    },
+  })
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,6 +10,7 @@ import { registerBullBoardOpenIdConnect } from "./common/bull-board/bull-board-o
 import { StackTraceLoggingExceptionFilter } from "./common/filters/stack-trace-logging-exception.filter"
 import { getLogLevels, StructuredLogger } from "./common/logger/structured-logger"
 import { enableDbListeners } from "./common/sse/postgres-status-stream.service"
+import { registerWebAppStaticAssets } from "./common/web-app/web-app.module"
 import { buildCorsOptionsDelegate, parseFrontendUrls } from "./config/cors"
 import { BuiltInMcpServersService } from "./domains/mcp-servers/built-in/built-in-mcp-servers.service"
 
@@ -30,6 +31,8 @@ async function bootstrap() {
     app.set("trust proxy", true)
   }
   registerBullBoardOpenIdConnect(app)
+  // Web front served from this process in the app-runtime image (no-op otherwise).
+  registerWebAppStaticAssets(app)
   app.useBodyParser("json", { limit: "500kb" })
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/web/.env-example
+++ b/apps/web/.env-example
@@ -1,4 +1,7 @@
 VITE_API_URL=http://localhost:3000
+# Public path of the SPA. Leave unset (`/`) for dev and static hosting. The
+# app-runtime Docker image builds with `/app/` because the API serves it there.
+#VITE_BASE_PATH=/
 VITE_AGENT_EMBED_URL=https://connect.localhost:5175
 VITE_API_TIMEOUT_MS=10000
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,5 +1,13 @@
 # Web Rules (Next.js — apps/web)
 
+## Runtime Configuration
+
+**Rule**: Never read `import.meta.env.VITE_*` outside `src/config/runtime-config.ts`. Import `runtimeConfig` from `@/config/runtime-config` instead.
+
+Vite inlines `VITE_*` values at build time. In the `app-runtime` Docker image the API injects `window.__CONFIG__` into `index.html` from its environment, and `runtimeConfig` prefers those values. A direct `import.meta.env` read would ignore them. New settings go in three places: the `RuntimeConfig` type and its build-time fallback, the `WEB_*` mapping in `apps/api/src/common/web-app/web-app-config.ts`, and both `.env-example` files.
+
+URLs that point back to the SPA (Auth0 redirects, `public/` assets) go through `getAppUrl()` and `publicAssetUrl()`: the SPA is served under `/app` by the API and at `/` by static hosting.
+
 ## Redux & Feature Architecture
 
 ### API Calls Must Go Through Redux + Services

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,7 +7,7 @@
          "NotFoundError: removeChild". The app is localized via i18next, so browser
          translation is disabled document-wide. -->
     <meta name="google" content="notranslate" />
-    <link rel="icon" type="image/svg+xml" href="/theme/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%theme/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>__APP_TITLE__</title>
   </head>

--- a/apps/web/src/common/components/resources/ResourceCard.tsx
+++ b/apps/web/src/common/components/resources/ResourceCard.tsx
@@ -1,5 +1,6 @@
 import { ExternalLinkIcon, PlayIcon } from "lucide-react"
 import { useState } from "react"
+import { runtimeConfig } from "@/config/runtime-config"
 
 export type ResourceCardData = {
   title: string
@@ -10,7 +11,7 @@ export type ResourceCardData = {
 /** Absolutizes uploaded-file links (relative API paths) against the API base URL. */
 export function resolveLink(link: string): string {
   if (/^https?:\/\//.test(link)) return link
-  const baseUrl = import.meta.env.VITE_API_URL as string
+  const baseUrl = runtimeConfig.apiUrl
   return `${baseUrl}${link}`
 }
 

--- a/apps/web/src/common/components/sidebar/SidebarLayout.tsx
+++ b/apps/web/src/common/components/sidebar/SidebarLayout.tsx
@@ -15,9 +15,9 @@ import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import type { Organization } from "@/common/features/organizations/organizations.models"
 import { RouteNames } from "@/common/routes/helpers"
+import { publicAssetUrl } from "@/config/runtime-config"
 import type { DeskRoutes } from "@/desk/routes/helpers"
 import { isStudioInterface, type StudioRoutes } from "@/studio/routes/helpers"
-
 import { EditProfileDialog } from "./nav/EditProfileDialog"
 import { NavUserMenuItems } from "./nav/NavUserMenuItems"
 import { SidebarBreadcrumb } from "./SidebarBreadcrumb"
@@ -97,7 +97,7 @@ export function HeaderWithLogo({ organization }: { organization?: Organization }
   return (
     <div className="flex flex-1 gap-2 items-center">
       <button type="button" onClick={onClick} className="p-1 size-10 contain-content">
-        <img src="/theme/logo.svg" alt="Logo" className="max-h-10 w-auto" />
+        <img src={publicAssetUrl("theme/logo.svg")} alt="Logo" className="max-h-10 w-auto" />
       </button>
 
       <button type="button" onClick={onClick} className="flex-1">

--- a/apps/web/src/common/components/sidebar/nav/HorizontalNavbar.tsx
+++ b/apps/web/src/common/components/sidebar/nav/HorizontalNavbar.tsx
@@ -4,6 +4,7 @@ import { NavUser } from "@/common/components/sidebar/nav/NavUser"
 
 import type { User } from "@/common/features/me/me.models"
 import { RouteNames } from "@/common/routes/helpers"
+import { publicAssetUrl } from "@/config/runtime-config"
 import { EditProfileDialog } from "./EditProfileDialog"
 import { NavUserMenuItems } from "./NavUserMenuItems"
 
@@ -22,7 +23,7 @@ export function HorizontalNavbar({
   return (
     <div className="w-full h-16 bg-white border-b flex items-center justify-between px-4 gap-2">
       <button type="button" className="p-1 size-10 contain-content" onClick={goHome}>
-        <img src="/theme/logo.svg" alt="Logo" className="max-h-10 w-auto" />
+        <img src={publicAssetUrl("theme/logo.svg")} alt="Logo" className="max-h-10 w-auto" />
       </button>
 
       <button type="button" onClick={goHome} className="flex-1">

--- a/apps/web/src/common/components/sidebar/nav/NavUserMenuItems.tsx
+++ b/apps/web/src/common/components/sidebar/nav/NavUserMenuItems.tsx
@@ -2,6 +2,7 @@ import { DropdownMenuItem, DropdownMenuSeparator } from "@caseai-connect/ui/shad
 import { ExternalLinkIcon, LogOutIcon, UserPenIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useAuthHandler } from "@/common/hooks/use-auth-handler"
+import { runtimeConfig } from "@/config/runtime-config"
 
 type Props = {
   onEditProfile: () => void
@@ -35,7 +36,7 @@ function EditProfileMenuItem({ onOpen }: { onOpen: () => void }) {
 
 function HelpCenter() {
   const { t } = useTranslation("user")
-  const path = import.meta.env.VITE_HELP_CENTER_URL as string | undefined
+  const path = runtimeConfig.helpCenterUrl
   if (!path) return null
   return (
     <DropdownMenuItem onSelect={() => window.open(path, "_blank")}>

--- a/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming.ts
+++ b/apps/web/src/common/features/agents/agent-sessions/shared/agent-session-messages/external/agent-session-messages-streaming.ts
@@ -1,3 +1,4 @@
+import { runtimeConfig } from "@/config/runtime-config"
 import { getAccessToken } from "@/external/auth0Client"
 import {
   processSSEChunk,
@@ -43,8 +44,7 @@ export async function streamChatResponse({
     const token = await getAccessToken()
     if (!token) throw new Error("No access token available")
 
-    const baseURL = import.meta.env.VITE_API_URL as string | undefined
-    if (!baseURL) throw new Error("VITE_API_URL is not defined")
+    const baseURL = runtimeConfig.apiUrl
 
     const url = buildStreamUrl({
       baseURL,

--- a/apps/web/src/common/hooks/use-auth-handler.ts
+++ b/apps/web/src/common/hooks/use-auth-handler.ts
@@ -1,5 +1,6 @@
 import { useAuth0 } from "@auth0/auth0-react"
 import { AUTH0_ORGANIZATION_ID } from "@/config/auth0.config"
+import { getAppUrl } from "@/config/runtime-config"
 
 export function useAuthHandler() {
   const { loginWithRedirect, logout } = useAuth0()
@@ -12,7 +13,7 @@ export function useAuthHandler() {
     })
 
   const handleLogOut = () => {
-    logout({ logoutParams: { returnTo: window.location.origin } })
+    logout({ logoutParams: { returnTo: getAppUrl() } })
   }
   return { handleLogOut, handleLogIn }
 }

--- a/apps/web/src/common/routes/LogoutRoute.tsx
+++ b/apps/web/src/common/routes/LogoutRoute.tsx
@@ -1,8 +1,9 @@
 import { useAuth0 } from "@auth0/auth0-react"
+import { getAppUrl } from "@/config/runtime-config"
 import { LoadingRoute } from "./LoadingRoute"
 
 export function LogoutRoute() {
   const { logout } = useAuth0()
-  logout({ logoutParams: { returnTo: window.location.origin } })
+  logout({ logoutParams: { returnTo: getAppUrl() } })
   return <LoadingRoute />
 }

--- a/apps/web/src/common/routes/OnboardingRoute.tsx
+++ b/apps/web/src/common/routes/OnboardingRoute.tsx
@@ -13,6 +13,7 @@ import {
   selectOrganizationsWithProjectsData,
 } from "@/common/features/organizations/organizations.selectors"
 import { useAppSelector } from "@/common/store/hooks"
+import { publicAssetUrl } from "@/config/runtime-config"
 import type { PendingInvitations } from "@/studio/features/invitations/invitations.models"
 import { ProjectCreatorButton } from "@/studio/features/projects/components/ProjectCreator"
 import { PendingInvitationList } from "../components/home/PendingInvitationList"
@@ -23,7 +24,6 @@ import {
 } from "../components/home/SearchWorkspaces"
 import { WorkspaceItem } from "../components/home/WorkspaceItem"
 import { Wrap } from "../components/layouts/Wrap"
-
 import type { User } from "../features/me/me.models"
 import { selectMe, selectPendingInvitations } from "../features/me/me.selectors"
 import { meActions } from "../features/me/me.slice"
@@ -94,7 +94,11 @@ function Main({
             title={
               <div className="flex items-center gap-4">
                 <div className="size-9">
-                  <img src="/theme/logo.svg" alt="Logo" className="max-h-10 w-auto" />
+                  <img
+                    src={publicAssetUrl("theme/logo.svg")}
+                    alt="Logo"
+                    className="max-h-10 w-auto"
+                  />
                 </div>
                 {t("organization:list:title", { name: user.name })}
               </div>

--- a/apps/web/src/common/routes/Router.tsx
+++ b/apps/web/src/common/routes/Router.tsx
@@ -4,6 +4,7 @@ import { HomeRoute } from "@/common/routes/HomeRoute"
 import { LogoutRoute } from "@/common/routes/LogoutRoute"
 import { McpOauthCallbackRoute } from "@/common/routes/McpOauthCallbackRoute"
 import { NotFoundRoute } from "@/common/routes/NotFoundRoute"
+import { APP_BASE_PATH } from "@/config/runtime-config"
 import { deskRoutes } from "@/desk/routes/DeskRoutes"
 import { evalRoutes } from "@/eval/routes/EvalRoutes"
 import { reviewerRoutes } from "@/reviewer/routes/ReviewerRoutes"
@@ -14,40 +15,44 @@ import { OnboardingRoute } from "./OnboardingRoute"
 import { ProtectedRoute } from "./ProtectedRoute"
 
 const router = () =>
-  createBrowserRouter([
-    {
-      path: RouteNames.HOME,
-      element: <HomeRoute />,
-    },
+  createBrowserRouter(
+    [
+      {
+        path: RouteNames.HOME,
+        element: <HomeRoute />,
+      },
 
-    {
-      path: RouteNames.LOGOUT,
-      element: <LogoutRoute />,
-    },
+      {
+        path: RouteNames.LOGOUT,
+        element: <LogoutRoute />,
+      },
 
-    {
-      element: (
-        <ProtectedRoute>
-          <Outlet />
-        </ProtectedRoute>
-      ),
-      children: [
-        onboardingRoute,
-        mcpOauthCallbackRoute,
-        studioRoutes,
-        deskRoutes,
-        evalRoutes,
-        backofficeRoutes,
-        testerRoutes,
-        reviewerRoutes,
-      ],
-    },
+      {
+        element: (
+          <ProtectedRoute>
+            <Outlet />
+          </ProtectedRoute>
+        ),
+        children: [
+          onboardingRoute,
+          mcpOauthCallbackRoute,
+          studioRoutes,
+          deskRoutes,
+          evalRoutes,
+          backofficeRoutes,
+          testerRoutes,
+          reviewerRoutes,
+        ],
+      },
 
-    {
-      path: "*",
-      element: <NotFoundRoute />,
-    },
-  ])
+      {
+        path: "*",
+        element: <NotFoundRoute />,
+      },
+    ],
+    // Served under a sub-path by the API (`/app`), at the root by static hosting.
+    { basename: APP_BASE_PATH.replace(/\/$/, "") || undefined },
+  )
 
 export function Router() {
   return <RouterProvider router={router()} />

--- a/apps/web/src/common/sse/sse-stream-reader.ts
+++ b/apps/web/src/common/sse/sse-stream-reader.ts
@@ -1,3 +1,4 @@
+import { runtimeConfig } from "@/config/runtime-config"
 import { getAccessToken } from "@/external/auth0Client"
 
 function parseSSEEvent<TDto>(eventText: string, label: string): TDto | null {
@@ -47,7 +48,7 @@ export async function readSSEStream<TDto, TEvent>(params: {
 }): Promise<void> {
   const { config, onStatusChanged } = params
   const token = await getAccessToken()
-  const baseURL = import.meta.env.VITE_API_URL as string
+  const baseURL = runtimeConfig.apiUrl
   const streamPath = config.getStreamPath({
     organizationId: params.organizationId,
     projectId: params.projectId,

--- a/apps/web/src/config/auth0.config.ts
+++ b/apps/web/src/config/auth0.config.ts
@@ -1,19 +1,21 @@
+import { getAppUrl, runtimeConfig } from "./runtime-config"
+
 /**
- * Auth0 organization ID from environment variables.
+ * Auth0 organization ID from the runtime configuration.
  * Used for all loginWithRedirect calls.
  */
-export const AUTH0_ORGANIZATION_ID = import.meta.env.VITE_AUTH0_ORGANIZATION_ID as string
+export const AUTH0_ORGANIZATION_ID = runtimeConfig.auth0OrganizationId
 
 /**
  * Shared Auth0 configuration used by both Auth0Provider and Auth0 client instances.
  * This ensures a single source of truth for Auth0 settings.
  */
 export const auth0Config = {
-  domain: import.meta.env.VITE_AUTH0_DOMAIN as string,
-  clientId: import.meta.env.VITE_AUTH0_CLIENT_ID as string,
+  domain: runtimeConfig.auth0Domain,
+  clientId: runtimeConfig.auth0ClientId,
   authorizationParams: {
-    redirect_uri: window.location.origin,
-    audience: import.meta.env.VITE_AUTH0_AUDIENCE as string,
+    redirect_uri: getAppUrl(),
+    audience: runtimeConfig.auth0Audience,
     scope: "openid profile email offline_access",
   },
   useRefreshTokens: true,

--- a/apps/web/src/config/runtime-config.spec.ts
+++ b/apps/web/src/config/runtime-config.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { mergeRuntimeConfig, type RuntimeConfig } from "./runtime-config"
+
+const buildTime: RuntimeConfig = {
+  apiUrl: "https://api.build",
+  appTitle: "Build title",
+  auth0Domain: "build.auth0.com",
+  auth0ClientId: "build-client",
+  auth0Audience: "https://build/api",
+  auth0OrganizationId: "org_build",
+}
+
+describe("mergeRuntimeConfig", () => {
+  it("returns the build-time values when nothing is injected", () => {
+    expect(mergeRuntimeConfig(buildTime, undefined)).toEqual(buildTime)
+  })
+
+  it("lets the injected values win, key by key", () => {
+    const merged = mergeRuntimeConfig(buildTime, { apiUrl: "", auth0ClientId: "runtime-client" })
+    expect(merged.apiUrl).toBe("")
+    expect(merged.auth0ClientId).toBe("runtime-client")
+    expect(merged.appTitle).toBe("Build title")
+  })
+
+  it("ignores undefined and null injected values", () => {
+    const injected = {
+      appTitle: undefined,
+      helpCenterUrl: null,
+    } as unknown as Partial<RuntimeConfig>
+    expect(mergeRuntimeConfig(buildTime, injected).appTitle).toBe("Build title")
+    expect(mergeRuntimeConfig(buildTime, injected).helpCenterUrl).toBeUndefined()
+  })
+})

--- a/apps/web/src/config/runtime-config.ts
+++ b/apps/web/src/config/runtime-config.ts
@@ -1,0 +1,99 @@
+/**
+ * Runtime configuration of the web app.
+ *
+ * Two sources, in priority order:
+ * 1. `window.__CONFIG__`, injected into `index.html` by the API when it serves
+ *    the SPA (the `app-runtime` image). One image serves every tenant, the
+ *    values come from the API environment, like Grafana or Argo CD do.
+ * 2. The `VITE_*` variables that Vite inlines at build time. Used by `vite dev`
+ *    and by the static hosting builds (one build per tenant).
+ *
+ * Every read of the configuration goes through this module. Never read
+ * `import.meta.env.VITE_*` elsewhere: the value would be frozen at build time.
+ */
+export type RuntimeConfig = {
+  /** Base URL of the API. Empty string means same origin as the page. */
+  apiUrl: string
+  apiTimeoutMs?: string
+  appTitle?: string
+  /** Base URL of the agent embed bundle (`launcher.js`, `index.html`). */
+  agentEmbedUrl?: string
+  helpCenterUrl?: string
+  helpAgentEmbedToken?: string
+  helpAgentEmbedColor?: string
+  helpAgentEmbedHint?: string
+  auth0Domain: string
+  auth0ClientId: string
+  auth0Audience: string
+  auth0OrganizationId: string
+  defaultConversationAgentPrompt?: string
+  defaultFormAgentPrompt?: string
+  defaultFormAgentSchema?: string
+  defaultExtractionAgentPrompt?: string
+  defaultExtractionAgentSchema?: string
+}
+
+declare global {
+  interface Window {
+    __CONFIG__?: Partial<RuntimeConfig>
+  }
+}
+
+function readBuildTimeConfig(): RuntimeConfig {
+  const env = import.meta.env
+  return {
+    apiUrl: env.VITE_API_URL ?? "",
+    apiTimeoutMs: env.VITE_API_TIMEOUT_MS,
+    appTitle: env.VITE_APP_TITLE,
+    agentEmbedUrl: env.VITE_AGENT_EMBED_URL,
+    helpCenterUrl: env.VITE_HELP_CENTER_URL,
+    helpAgentEmbedToken: env.VITE_HELP_AGENT_EMBED_TOKEN,
+    helpAgentEmbedColor: env.VITE_HELP_AGENT_EMBED_COLOR,
+    helpAgentEmbedHint: env.VITE_HELP_AGENT_EMBED_HINT,
+    auth0Domain: env.VITE_AUTH0_DOMAIN ?? "",
+    auth0ClientId: env.VITE_AUTH0_CLIENT_ID ?? "",
+    auth0Audience: env.VITE_AUTH0_AUDIENCE ?? "",
+    auth0OrganizationId: env.VITE_AUTH0_ORGANIZATION_ID ?? "",
+    defaultConversationAgentPrompt: env.VITE_DEFAULT_CONVERSATION_AGENT_PROMPT,
+    defaultFormAgentPrompt: env.VITE_DEFAULT_FORM_AGENT_PROMPT,
+    defaultFormAgentSchema: env.VITE_DEFAULT_FORM_AGENT_SCHEMA,
+    defaultExtractionAgentPrompt: env.VITE_DEFAULT_EXTRACTION_AGENT_PROMPT,
+    defaultExtractionAgentSchema: env.VITE_DEFAULT_EXTRACTION_AGENT_SCHEMA,
+  }
+}
+
+/** Injected values win over build-time values, key by key. Undefined injected keys are ignored. */
+export function mergeRuntimeConfig(
+  buildTime: RuntimeConfig,
+  injected: Partial<RuntimeConfig> | undefined,
+): RuntimeConfig {
+  const merged: RuntimeConfig = { ...buildTime }
+  for (const [key, value] of Object.entries(injected ?? {})) {
+    if (value !== undefined && value !== null) {
+      ;(merged as Record<string, string | undefined>)[key] = String(value)
+    }
+  }
+  return merged
+}
+
+export const runtimeConfig: RuntimeConfig = mergeRuntimeConfig(
+  readBuildTimeConfig(),
+  typeof window === "undefined" ? undefined : window.__CONFIG__,
+)
+
+/**
+ * Public path the SPA is served from, with a trailing slash: `/` for the static
+ * hosting builds, `/app/` when the API serves it. Fixed at build time by Vite
+ * (`base` in vite.config.ts), this is a property of the image, not of the tenant.
+ */
+export const APP_BASE_PATH: string = import.meta.env.BASE_URL
+
+/** Absolute URL of the SPA root, without trailing slash. Used for Auth0 redirects. */
+export function getAppUrl(): string {
+  return `${window.location.origin}${APP_BASE_PATH.replace(/\/$/, "")}`
+}
+
+/** URL of a file from `public/`, resolved against the SPA base path. */
+export function publicAssetUrl(relativePath: string): string {
+  return `${APP_BASE_PATH}${relativePath.replace(/^\//, "")}`
+}

--- a/apps/web/src/external/auth0Client.ts
+++ b/apps/web/src/external/auth0Client.ts
@@ -1,5 +1,6 @@
 import { type Auth0Client, createAuth0Client } from "@auth0/auth0-spa-js"
 import { auth0ClientConfig } from "@/config/auth0.config"
+import { getAppUrl } from "@/config/runtime-config"
 
 /**
  * Singleton Auth0 client instance.
@@ -84,7 +85,7 @@ export async function logoutAuth0(): Promise<void> {
   const client = await getAuth0Client()
   await client.logout({
     logoutParams: {
-      returnTo: window.location.origin,
+      returnTo: getAppUrl(),
     },
   })
 }

--- a/apps/web/src/external/axios.ts
+++ b/apps/web/src/external/axios.ts
@@ -1,4 +1,5 @@
 import axios, { type AxiosInstance } from "axios"
+import { runtimeConfig } from "@/config/runtime-config"
 import { Auth0AuthenticationError, getAccessToken, logoutAuth0 } from "./auth0Client"
 
 let axiosInstance: AxiosInstance | null = null
@@ -9,8 +10,8 @@ export const getAxiosInstance = (): AxiosInstance => {
 }
 
 const buildAxiosInstance = (): AxiosInstance => {
-  const baseURL = import.meta.env.VITE_API_URL as string
-  const timeoutMs = Number(import.meta.env.VITE_API_TIMEOUT_MS ?? "10000")
+  const baseURL = runtimeConfig.apiUrl
+  const timeoutMs = Number(runtimeConfig.apiTimeoutMs ?? "10000")
   const axiosInstance = axios.create({ baseURL: `${baseURL}/`, timeout: timeoutMs })
 
   // Set up request interceptor to automatically inject Auth0 access token

--- a/apps/web/src/studio/features/agents/agent-settings/components/tabs/EmbedTab.tsx
+++ b/apps/web/src/studio/features/agents/agent-settings/components/tabs/EmbedTab.tsx
@@ -14,6 +14,7 @@ import { useMount } from "@/common/hooks/use-mount"
 import { useCurrentId, useValue } from "@/common/hooks/use-value"
 import { AsyncRoute } from "@/common/routes/AsyncRoute"
 import { useAppDispatch, useAppSelector } from "@/common/store/hooks"
+import { runtimeConfig } from "@/config/runtime-config"
 import { useReportDirty } from "@/studio/features/agents/agent-settings/components/agent-tab-form.shared"
 import type { AgentEmbedConfig } from "../../../../agent-embed-configs/agent-embed-configs.models"
 import { selectAgentEmbedConfig } from "../../../../agent-embed-configs/agent-embed-configs.selectors"
@@ -79,8 +80,7 @@ function WithData({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }
   const isDirty = config ? JSON.stringify(form) !== JSON.stringify(toFormState(config)) : false
   useReportDirty(isDirty, onDirtyChange)
 
-  const embedBaseUrl =
-    (import.meta.env.VITE_AGENT_EMBED_URL as string | undefined) ?? window.location.origin
+  const embedBaseUrl = runtimeConfig.agentEmbedUrl ?? window.location.origin
   const embedSnippet = config
     ? `<script src="${embedBaseUrl}/launcher.js" data-token="${config.embedToken}"></script>`
     : ""

--- a/apps/web/src/studio/features/agents/components/default-agent-values/conversation-agent-default-values.ts
+++ b/apps/web/src/studio/features/agents/components/default-agent-values/conversation-agent-default-values.ts
@@ -1,6 +1,8 @@
+import { runtimeConfig } from "@/config/runtime-config"
+
 export const conversationAgentDefaultValues = {
   prompt:
-    (import.meta.env.VITE_DEFAULT_CONVERSATION_AGENT_PROMPT as string | undefined) ??
+    runtimeConfig.defaultConversationAgentPrompt ??
     `## Purpose
 Your purpose is to assist users by answering their questions and helping them accomplish their goals.
 

--- a/apps/web/src/studio/features/agents/components/default-agent-values/extraction-agent-default-values.ts
+++ b/apps/web/src/studio/features/agents/components/default-agent-values/extraction-agent-default-values.ts
@@ -1,10 +1,11 @@
 import type { outputJsonSchemaSchema } from "@caseai-connect/api-contracts"
 import type { z } from "zod"
+import { runtimeConfig } from "@/config/runtime-config"
 import { buildOutputJsonSchema } from "./default-agent-values.helpers"
 
 export const extractionAgentDefaultValues = {
   prompt:
-    (import.meta.env.VITE_DEFAULT_EXTRACTION_AGENT_PROMPT as string | undefined) ??
+    runtimeConfig.defaultExtractionAgentPrompt ??
     `Extract structured information from the uploaded document.
 
 Return ONLY the JSON object that matches the provided output schema.
@@ -16,7 +17,7 @@ Rules:
 - Do not include explanations or markdown.`,
 
   getOutputJsonSchema: () => {
-    const envSchema = import.meta.env.VITE_DEFAULT_EXTRACTION_AGENT_SCHEMA as string | undefined
+    const envSchema = runtimeConfig.defaultExtractionAgentSchema
 
     const defaultSchema: z.infer<typeof outputJsonSchemaSchema> = {
       type: "object",

--- a/apps/web/src/studio/features/agents/components/default-agent-values/form-agent-default-values.ts
+++ b/apps/web/src/studio/features/agents/components/default-agent-values/form-agent-default-values.ts
@@ -1,14 +1,15 @@
 import type { outputJsonSchemaSchema } from "@caseai-connect/api-contracts"
 import type { z } from "zod"
+import { runtimeConfig } from "@/config/runtime-config"
 import { buildOutputJsonSchema } from "./default-agent-values.helpers"
 
 export const formAgentDefaultValues = {
   prompt:
-    (import.meta.env.VITE_DEFAULT_FORM_AGENT_PROMPT as string | undefined) ??
+    runtimeConfig.defaultFormAgentPrompt ??
     `Your main task is to help the user fill out the form by asking questions and providing guidance. Ask one question at a time to fill out the form.`,
 
   getOutputJsonSchema: () => {
-    const envSchema = import.meta.env.VITE_DEFAULT_FORM_AGENT_SCHEMA as string | undefined
+    const envSchema = runtimeConfig.defaultFormAgentSchema
 
     const defaultSchema: z.infer<typeof outputJsonSchemaSchema> = {
       type: "object",

--- a/apps/web/src/studio/hooks/use-help-launcher.ts
+++ b/apps/web/src/studio/hooks/use-help-launcher.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
+import { runtimeConfig } from "@/config/runtime-config"
 import i18n from "@/i18n"
 
 declare global {
@@ -39,19 +40,18 @@ export function useHelpLauncher() {
 
   // Inject the launcher script once on mount.
   useEffect(() => {
-    const token = import.meta.env.VITE_HELP_AGENT_EMBED_TOKEN as string | undefined
+    const token = runtimeConfig.helpAgentEmbedToken
     if (!token || document.getElementById(HELP_SCRIPT_ID)) return
 
-    const embedBaseUrl =
-      (import.meta.env.VITE_AGENT_EMBED_URL as string | undefined) ?? window.location.origin
+    const embedBaseUrl = runtimeConfig.agentEmbedUrl ?? window.location.origin
     const script = document.createElement("script")
     script.id = HELP_SCRIPT_ID
     script.src = `${embedBaseUrl}/launcher.js`
 
-    const color = import.meta.env.VITE_HELP_AGENT_EMBED_COLOR as string | undefined
+    const color = runtimeConfig.helpAgentEmbedColor
     if (color) script.dataset.color = color
 
-    const hintRaw = import.meta.env.VITE_HELP_AGENT_EMBED_HINT as string | undefined
+    const hintRaw = runtimeConfig.helpAgentEmbedHint
     if (hintRaw) script.dataset.hint = resolveHint(hintRaw, i18n.language)
 
     script.dataset.displayMode = "drawer"
@@ -64,7 +64,7 @@ export function useHelpLauncher() {
   // Update the hint bubble text in-place when the user changes language.
   // Skipped on the first render (the injection effect above already set it).
   useEffect(() => {
-    const hintRaw = import.meta.env.VITE_HELP_AGENT_EMBED_HINT as string | undefined
+    const hintRaw = runtimeConfig.helpAgentEmbedHint
     if (!hintRaw) return
     window.__agentStudioSetHint?.(resolveHint(hintRaw, reactiveI18n.language))
   }, [reactiveI18n.language])

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig(({ mode }) => {
     : undefined
 
   return {
+    // Public path of the SPA. `/` for `vite dev` and the static hosting builds,
+    // `/app/` when the API serves the build (the `app-runtime` image). Fixed at
+    // build time on purpose: a property of the image, not of the tenant.
+    base: env.VITE_BASE_PATH?.trim() || "/",
     plugins: [
       react({
         babel: {


### PR DESCRIPTION
## Why

The web front reads its settings from `VITE_*` variables that Vite inlines at build time. Each deployment needs its own build of the front. A Kubernetes chart must configure the front at deploy time, with values and environment variables, the way Grafana, Keycloak or Argo CD do. This PR makes that possible and ships a Docker target that serves the front and the API from one image.

## What changes

**apps/web**
- `src/config/runtime-config.ts`: one module reads `window.__CONFIG__` first, then the `VITE_*` values as a fallback for `vite dev` and static hosting builds. All 13 former `import.meta.env.VITE_*` reads go through it.
- Auth0 redirect and logout URLs use `getAppUrl()`, `public/` assets use `publicAssetUrl()`: the SPA works at `/` (static hosting) and at `/app` (served by the API). The router gets its `basename` from the Vite base path.
- `vite.config.ts`: `base` comes from `VITE_BASE_PATH` (default `/`).

**apps/api**
- `common/web-app`: when `WEB_APP_DIST_DIR` points to a built front, the API serves it under `/app`. `index.html` gets `window.__CONFIG__` injected from `WEB_*` variables, with defaults for the same origin and the Auth0 tenant the API already validates. Hashed assets are immutable, the entry page is never cached. `/` redirects to `/app/`. Nothing is registered when the variable is unset.
- The API routes stay at the root. The SPA lives under `/app` so a browser reload on a client route never hits an API route.

**Dockerfile**
- New `web-build` stage and `app-runtime` target (`FROM api-runtime` plus the `dist`). The `api-runtime`, `cpu-workers-runtime` and `gpu-workers-runtime` targets do not change.

## Checks

- `npm run biome:check`, `npm run typecheck`: pass.
- Web: 165 vitest tests pass, including the new `runtime-config.spec.ts`.
- API: 16 new jest tests pass (`src/common/web-app`). The full API suite runs in CI (no local test database in this worktree).
- `docker build --target app-runtime`: builds. The image contains `apps/web/dist` with `/app/` asset paths, sets `WEB_APP_DIST_DIR`, and adds 10 MB to `api-runtime`. `react` and `react-dom` were already present in `api-runtime`; this PR adds no front package to the production `node_modules`.

## Not in this PR

- No change to the production deployment of the front.
- No `/api` prefix on the API routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
