### PR TITLE
fix(chart): MCP OAuth callback derived from the web URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Kubernetes: authorizing an MCP server with OAuth works out of the box, the callback address follows the web URL.
 - Sign-in: an error returned by the identity provider is shown with a retry button instead of reloading endlessly.
 - (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.

--- a/deploy/helm/bayes-platform/templates/_helpers.tpl
+++ b/deploy/helm/bayes-platform/templates/_helpers.tpl
@@ -160,6 +160,12 @@ on other chart values.
 {{- end }}
 - name: FRONTEND_URL
   value: {{ .Values.urls.web | quote }}
+{{- if not (hasKey .Values.config "MCP_OAUTH_REDIRECT_URL") }}
+# Where MCP servers send the browser back after an OAuth authorization: a
+# route of the web front. Set config.MCP_OAUTH_REDIRECT_URL to override.
+- name: MCP_OAUTH_REDIRECT_URL
+  value: {{ printf "%s/oauth/mcp/callback" (trimSuffix "/" .Values.urls.web) | quote }}
+{{- end }}
 {{- if eq .Values.storage.mode "gcs" }}
 - name: GCS_STORAGE_BUCKET_NAME
   value: {{ required "storage.gcs.bucket is required when storage.mode is gcs" .Values.storage.gcs.bucket | quote }}

--- a/deploy/helm/bayes-platform/values.yaml
+++ b/deploy/helm/bayes-platform/values.yaml
@@ -18,6 +18,8 @@ global:
 # The web front is served by the API (app image) under /app on the api URL:
 # `web` is the address users open, `api` the origin the browser calls. Keep
 # them on the same host unless you serve the front from somewhere else.
+# The addresses the platform derives from `web` (the OAuth callback of MCP
+# servers, for example) follow it: no other URL setting is needed.
 urls:
   api: https://platform.example.org
   web: https://platform.example.org/app


### PR DESCRIPTION
## Summary

The chart did not set `MCP_OAUTH_REDIRECT_URL`. The API reads it with `getOrThrow` when a user authorizes an MCP server with OAuth, so every install answered a 500 on that action.

- Default in the shared env: `<urls.web>/oauth/mcp/callback`, the callback route of the web front. `config.MCP_OAUTH_REDIRECT_URL` overrides it.
- Values comment and changelog.

Checked the other settings the API reads with `getOrThrow` (Auth0 issuer, audience, organization, client ids, M2M secret, database connection name): all covered by the chart.

`helm lint` passes. `helm template` renders the default from `urls.web` and drops it when the override is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)