### PR TITLE
chore(chart): rename initialAdmins to platformSuperadmins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ## [Unreleased]
 
 ### Added
-- Kubernetes: the first administrators of a new install are set from the values, no database access needed.
+- Kubernetes: the platform administrators are listed in the chart values, no database access needed.
 - Kubernetes: the platform connects to databases that require TLS (Cloud SQL, RDS) with one setting.
 - (beta) MCP servers: connect servers that use OAuth by authorizing access in the browser, alongside API keys.
 - Kubernetes: the platform can be installed on any cluster with a Helm chart, with bundled Postgres and Redis.

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Notes:
 
 A Helm chart installs the full platform (API, workers, front ends, PDF converter) on any Kubernetes cluster, with bundled Postgres and Redis or with managed services. See [deploy/helm/bayes-platform/README.md](deploy/helm/bayes-platform/README.md).
 
-Global roles are granted by an operator, never at sign-in: `initialAdmins` in the chart values for the first administrators, then `npm run platform-role -- grant|revoke|list --email <email> [--role <role>]` (or the same script from the runtime image).
+Global roles are granted by an operator, never at sign-in: `platformSuperadmins` in the chart values (grant only, applied at every upgrade), then `npm run platform-role -- grant|revoke|list --email <email> [--role <role>]` (or the same script from the runtime image).
 
 ## Running Tests
 

--- a/apps/api/src/domains/rbac/platform-role.service.ts
+++ b/apps/api/src/domains/rbac/platform-role.service.ts
@@ -21,7 +21,7 @@ export function isPlatformRoleKey(value: string): value is PlatformRoleKey {
  * the identity provider reports would let anyone who can register an address
  * of the right shape become staff. Roles are granted by an operator, through
  * the platform-role command (scripts/platform-role.ts), the chart's
- * initialAdmins job, or later the back office.
+ * platformSuperadmins job, or later the back office.
  */
 @Injectable()
 export class PlatformRoleService {

--- a/apps/api/src/scripts/platform-role.ts
+++ b/apps/api/src/scripts/platform-role.ts
@@ -13,7 +13,7 @@
  * with a placeholder identity and linked to the real one at first sign-in
  * (the same path as an invited member). This is how the first administrator
  * of a fresh install gets in. Roles are never granted automatically at
- * sign-in: an operator decides, here or in the chart's initialAdmins job.
+ * sign-in: an operator decides, here or in the chart's platformSuperadmins job.
  */
 import { randomUUID } from "node:crypto"
 import { Logger } from "@nestjs/common"

--- a/deploy/helm/bayes-platform/README.md
+++ b/deploy/helm/bayes-platform/README.md
@@ -131,12 +131,12 @@ The database migrations run as a Job after the first install and before every up
 kubectl -n platform logs job/platform-bayes-platform-migrate
 ```
 
-## First administrator
+## Platform administrators
 
 Global roles (`platform_superadmin`, `platform_staff`) are never granted automatically at sign-in: an operator decides who holds them.
 
-- **At install**: list the emails in `initialAdmins`. A Job runs after the migrations and grants `platform_superadmin` to each of them. The users are created if they never signed in, and linked to their identity at first sign-in, so the first administrator can sign in and create the first organization right away.
-- **Later**: the `platform-role` command, from any api pod:
+- **In the values**: list the emails in `platformSuperadmins`. A Job runs after the migrations, on every install and upgrade, and grants `platform_superadmin` to each of them. The users are created if they never signed in, and linked to their identity at first sign-in, so the first administrator can sign in and create the first organization right away. Adding an email later grants it at the next upgrade. Removing one revokes nothing.
+- **Grant, revoke or list by command**, from any api pod:
 
 ```bash
 kubectl -n platform exec deploy/platform-bayes-platform-api -- \

--- a/deploy/helm/bayes-platform/templates/platform-superadmins-job.yaml
+++ b/deploy/helm/bayes-platform/templates/platform-superadmins-job.yaml
@@ -1,16 +1,18 @@
-{{- if .Values.initialAdmins }}
-# Grants platform_superadmin to the emails of initialAdmins, after the
-# migrations. Idempotent: an email already granted is left as is. The users
+{{- if .Values.platformSuperadmins }}
+# Grants platform_superadmin to the emails of platformSuperadmins, after the
+# migrations, on every install and upgrade. Idempotent: an email already
+# granted is left as is. Grant only: an email removed from the list keeps its
+# role, revocation is an operator command (platform-role revoke). The users
 # are created if they never signed in, and linked to their identity at first
 # sign-in. This is the only automatic role grant: an operator lists the
 # emails in the values, nothing is decided at sign-in.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "bayes-platform.componentName" (dict "root" . "component" "initial-admins") }}
+  name: {{ include "bayes-platform.componentName" (dict "root" . "component" "platform-superadmins") }}
   labels:
     {{- include "bayes-platform.labels" . | nindent 4 }}
-    app.kubernetes.io/component: initial-admins
+    app.kubernetes.io/component: platform-superadmins
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "10"
@@ -20,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "bayes-platform.selectorLabels" (dict "root" . "component" "initial-admins") | nindent 8 }}
+        {{- include "bayes-platform.selectorLabels" (dict "root" . "component" "platform-superadmins") | nindent 8 }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "bayes-platform.serviceAccountName" . }}
@@ -34,7 +36,7 @@ spec:
       initContainers:
         {{- include "bayes-platform.waitForDatabase" . | nindent 8 }}
       containers:
