### PR TITLE
ci: publish the images after the tests, GPU image on the self-hosted runner

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -51,11 +51,17 @@ jobs:
               type=registry,ref=ghcr.io/bayesimpact/bayes-platform/cache:app
               type=registry,ref=ghcr.io/bayesimpact/bayes-platform/cache:cpu-workers
               type=registry,ref=ghcr.io/bayesimpact/bayes-platform/cache:gpu-workers
-          # Close to 10 GB uncompressed (Torch with CUDA, Docling): bigger runner.
+          # Close to 10 GB uncompressed (Torch with CUDA, Docling). Built on the
+          # self-hosted runner with its persistent BuildKit builder: the
+          # extracted Torch layers stay on the runner between builds, where a
+          # GitHub runner re-extracts 6 GB from the registry cache every time
+          # (ten minutes of the sixteen). This workflow runs on pushes to main,
+          # tags and manual dispatch only, never on pull requests.
           - image: gpu-workers
             dockerfile: apps/api/Dockerfile
             target: gpu-workers-runtime
-            runner: ubuntu-latest-m
+            runner: self-hosted
+            builder: platform
             cache_from: |
               type=registry,ref=ghcr.io/bayesimpact/bayes-platform/cache:app
               type=registry,ref=ghcr.io/bayesimpact/bayes-platform/cache:cpu-workers
@@ -82,13 +88,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free disk space on the runner
-        if: matrix.image == 'gpu-workers'
+        if: matrix.image == 'gpu-workers' && matrix.runner != 'self-hosted'
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune -af
           df -h /
 
+      # GitHub runners get a throwaway builder. The self-hosted runner has a
+      # persistent one, selected by name on the build step.
       - uses: docker/setup-buildx-action@v3
+        if: matrix.runner != 'self-hosted'
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -121,6 +130,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
+          builder: ${{ matrix.builder }}
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary

One workflow on pushes to main and on release tags, `publish-images.yml`. `prod.yml` is removed, with its dispatch to the deployment repository.

- **Checks, tests and image builds run in parallel.** The tests run on the self-hosted runner, as before.
- **The images are pushed under the `sha-<short sha>` tag only**, a tag nothing consumes.
- **When the checks and the tests pass**, a publish job adds the deployment tags to the six images (`main`, `latest`, `main-<run>-<sha>` on main, the CalVer version on a release tag) with `docker buildx imagetools create`, no rebuild. It then sends `platform-images-published` to the deployment repository. When the tests fail, only the `sha-` tag exists and nothing is deployed.
- **The Helm chart** is published on a release tag after the publish job.
- **The `gpu-workers` image is built on the self-hosted runner** with the persistent buildx builder `platform`: 16 minutes on a GitHub runner, ten of them re-extracting 6 GB of cached Torch layers.
- `docs/architecture.md` describes the new pipeline.

## Notes

- The `make notify-error` steps of `prod.yml` called a target that does not exist. Not carried over. Deploy notifications come from Flux.
- The tests and the GPU build share one self-hosted runner and queue behind each other. A second runner instance on the same machine removes the queue.

## Merge order

The persistent builder must exist on the runner before this is merged, otherwise the `gpu-workers` job fails with `no builder "platform" found`. Re-run the job after the runner is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)