### PR TITLE
perf(docker): install dependencies before copying the sources

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,31 +1,50 @@
 #
-# 🏡 Production Build
+# Layer order matters for the build cache: dependency manifests are copied and
+# installed before the sources, so a code change only re-runs the compile
+# steps. The Python/Torch layers of the GPU image depend on the requirements
+# files only, never on the application code.
 #
-FROM node:24.20.0-bookworm-slim AS build
+
+#
+# 📦 Dependencies of the API (dev + prod), from the manifests only
+#
+FROM node:24.20.0-bookworm-slim AS api-deps
 
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends libc6 && rm -rf /var/lib/apt/lists/*
 
-# Copy source code
-COPY apps/api ./apps/api
-COPY ./packages ./packages
-COPY package-lock.json ./
-COPY package.json ./
+# Every workspace manifest the lockfile knows about, no sources.
+COPY package.json package-lock.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/api-contracts/package.json ./packages/api-contracts/
+COPY packages/jest-config/package.json ./packages/jest-config/
+COPY packages/typescript-config/package.json ./packages/typescript-config/
+COPY packages/ui/package.json ./packages/ui/
 
-# Generate the production build. The build script runs "nest build" to compile the application.
 # Scope install to API + api-contracts so packages/ui's runtime deps (vite, tailwind, radix, react)
 # never enter node_modules/. Frontend workspaces are left on disk but their deps aren't installed.
 RUN npm ci \
     --workspace=@caseai-connect/api \
     --workspace=@caseai-connect/api-contracts \
     --include-workspace-root
-RUN cd apps/api && npm run build
-RUN cd packages/api-contracts && npm run build
 
-# Discard the dev install and reinstall only production deps. A fresh `npm ci --omit=dev`
-# produces a cleaner tree than `npm prune --omit=dev`, which leaves extraneous packages
-# (e.g. next/react pulled by @repo/jest-config's devDeps) lingering in node_modules.
-RUN rm -rf node_modules apps/api/node_modules packages/*/node_modules
+#
+# 📦 Production dependencies of the API, from the manifests only
+#
+# A fresh `npm ci --omit=dev` produces a cleaner tree than `npm prune --omit=dev`,
+# which leaves extraneous packages (e.g. next/react pulled by @repo/jest-config's
+# devDeps) lingering in node_modules.
+#
+FROM node:24.20.0-bookworm-slim AS api-prod-deps
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/api-contracts/package.json ./packages/api-contracts/
+COPY packages/jest-config/package.json ./packages/jest-config/
+COPY packages/typescript-config/package.json ./packages/typescript-config/
+COPY packages/ui/package.json ./packages/ui/
+
 RUN npm ci --omit=dev \
     --workspace=@caseai-connect/api \
     --workspace=@caseai-connect/api-contracts \
@@ -41,6 +60,19 @@ RUN rm -rf node_modules/next node_modules/sharp node_modules/@img
 RUN mkdir -p /app/apps/api/node_modules
 
 #
+# 🏡 Production Build
+#
+FROM api-deps AS build
+
+# Sources, after the install: a code change starts here.
+COPY apps/api ./apps/api
+COPY ./packages ./packages
+
+# Generate the production build. The build script runs "nest build" to compile the application.
+RUN cd apps/api && npm run build
+RUN cd packages/api-contracts && npm run build
+
+#
 # 🌐 Web front build (only used by the app-runtime target)
 #
 # Builds apps/web with `/app/` as public path: the API serves the result under
@@ -51,16 +83,22 @@ RUN mkdir -p /app/apps/api/node_modules
 FROM node:24.20.0-bookworm-slim AS web-build
 
 WORKDIR /app
-COPY apps/web ./apps/web
-COPY ./packages ./packages
-COPY package-lock.json ./
-COPY package.json ./
+COPY package.json package-lock.json ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/api-contracts/package.json ./packages/api-contracts/
+COPY packages/jest-config/package.json ./packages/jest-config/
+COPY packages/typescript-config/package.json ./packages/typescript-config/
+COPY packages/ui/package.json ./packages/ui/
 
 RUN npm ci \
     --workspace=@caseai-connect/web \
     --workspace=@caseai-connect/ui \
     --workspace=@caseai-connect/api-contracts \
     --include-workspace-root
+
+COPY apps/web ./apps/web
+COPY ./packages ./packages
+
 ENV VITE_BASE_PATH=/app/
 RUN cd apps/web && npm run build
 
@@ -76,10 +114,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends libc6 && rm -rf
 ENV NODE_ENV=production
 
 # Copy only the necessary files
-COPY --from=build /app/apps/api/dist /app/apps/api/dist
+COPY --from=api-prod-deps /app/node_modules node_modules
+COPY --from=api-prod-deps /app/apps/api/node_modules /app/apps/api/node_modules
 COPY --from=build /app/packages/api-contracts /app/packages/api-contracts
-COPY --from=build /app/apps/api/node_modules /app/apps/api/node_modules
-COPY --from=build /app/node_modules node_modules
+COPY --from=build /app/apps/api/dist /app/apps/api/dist
 
 #
 # 🚀 API Runtime (no Docling)
