### PR TITLE
ci: notify the deployment repository when the images are published

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -141,6 +141,33 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+  # Tell the deployment repository which tag is ready. The staging cluster
+  # follows main; the deployment repository turns this event into a pull
+  # request on its values and Flux deploys. Same GitHub App as prod.yml.
+  notify:
+    name: notify deployments
+    if: github.ref == 'refs/heads/main'
+    needs: [images]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Dispatch platform-images-published
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/${{ github.repository_owner }}/infra/dispatches \
+            -f event_type=platform-images-published \
+            -f "client_payload[tag]=main-${{ github.run_number }}-${GITHUB_SHA::7}" \
+            -f "client_payload[sha]=${{ github.sha }}" \
+            -f "client_payload[repo]=${{ github.repository }}"
+
   chart:
     name: helm chart
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
This commit was pushed to the branch of #772 a minute after that pull request was merged, so it never reached `main`. Same content, on its own.

After the six images of a run are on ghcr, a last job `notify` (on `main` only) sends a `repository_dispatch` event `platform-images-published` to the deployment repository with the shared `main-<run>-<sha>` tag, the sha and the repository name. Same GitHub App and same pattern as the `dispatch` job of `prod.yml`. This repository does not know what the deployment repository does with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)