-        - name: initial-admins
+        - name: platform-superadmins
           image: {{ include "bayes-platform.image" (dict "root" . "image" .Values.api.image) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           workingDir: /app/apps/api
@@ -43,7 +45,7 @@ spec:
             - -c
             - |
               set -e
-              {{- range .Values.initialAdmins }}
+              {{- range .Values.platformSuperadmins }}
               node /app/apps/api/dist/scripts/platform-role.js grant --email {{ . | quote }} --role platform_superadmin
               {{- end }}
           env:

--- a/deploy/helm/bayes-platform/values.yaml
+++ b/deploy/helm/bayes-platform/values.yaml
@@ -303,14 +303,16 @@ help:
       memory: 128Mi
 
 # ---------------------------------------------------------------------------
-# First administrators: emails granted platform_superadmin by a Job after the
-# migrations (they create organizations and open the back office). The users
-# are created if they never signed in, and linked to their identity at first
-# sign-in. Nothing is granted at sign-in: this list is the only automatic
-# grant, and it is a decision in the values. Later grants: the platform-role
-# command (see README.md).
+# Platform super administrators: emails granted platform_superadmin by a Job
+# after the migrations, on every install and upgrade (they create
+# organizations and open the back office). Adding an email grants the role at
+# the next upgrade. Removing one revokes nothing: revocation is the
+# platform-role command (see README.md), so a role granted by an operator is
+# never undone by a deployment. The users are created if they never signed
+# in, and linked to their identity at first sign-in. Nothing is granted at
+# sign-in: this list is the only automatic grant.
 # ---------------------------------------------------------------------------
-initialAdmins: []
+platformSuperadmins: []
 #  - admin@example.org
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The list of administrators in the chart values is applied by a Job at every install and upgrade, not only at the first install. `initialAdmins` said otherwise. The new name, `platformSuperadmins`, says which role it grants.

- Values key, Job template and component name renamed. The Job comment and the values comment say that the list is grant only: an email removed from the list keeps its role, revocation is the `platform-role revoke` command. A deployment never undoes what an operator granted.
- Chart README, root README, changelog and two code comments updated.

Breaking for chart values: `initialAdmins` is ignored after this change. The chart is at 0.1.0 with one known deployment, updated alongside.

`helm lint` and `helm template` with two emails render one Job with the two grant commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)