### PR TITLE
fix(api): the status listeners honour DATABASE_SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Live status updates now work on databases that require TLS.
 - Sign-in: an error returned by the identity provider is shown with a retry button instead of reloading endlessly.
 - (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
-- Live status updates now work on databases that require TLS.
 - Sign-in: an error returned by the identity provider is shown with a retry button instead of reloading endlessly.
 - (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.

--- a/apps/api/src/common/sse/postgres-status-stream.service.ts
+++ b/apps/api/src/common/sse/postgres-status-stream.service.ts
@@ -1,6 +1,7 @@
 import { Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common"
 import { Client } from "pg"
 import { type Observable, Subject } from "rxjs"
+import { databaseSslOptions } from "@/config/database-ssl"
 
 let dbListenersEnabled = false
 
@@ -66,6 +67,8 @@ export abstract class PostgresStatusStreamService<TEventDto>
       user: process.env.DATABASE_USERNAME,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE_NAME,
+      // Same TLS setting as the TypeORM data source (DATABASE_SSL).
+      ...databaseSslOptions(),
     })
 
     listenerClient.on("notification", (notification) => {

--- a/apps/api/src/config/database-ssl.spec.ts
+++ b/apps/api/src/config/database-ssl.spec.ts
@@ -1,0 +1,28 @@
+import { databaseSslOptions } from "./database-ssl"
+
+describe("databaseSslOptions", () => {
+  it("returns no ssl option when DATABASE_SSL is unset or disabled", () => {
+    expect(databaseSslOptions({})).toEqual({})
+    expect(databaseSslOptions({ DATABASE_SSL: "false" })).toEqual({})
+    expect(databaseSslOptions({ DATABASE_SSL: "disable" })).toEqual({})
+  })
+
+  it("encrypts without verifying the certificate for require", () => {
+    expect(databaseSslOptions({ DATABASE_SSL: "require" })).toEqual({
+      ssl: { rejectUnauthorized: false },
+    })
+    expect(databaseSslOptions({ DATABASE_SSL: " Require " })).toEqual({
+      ssl: { rejectUnauthorized: false },
+    })
+  })
+
+  it("verifies against the given CA for verify-full", () => {
+    expect(databaseSslOptions({ DATABASE_SSL: "verify-full", DATABASE_SSL_CA: "PEM" })).toEqual({
+      ssl: { rejectUnauthorized: true, ca: "PEM" },
+    })
+  })
+
+  it("refuses verify-full without a CA", () => {
+    expect(() => databaseSslOptions({ DATABASE_SSL: "verify-full" })).toThrow("DATABASE_SSL_CA")
+  })
+})

--- a/apps/api/src/config/database-ssl.ts
+++ b/apps/api/src/config/database-ssl.ts
@@ -1,0 +1,25 @@
+/**
+ * TLS towards the database, for every Postgres client of the API: the TypeORM
+ * data source and the raw `pg` clients (LISTEN/NOTIFY listeners). Managed
+ * instances (Cloud SQL in ENCRYPTED_ONLY mode, RDS...) refuse plain
+ * connections.
+ *
+ * DATABASE_SSL unset, "false" or "disable": no TLS (local Docker Postgres).
+ * DATABASE_SSL=require: encrypted, server certificate not verified. Cloud SQL
+ *   signs its certificate with a per-instance CA, so this is the usual setting
+ *   inside a private network.
+ * DATABASE_SSL=verify-full: encrypted and verified against DATABASE_SSL_CA
+ *   (the CA certificate, PEM).
+ */
+export type DatabaseSslOptions = { ssl?: { rejectUnauthorized: boolean; ca?: string } }
+
+export function databaseSslOptions(env: NodeJS.ProcessEnv = process.env): DatabaseSslOptions {
+  const mode = env.DATABASE_SSL?.trim().toLowerCase()
+  if (!mode || mode === "false" || mode === "disable") return {}
+  if (mode === "verify-full") {
+    const ca = env.DATABASE_SSL_CA
+    if (!ca) throw new Error("DATABASE_SSL=verify-full requires DATABASE_SSL_CA (PEM certificate)")
+    return { ssl: { rejectUnauthorized: true, ca } }
+  }
+  return { ssl: { rejectUnauthorized: false } }
+}

--- a/apps/api/src/config/typeorm.ts
+++ b/apps/api/src/config/typeorm.ts
@@ -3,6 +3,7 @@ import { registerAs } from "@nestjs/config"
 import type { TypeOrmModuleOptions } from "@nestjs/typeorm"
 import { config as dotenvConfig } from "dotenv"
 import { DataSource, type DataSourceOptions } from "typeorm"
+import { databaseSslOptions } from "./database-ssl"
 
 dotenvConfig({ path: ".env" })
 
@@ -15,28 +16,6 @@ if (process.env.DATABASE_HOST?.startsWith("/cloudsql")) {
 
 const databaseUrl = process.env.DATABASE_URL
 
-/**
- * TLS towards the database. Managed instances (Cloud SQL in ENCRYPTED_ONLY
- * mode, RDS...) refuse plain connections.
- *
- * DATABASE_SSL unset, "false" or "disable": no TLS (local Docker Postgres).
- * DATABASE_SSL=require: encrypted, server certificate not verified. Cloud SQL
- *   signs its certificate with a per-instance CA, so this is the usual setting
- *   inside a private network.
- * DATABASE_SSL=verify-full: encrypted and verified against DATABASE_SSL_CA
- *   (the CA certificate, PEM).
- */
-function sslOptions(): { ssl?: { rejectUnauthorized: boolean; ca?: string } } {
-  const mode = process.env.DATABASE_SSL?.trim().toLowerCase()
-  if (!mode || mode === "false" || mode === "disable") return {}
-  if (mode === "verify-full") {
-    const ca = process.env.DATABASE_SSL_CA
-    if (!ca) throw new Error("DATABASE_SSL=verify-full requires DATABASE_SSL_CA (PEM certificate)")
-    return { ssl: { rejectUnauthorized: true, ca } }
-  }
-  return { ssl: { rejectUnauthorized: false } }
-}
-
 export const config: () => TypeOrmModuleOptions = () => ({
   type: "postgres",
   ...(databaseUrl
@@ -48,7 +27,7 @@ export const config: () => TypeOrmModuleOptions = () => ({
         password: process.env.DATABASE_PASSWORD,
         database: process.env.DATABASE_NAME,
       }),
-  ...sslOptions(),
+  ...databaseSslOptions(),
   entities: [`${__dirname}/../**/*.entity.{js,ts}`],
   migrations: [`${__dirname}/../**/migrations/*.{js,ts}`],
   autoLoadEntities: true,


### PR DESCRIPTION
Seen on a cluster with Cloud SQL in `ENCRYPTED_ONLY` mode after #773: the API connects (TypeORM honours `DATABASE_SSL`), but the `LISTEN/NOTIFY` clients of `PostgresStatusStreamService` open their own `pg` connections without TLS and fail every reconnect (`pg_hba.conf rejects connection ... no encryption`, 89 times in 3 minutes). Live status updates (SSE) never reach the browser.

- `config/database-ssl.ts`: the TLS options (`DATABASE_SSL`, `DATABASE_SSL_CA`) in one place, unit tested.
- `config/typeorm.ts` uses it (no behaviour change).
- `postgres-status-stream.service.ts`: the listener client uses it too.

`npm run biome:check`, API typecheck and the new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)