### PR TITLE
fix(k8s): first deployment of the chart on a cluster with a managed database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
+- Kubernetes: the platform connects to databases that require TLS (Cloud SQL, RDS) with one setting.
 - (beta) MCP servers: connect servers that use OAuth by authorizing access in the browser, alongside API keys.
 - Kubernetes: the platform can be installed on any cluster with a Helm chart, with bundled Postgres and Redis.
 

--- a/apps/api/src/config/typeorm.ts
+++ b/apps/api/src/config/typeorm.ts
@@ -15,6 +15,28 @@ if (process.env.DATABASE_HOST?.startsWith("/cloudsql")) {
 
 const databaseUrl = process.env.DATABASE_URL
 
+/**
+ * TLS towards the database. Managed instances (Cloud SQL in ENCRYPTED_ONLY
+ * mode, RDS...) refuse plain connections.
+ *
+ * DATABASE_SSL unset, "false" or "disable": no TLS (local Docker Postgres).
+ * DATABASE_SSL=require: encrypted, server certificate not verified. Cloud SQL
+ *   signs its certificate with a per-instance CA, so this is the usual setting
+ *   inside a private network.
+ * DATABASE_SSL=verify-full: encrypted and verified against DATABASE_SSL_CA
+ *   (the CA certificate, PEM).
+ */
+function sslOptions(): { ssl?: { rejectUnauthorized: boolean; ca?: string } } {
+  const mode = process.env.DATABASE_SSL?.trim().toLowerCase()
+  if (!mode || mode === "false" || mode === "disable") return {}
+  if (mode === "verify-full") {
+    const ca = process.env.DATABASE_SSL_CA
+    if (!ca) throw new Error("DATABASE_SSL=verify-full requires DATABASE_SSL_CA (PEM certificate)")
+    return { ssl: { rejectUnauthorized: true, ca } }
+  }
+  return { ssl: { rejectUnauthorized: false } }
+}
+
 export const config: () => TypeOrmModuleOptions = () => ({
   type: "postgres",
   ...(databaseUrl
@@ -26,6 +48,7 @@ export const config: () => TypeOrmModuleOptions = () => ({
         password: process.env.DATABASE_PASSWORD,
         database: process.env.DATABASE_NAME,
       }),
+  ...sslOptions(),
   entities: [`${__dirname}/../**/*.entity.{js,ts}`],
   migrations: [`${__dirname}/../**/migrations/*.{js,ts}`],
   autoLoadEntities: true,

--- a/deploy/helm/bayes-platform/README.md
+++ b/deploy/helm/bayes-platform/README.md
@@ -135,7 +135,7 @@ kubectl -n platform logs job/platform-bayes-platform-migrate
 
 See `values-managed.example.yaml`. The differences with the default:
 
-- `postgresql.enabled: false` and `externalDatabase.*`. The database must have the `vector` extension: `CREATE EXTENSION IF NOT EXISTS vector;` run once by an administrator. On Cloud SQL the database user can run it.
+- `postgresql.enabled: false` and `externalDatabase.*`. `externalDatabase.ssl` is `require` by default (Cloud SQL refuses plain connections when its `ssl_mode` is `ENCRYPTED_ONLY`); set `verify-full` and `sslCaSecretKey` to check the server certificate. The `vector` extension is created by the first migration when the database user is allowed to; otherwise run `CREATE EXTENSION IF NOT EXISTS vector;` once as an administrator.
 - `redis.enabled: false` and `BULLMQ_REDIS_URL` in the Secret.
 - `storage.mode: gcs` with `storage.gcs.bucket`. The pods reach the bucket through the service account (`serviceAccount.annotations` for GKE Workload Identity). This mode also enables the `pdf-converter`.
 - `gpuWorkers.enabled: true` with `gpuWorkers.gpu.nodeSelector` set to the label of your GPU node pool. The pods request `nvidia.com/gpu: 1` and tolerate the `nvidia.com/gpu` taint.

--- a/deploy/helm/bayes-platform/templates/_helpers.tpl
+++ b/deploy/helm/bayes-platform/templates/_helpers.tpl
@@ -137,6 +137,17 @@ on other chart values.
       name: {{ include "bayes-platform.secretName" . }}
       key: {{ .Values.externalDatabase.passwordKey }}
 {{- end }}
+{{- if and (not .Values.postgresql.enabled) .Values.externalDatabase.ssl }}
+- name: DATABASE_SSL
+  value: {{ .Values.externalDatabase.ssl | quote }}
+{{- if .Values.externalDatabase.sslCaSecretKey }}
+- name: DATABASE_SSL_CA
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "bayes-platform.secretName" . }}
+      key: {{ .Values.externalDatabase.sslCaSecretKey }}
+{{- end }}
+{{- end }}
 {{- if .Values.redis.enabled }}
 - name: BULLMQ_REDIS_URL
   value: {{ printf "redis://%s:6379" (include "bayes-platform.componentName" (dict "root" . "component" "redis")) | quote }}

--- a/deploy/helm/bayes-platform/templates/frontends.yaml
+++ b/deploy/helm/bayes-platform/templates/frontends.yaml
@@ -39,7 +39,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
+        # nginx-unprivileged runs as user nginx (uid 101); runAsNonRoot needs a number.
         runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
       containers:
         - name: nginx
           image: {{ include "bayes-platform.image" (dict "root" $root "image" $values.image) }}

--- a/deploy/helm/bayes-platform/values.yaml
+++ b/deploy/helm/bayes-platform/values.yaml
@@ -84,6 +84,8 @@ config:
   # Tracing (optional). LANGFUSE_SK goes in the secret.
   LANGFUSE_BASE_URL: ""
   LANGFUSE_PK: ""
+  # Queue of the PDF exports sweep. Required on every worker process.
+  PDF_EXPORTS_SWEEP_QUEUE_NAME: pdf-exports-sweep
   # Bull Board (queue dashboard) on the API.
   BULL_BOARD_ENABLED: "false"
   BULL_BOARD_ALLOWED_EMAIL_DOMAIN: "@example.org"
@@ -120,6 +122,11 @@ externalDatabase:
   username: platform
   # Key of the password in secrets.existingSecret.
   passwordKey: DATABASE_PASSWORD
+  # TLS: "" (none), "require" (encrypted, certificate not verified: Cloud SQL,
+  # private network), or "verify-full" with sslCaSecretKey (PEM in the Secret).
+  ssl: require
+  sslCaSecretKey: ""
+
 
 # ---------------------------------------------------------------------------
 # Redis (BullMQ queues)
@@ -198,6 +205,7 @@ cpuWorkers:
     - web-source-embeddings
     - extraction-agent-session-queue
     - conversation-retention-sweep
+    - pdf-exports-sweep
   # Without GPU workers, the CPU pool also takes the document embeddings
   # (Docling disabled: text extraction without OCR).
   takeEmbeddingsWhenNoGpu: true


### PR DESCRIPTION
Three things seen on the first deployment of the chart on a real cluster (Cloud SQL, Workload Identity, GPU pool), none reproducible with the bundled Postgres.

1. **Database TLS.** Cloud SQL with `ssl_mode = ENCRYPTED_ONLY` answers `pg_hba.conf rejects connection ... no encryption`. `apps/api/src/config/typeorm.ts` reads a new `DATABASE_SSL`: `require` (encrypted, certificate not verified: Cloud SQL signs with a per-instance CA) or `verify-full` with `DATABASE_SSL_CA` (PEM). Unset: no TLS, as today. The chart sets it from `externalDatabase.ssl`, `require` by default, and passes the CA from the Secret when `sslCaSecretKey` is set.
2. **`PDF_EXPORTS_SWEEP_QUEUE_NAME`** is required on every worker process since the PDF exports sweep. The chart sets it in the shared config and adds `pdf-exports-sweep` to the CPU workers' queues, as production does.
3. **web-embed and help** failed with `container has runAsNonRoot and image has non-numeric user (nginx)`. The pods now run as uid 101 (the `nginx` user of `nginx-unprivileged`).

`helm lint` passes, both values render, `npm run biome:check` and the API typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)