### PR TITLE
ci: workers smoke on the self-hosted runner

### DIFF
--- a/.github/workflows/branch-workers-smoke.yml
+++ b/.github/workflows/branch-workers-smoke.yml
@@ -12,7 +12,15 @@ on:
 
 jobs:
   workers-smoke:
-    runs-on: ubuntu-latest
+    # Self-hosted: the Docker daemon of the runner keeps the build cache
+    # between runs, so only the layers that depend on the branch are rebuilt
+    # (the Torch install alone is two minutes on a GitHub runner). Push events
+    # fire for branches of this repository only, never for forks.
+    runs-on: self-hosted
+    # One smoke at a time on the runner: the compose stack binds fixed ports.
+    concurrency:
+      group: workers-smoke-self-hosted
+      cancel-in-progress: false
     steps:
       - name: Use Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

The workers smoke builds the CPU and GPU images with `docker build` and starts them with compose, 4 to 5 minutes on a GitHub runner, two of them installing Torch. On the self-hosted runner the Docker daemon keeps its build cache between runs, so only the layers that depend on the branch are rebuilt. Expected: 1 to 2 minutes.

- `runs-on: self-hosted`.
- Concurrency group: one smoke at a time, the compose stack binds fixed ports (55432, 56379, 3003, distinct from the tests).

Push events fire for branches of this repository only, never for forks, so no external code reaches the runner through this workflow.

The runner keeps a cap on the daemon build cache so the Torch layers are not evicted between two runs (deployment repository).

🤖 Generated with [Claude Code](https://claude.com/claude-code)