@@ -111,24 +149,19 @@ FROM runtime-base AS cpu-workers-runtime
 CMD ["node", "--enable-source-maps", "/app/apps/api/dist/workers-main.js"]
 
 #
-# 🚀 GPU Workers Runtime (Docling enabled)
+# 🐍 Docling base: Python, Torch (CUDA) and Docling, from the requirements only
 #
-FROM runtime-base AS gpu-workers-runtime
+# Nothing here depends on the application code, so these layers (several GB)
+# survive every commit and only rebuild when a requirements file changes.
+#
+FROM node:24.20.0-bookworm-slim AS docling-base
 
+WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  libc6 \
   python3 python3-pip python3-venv \
   libxcb1 libgl1 libglib2.0-0 \
   && rm -rf /var/lib/apt/lists/*
-
-# Needed for the docling TS wrapper to execute our custom document_chunker CLI
-# inside the container (`apps/api/bin` is not copied into runtime-base).
-COPY --from=build /app/apps/api/bin /app/apps/api/bin
-
-# We need the sample PDF for the Docling self-test
-# Warning: this test is only run if the environment variable WORKER_DOCLING_SELF_TEST_ENABLED is set to true
-COPY --from=build /app/apps/api/test/fixtures/sample.pdf /app/apps/api/bin/sample.pdf
-
-RUN chmod +x /app/apps/api/bin/document_chunker || true
 
 # Python dependencies are pinned in the requirements files (single source of
 # truth for both this image and local testing). Torch must be installed first
@@ -142,10 +175,36 @@ RUN python3 -m venv /opt/docling-venv \
   # pip is build-time only. Its vendored msgpack/setuptools copies carry HIGH CVEs
   # that trivy reports, so remove it from the runtime venv once installs are done.
   && /opt/docling-venv/bin/pip uninstall -y pip \
+  && ln -s /opt/docling-venv/bin/docling /usr/local/bin/docling
+
+# Needed for the docling TS wrapper to execute our custom document_chunker CLI
+# inside the container (`apps/api/bin` is not part of runtime-base).
+COPY apps/api/bin /app/apps/api/bin
+
+# We need the sample PDF for the Docling self-test
+# Warning: this test is only run if the environment variable WORKER_DOCLING_SELF_TEST_ENABLED is set to true
+COPY apps/api/test/fixtures/sample.pdf /app/apps/api/bin/sample.pdf
+
+# Pre-warm: downloads the Docling models into the image. Depends on the
+# chunker script and the fixture only.
+RUN chmod +x /app/apps/api/bin/document_chunker || true \
   && /opt/docling-venv/bin/python /app/apps/api/bin/document_chunker.py \
     --doc-path /app/apps/api/bin/sample.pdf \
     --output-json /tmp/docling-prewarm.json \
-    --max-nodes 1 \
-  && ln -s /opt/docling-venv/bin/docling /usr/local/bin/docling
+    --max-nodes 1
+
+#
+# 🚀 GPU Workers Runtime (Docling enabled)
+#
+# The Docling base plus the same runtime files as runtime-base.
+#
+FROM docling-base AS gpu-workers-runtime
+
+ENV NODE_ENV=production
+
+COPY --from=api-prod-deps /app/node_modules node_modules
+COPY --from=api-prod-deps /app/apps/api/node_modules /app/apps/api/node_modules
+COPY --from=build /app/packages/api-contracts /app/packages/api-contracts
+COPY --from=build /app/apps/api/dist /app/apps/api/dist
 
 CMD ["node", "--enable-source-maps", "/app/apps/api/dist/workers-main.js"]


### PR DESCRIPTION
The registry cache of `publish-images.yml` works, but the layer order of `apps/api/Dockerfile` defeats it on every commit:

- the `build` stage copied the sources **before** `npm ci`, so any code change re-ran both installs and the compile (about 4 minutes);
- `gpu-workers-runtime` installed Python, Torch and Docling **after** copying `dist`, so any code change rebuilt Torch (about 12 minutes).

## What changes

- `api-deps` and `api-prod-deps` stages install from the manifests only (root `package.json` and lockfile, `apps/api/package.json`, `packages/*/package.json`). The `build` stage copies the sources after and compiles.
- `docling-base` holds apt, the venv, Torch, Docling and the model pre-warm. It depends on the two requirements files and `apps/api/bin` only. `gpu-workers-runtime` copies the runtime files on top of it.
- `web-build`: same order for the front.

Same targets, same runtime layout (`/app/apps/api/dist`, `/app/node_modules`, `/app/packages/api-contracts`, `/app/apps/api/bin` for the GPU image). Makefile, production deployment and chart are unchanged.

## Checks

- `docker build --check`: passes.
- Two local builds of `app-runtime`, the second after a one-line change in `apps/api/src/main.ts`: `npm ci` (dev and prod), the web install and the web build come from the cache; only `nest build` (10 s) and the `api-contracts` build run.
- The image starts, `dist/main.js`, the web `dist`, `packages/api-contracts/dist` and the `typeorm` CLI are in place.
- Not built locally: `gpu-workers-runtime` (Torch download). Its first CI run populates the `docling-base` layers; the next code change should skip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)