### PR TITLE
fix(deps): update multer to 2.3.0 and @xmldom/xmldom to 0.9.12 / 0.8.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11892,9 +11892,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -22961,9 +22961,9 @@
       }
     },
     "node_modules/mammoth/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -24380,9 +24380,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,12 @@
     "packages/*"
   ],
   "overrides": {
-    "typeorm": "^0.3.29"
+    "typeorm": "^0.3.29",
+    "multer": "^2.3.0",
+    "@xmldom/xmldom": "^0.9.12",
+    "mammoth": {
+      "@xmldom/xmldom": "^0.8.15"
+    }
   },
   "dependencies": {
     "@ai-sdk/open-responses": "^1.0.4",


### PR DESCRIPTION
## Why

The `security` workflow (trivy) fails on every branch since its database picked up these advisories, published 2026-08-28 and 2026-09-01. The three API-based images are affected, the PDF converter is not.

| Package | Installed | Fixed | Pulled by | Findings |
|---|---|---|---|---|
| multer | 2.2.0 | 2.3.0 | @nestjs/platform-express (exact pin, also in Nest 12) | 3 HIGH, denial of service on uploads |
| @xmldom/xmldom | 0.9.10 | 0.9.12 | @llamaindex/readers | 11 HIGH |
| @xmldom/xmldom | 0.8.13 | 0.8.15 | mammoth | 8 HIGH |

## What changes

npm `overrides` in the root `package.json` pin the fixed versions. The lockfile changes are limited to the three package entries (version, resolved, integrity).

`npm ls multer` shows the override as "invalid" because the spec comes from a workspace package. This is an npm display quirk with workspaces (reproduced on a minimal workspace project); the installed tree is 2.3.0 and `npm ci` passes.

## Checks

- `npm ci`, `npm run biome:check`, API `tsc --noEmit`: pass.
- `docker build --target api-runtime` then trivy 0.69.3 with the repo options and ignore file: 0 findings, exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)