### PR TITLE
fix(k8s): recreate strategy for the GPU workers

### DIFF
--- a/deploy/helm/bayes-platform/templates/workers.yaml
+++ b/deploy/helm/bayes-platform/templates/workers.yaml
@@ -28,6 +28,13 @@ metadata:
     app.kubernetes.io/component: {{ $pool.component }}
 spec:
   replicas: {{ $values.replicas }}
+  {{- if $pool.gpu }}
+  # One GPU per node and a small pool: a rolling update would wait for a new
+  # pod that cannot get a GPU while the old pod still holds it. Stop the old
+  # pod first. The queues buffer the jobs meanwhile.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "bayes-platform.selectorLabels" (dict "root" $root "component" $pool.component) | nindent 6 }}


### PR DESCRIPTION
Seen on the first upgrade of the chart on a cluster with a GPU pool capped at one node: the rolling update created the new gpu-workers pod, which stayed Pending (`Insufficient nvidia.com/gpu`, the old pod still held the GPU, and the autoscaler had reached the pool's max size), while the old pod was kept until the new one became ready. Deadlock, until someone deletes the old ReplicaSet.

The GPU pool Deployment uses `strategy: Recreate`: the old pod stops first, the new one takes the GPU. The queues buffer the jobs in between. CPU workers keep the rolling update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)