### PR TITLE
fix(web): show the identity provider error instead of looping back to Auth0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Sign-in: an error returned by the identity provider is shown with a retry button instead of reloading endlessly.
 - (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.
 - (beta) PDF export: more reliable on large documents, download card in the agent's language, files kept as long as the link works.

--- a/apps/web/src/common/auth/auth-callback-error.spec.ts
+++ b/apps/web/src/common/auth/auth-callback-error.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { getAuthCallbackError } from "./auth-callback-error"
+
+describe("getAuthCallbackError", () => {
+  it("returns null when the query string carries no error", () => {
+    expect(getAuthCallbackError("")).toBeNull()
+    expect(getAuthCallbackError("?code=abc&state=xyz")).toBeNull()
+  })
+
+  it("reads the error code and its description", () => {
+    const search =
+      "?error=invalid_request&error_description=parameter%20organization%20is%20not%20allowed%20for%20this%20client&state=abc"
+    expect(getAuthCallbackError(search)).toEqual({
+      code: "invalid_request",
+      description: "parameter organization is not allowed for this client",
+    })
+  })
+
+  it("keeps a null description when Auth0 sends none", () => {
+    expect(getAuthCallbackError("?error=access_denied")).toEqual({
+      code: "access_denied",
+      description: null,
+    })
+  })
+})

--- a/apps/web/src/common/auth/auth-callback-error.ts
+++ b/apps/web/src/common/auth/auth-callback-error.ts
@@ -1,0 +1,20 @@
+/**
+ * Auth0 reports a failed authorization by redirecting back to the app with
+ * `error` and `error_description` in the query string, for example
+ * `?error=invalid_request&error_description=parameter organization is not allowed for this client`.
+ *
+ * Without a guard, a route that calls loginWithRedirect whenever the user is
+ * not authenticated sends the browser straight back to Auth0, which answers
+ * with the same error: a redirect loop the user cannot escape.
+ */
+export type AuthCallbackError = {
+  code: string
+  description: string | null
+}
+
+export function getAuthCallbackError(search: string): AuthCallbackError | null {
+  const params = new URLSearchParams(search)
+  const code = params.get("error")
+  if (!code) return null
+  return { code, description: params.get("error_description") }
+}

--- a/apps/web/src/common/auth/use-auth-callback-error.ts
+++ b/apps/web/src/common/auth/use-auth-callback-error.ts
@@ -1,0 +1,12 @@
+import { useLocation } from "react-router-dom"
+import { type AuthCallbackError, getAuthCallbackError } from "./auth-callback-error"
+
+/**
+ * The error Auth0 put in the URL when the authorization failed, or null.
+ * Routes that start a login must render AuthErrorRoute when this is set,
+ * instead of redirecting to Auth0 again.
+ */
+export function useAuthCallbackError(): AuthCallbackError | null {
+  const { search } = useLocation()
+  return getAuthCallbackError(search)
+}

--- a/apps/web/src/common/routes/AuthErrorRoute.tsx
+++ b/apps/web/src/common/routes/AuthErrorRoute.tsx
@@ -1,0 +1,46 @@
+import { useAuth0 } from "@auth0/auth0-react"
+import { Button } from "@caseai-connect/ui/shad/button"
+import { useTranslation } from "react-i18next"
+import { useLocation, useNavigate } from "react-router-dom"
+import type { AuthCallbackError } from "@/common/auth/auth-callback-error"
+import { getAppUrl } from "@/config/runtime-config"
+import { RouteNames } from "./helpers"
+
+/**
+ * Shown when Auth0 comes back with an error instead of a session. Explains
+ * the error and lets the user retry or log out, instead of bouncing to Auth0
+ * again in a loop.
+ */
+export function AuthErrorRoute({ error }: { error: AuthCallbackError }) {
+  const { t } = useTranslation("auth", { keyPrefix: "callbackError" })
+  const { logout } = useAuth0()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const retry = () => {
+    // Drop the error parameters, then let the home route start a clean login.
+    navigate({ pathname: RouteNames.HOME, search: "" }, { replace: true })
+  }
+
+  const logOut = () => {
+    logout({ logoutParams: { returnTo: getAppUrl() } })
+  }
+
+  console.error("Auth0 callback error:", error.code, error.description, location.pathname)
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <p className="text-4xl font-bold">{t("title")}</p>
+      <p className="text-xl">{error.description ?? error.code}</p>
+      <p className="text-muted-foreground max-w-prose">{t("hint")}</p>
+      <div className="flex gap-2">
+        <Button onClick={retry}>
+          <span className="capitalize-first">{t("retry")}</span>
+        </Button>
+        <Button variant="outline" onClick={logOut}>
+          <span className="capitalize-first">{t("logout")}</span>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/common/routes/HomeRoute.tsx
+++ b/apps/web/src/common/routes/HomeRoute.tsx
@@ -1,7 +1,7 @@
 import { useAuth0 } from "@auth0/auth0-react"
 import { useEffect } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
-import { getAuthCallbackError } from "@/common/auth/auth-callback-error"
+import { useAuthCallbackError } from "@/common/auth/use-auth-callback-error"
 import { selectOrganizationsData } from "@/common/features/organizations/organizations.selectors"
 import { ADS } from "@/common/store/async-data-status"
 import { useAppSelector } from "@/common/store/hooks"
@@ -36,7 +36,7 @@ export function HomeRoute() {
   const organizations = useAppSelector(selectOrganizationsData)
   const [searchParams] = useSearchParams()
   // Auth0 sent us back with an error: show it instead of redirecting again.
-  const callbackError = getAuthCallbackError(searchParams.toString())
+  const callbackError = useAuthCallbackError()
 
   useEffect(() => {
     if (isLoading || callbackError) return

--- a/apps/web/src/common/routes/HomeRoute.tsx
+++ b/apps/web/src/common/routes/HomeRoute.tsx
@@ -35,7 +35,6 @@ export function HomeRoute() {
   const { isLoading, isAuthenticated, loginWithRedirect, logout } = useAuth0()
   const organizations = useAppSelector(selectOrganizationsData)
   const [searchParams] = useSearchParams()
-  // Auth0 sent us back with an error: show it instead of redirecting again.
   const callbackError = useAuthCallbackError()
 
   useEffect(() => {

--- a/apps/web/src/common/routes/HomeRoute.tsx
+++ b/apps/web/src/common/routes/HomeRoute.tsx
@@ -1,10 +1,12 @@
 import { useAuth0 } from "@auth0/auth0-react"
 import { useEffect } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
+import { getAuthCallbackError } from "@/common/auth/auth-callback-error"
 import { selectOrganizationsData } from "@/common/features/organizations/organizations.selectors"
 import { ADS } from "@/common/store/async-data-status"
 import { useAppSelector } from "@/common/store/hooks"
 import { AUTH0_ORGANIZATION_ID } from "@/config/auth0.config"
+import { AuthErrorRoute } from "./AuthErrorRoute"
 import { RouteNames } from "./helpers"
 import { LoadingRoute } from "./LoadingRoute"
 
@@ -33,9 +35,11 @@ export function HomeRoute() {
   const { isLoading, isAuthenticated, loginWithRedirect, logout } = useAuth0()
   const organizations = useAppSelector(selectOrganizationsData)
   const [searchParams] = useSearchParams()
+  // Auth0 sent us back with an error: show it instead of redirecting again.
+  const callbackError = getAuthCallbackError(searchParams.toString())
 
   useEffect(() => {
-    if (isLoading) return
+    if (isLoading || callbackError) return
 
     // Check for Auth0 invitation params in the URL
     const invitation = searchParams.get("invitation")
@@ -79,7 +83,17 @@ export function HomeRoute() {
         },
       })
     }
-  }, [isAuthenticated, isLoading, loginWithRedirect, logout, organizations, searchParams, navigate])
+  }, [
+    callbackError,
+    isAuthenticated,
+    isLoading,
+    loginWithRedirect,
+    logout,
+    organizations,
+    searchParams,
+    navigate,
+  ])
 
+  if (callbackError) return <AuthErrorRoute error={callbackError} />
   return <LoadingRoute />
 }

--- a/apps/web/src/common/routes/ProtectedRoute.tsx
+++ b/apps/web/src/common/routes/ProtectedRoute.tsx
@@ -12,7 +12,6 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0()
   const isPlatformLoading = useAppSelector((state) => state.auth.isLoading)
   const termsAccepted = useAppSelector(selectTermsAccepted)
-  // Auth0 sent us back with an error: show it instead of redirecting again.
   const callbackError = useAuthCallbackError()
 
   useEffect(() => {

--- a/apps/web/src/common/routes/ProtectedRoute.tsx
+++ b/apps/web/src/common/routes/ProtectedRoute.tsx
@@ -1,7 +1,6 @@
 import { useAuth0 } from "@auth0/auth0-react"
 import { useEffect } from "react"
-import { useLocation } from "react-router-dom"
-import { getAuthCallbackError } from "@/common/auth/auth-callback-error"
+import { useAuthCallbackError } from "@/common/auth/use-auth-callback-error"
 import { selectTermsAccepted } from "@/common/features/me/me.selectors"
 import { useAppSelector } from "@/common/store/hooks"
 import { AUTH0_ORGANIZATION_ID } from "@/config/auth0.config"
@@ -13,9 +12,8 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0()
   const isPlatformLoading = useAppSelector((state) => state.auth.isLoading)
   const termsAccepted = useAppSelector(selectTermsAccepted)
-  const location = useLocation()
   // Auth0 sent us back with an error: show it instead of redirecting again.
-  const callbackError = getAuthCallbackError(location.search)
+  const callbackError = useAuthCallbackError()
 
   useEffect(() => {
     if (callbackError) return

--- a/apps/web/src/common/routes/ProtectedRoute.tsx
+++ b/apps/web/src/common/routes/ProtectedRoute.tsx
@@ -1,8 +1,11 @@
 import { useAuth0 } from "@auth0/auth0-react"
 import { useEffect } from "react"
+import { useLocation } from "react-router-dom"
+import { getAuthCallbackError } from "@/common/auth/auth-callback-error"
 import { selectTermsAccepted } from "@/common/features/me/me.selectors"
 import { useAppSelector } from "@/common/store/hooks"
 import { AUTH0_ORGANIZATION_ID } from "@/config/auth0.config"
+import { AuthErrorRoute } from "./AuthErrorRoute"
 import { LoadingRoute } from "./LoadingRoute"
 import { TermsRoute } from "./TermsRoute"
 
@@ -10,8 +13,12 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0()
   const isPlatformLoading = useAppSelector((state) => state.auth.isLoading)
   const termsAccepted = useAppSelector(selectTermsAccepted)
+  const location = useLocation()
+  // Auth0 sent us back with an error: show it instead of redirecting again.
+  const callbackError = getAuthCallbackError(location.search)
 
   useEffect(() => {
+    if (callbackError) return
     if (!isLoading && !isAuthenticated) {
       // Redirect to Auth0 login if not authenticated
       loginWithRedirect({
@@ -20,8 +27,9 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
         },
       })
     }
-  }, [isLoading, isAuthenticated, loginWithRedirect])
+  }, [callbackError, isLoading, isAuthenticated, loginWithRedirect])
 
+  if (callbackError) return <AuthErrorRoute error={callbackError} />
   if (isLoading || isPlatformLoading || !isAuthenticated) return <LoadingRoute />
 
   if (!termsAccepted) return <TermsRoute />

--- a/apps/web/src/locales/auth.en.json
+++ b/apps/web/src/locales/auth.en.json
@@ -1,0 +1,10 @@
+{
+  "auth": {
+    "callbackError": {
+      "title": "Sign-in failed",
+      "hint": "The identity provider refused the sign-in. If the problem persists, contact the administrator of this platform with the message above.",
+      "retry": "try again",
+      "logout": "log out"
+    }
+  }
+}

--- a/apps/web/src/locales/auth.fr.json
+++ b/apps/web/src/locales/auth.fr.json
@@ -1,0 +1,10 @@
+{
+  "auth": {
+    "callbackError": {
+      "title": "Connexion impossible",
+      "hint": "Le fournisseur d'identité a refusé la connexion. Si le problème persiste, contactez l'administrateur de la plateforme avec le message ci-dessus.",
+      "retry": "réessayer",
+      "logout": "se déconnecter"
+    }
+  }
+}


### PR DESCRIPTION
Auth0 reports a failed authorization by redirecting to the app with `error` and `error_description` in the query string, for example `?error=invalid_request&error_description=parameter organization is not allowed for this client`. `HomeRoute` and `ProtectedRoute` called `loginWithRedirect` whenever the user was not authenticated, so the browser bounced between the app and Auth0 without end, with a new `state` at each turn.

## What changes

- `common/auth/auth-callback-error.ts`: reads the error from the query string (unit tested).
- `AuthErrorRoute`: shows the provider's message, a "try again" that drops the error parameters and lets the home route start a clean login, and a "log out". Translated (en, fr).
- `HomeRoute` and `ProtectedRoute` render it when the callback carries an error, and skip the redirect.

## Checks

`npm run biome:check`, web typecheck, web tests (vitest, all green, 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)