### PR TITLE
ci: gate the API tests on the paths they exercise, smoke on the self-hosted runner, MCP OAuth callback in the chart

### DIFF
--- a/.github/workflows/branch-workers-smoke.yml
+++ b/.github/workflows/branch-workers-smoke.yml
@@ -12,7 +12,15 @@ on:
 
 jobs:
   workers-smoke:
-    runs-on: ubuntu-latest
+    # Self-hosted: the Docker daemon of the runner keeps the build cache
+    # between runs, so only the layers that depend on the branch are rebuilt
+    # (the Torch install alone is two minutes on a GitHub runner). Push events
+    # fire for branches of this repository only, never for forks.
+    runs-on: self-hosted
+    # One smoke at a time on the runner: the compose stack binds fixed ports.
+    concurrency:
+      group: workers-smoke-self-hosted
+      cancel-in-progress: false
     steps:
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     outputs:
       help-only: ${{ steps.filter.outputs.help-only }}
       api-tests: ${{ steps.filter.outputs.api-tests }}
+      web-tests: ${{ steps.filter.outputs.web-tests }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -37,6 +38,13 @@ jobs:
             echo "api-tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "api-tests=false" >> "$GITHUB_OUTPUT"
+          fi
+          # The web tests (vitest, no database) run when the web front, the
+          # shared packages or the dependencies changed.
+          if echo "$CHANGED" | grep -qE '^(apps/web/|packages/|package\.json$|package-lock\.json$)'; then
+            echo "web-tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "web-tests=false" >> "$GITHUB_OUTPUT"
           fi
 
   ci-checks:
@@ -96,3 +104,32 @@ jobs:
       - name: Run tests
         if: needs.changes.outputs.api-tests == 'true'
         run: TEST_WORKERS=6 make tests-only-parallel
+
+  web-tests:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip, nothing the web tests exercise changed
+        if: needs.changes.outputs.web-tests == 'false'
+        run: echo "Skipping the web tests, no change under apps/web, packages, package.json or package-lock.json"
+
+      - name: Use Node.js
+        if: needs.changes.outputs.web-tests == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          cache: npm
+
+      - name: Checkout code
+        if: needs.changes.outputs.web-tests == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install dependencies
+        if: needs.changes.outputs.web-tests == 'true'
+        run: npm ci
+
+      - name: Run web tests
+        if: needs.changes.outputs.web-tests == 'true'
+        run: npm run test --workspace=@caseai-connect/web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       help-only: ${{ steps.filter.outputs.help-only }}
+      api-tests: ${{ steps.filter.outputs.api-tests }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,6 +28,15 @@ jobs:
             echo "help-only=false" >> "$GITHUB_OUTPUT"
           else
             echo "help-only=true" >> "$GITHUB_OUTPUT"
+          fi
+          # The API tests run only when something they exercise changed: the
+          # API, the shared packages, the dependencies, the test database
+          # stack or the Makefile that drives them. A chart, workflow or docs
+          # change does not queue twenty minutes on the self-hosted runner.
+          if echo "$CHANGED" | grep -qE '^(apps/api/|packages/|infra/database/|package\.json$|package-lock\.json$|Makefile$)'; then
+            echo "api-tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "api-tests=false" >> "$GITHUB_OUTPUT"
           fi
 
   ci-checks:
@@ -49,7 +59,7 @@ jobs:
 
   tests:
     needs: changes
-    runs-on: ${{ needs.changes.outputs.help-only == 'true' && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ needs.changes.outputs.api-tests == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     # One tests job at a time on the self-hosted runner, across workflows: the
     # jobs share the Docker daemon, the database ports and the cleanup below.
     # Two at once wipe each other's containers and overload the machine.
@@ -58,12 +68,12 @@ jobs:
       group: tests-self-hosted
       cancel-in-progress: false
     steps:
-      - name: Skip — only apps/help changed
-        if: needs.changes.outputs.help-only == 'true'
-        run: echo "Skipping tests — only apps/help changed"
+      - name: Skip, nothing the API tests exercise changed
+        if: needs.changes.outputs.api-tests == 'false'
+        run: echo "Skipping the API tests, no change under apps/api, packages, infra/database, package.json, package-lock.json or Makefile"
 
       - name: Clean up Docker artifacts
-        if: needs.changes.outputs.help-only == 'false'
+        if: needs.changes.outputs.api-tests == 'true'
         # The buildx builder containers stay: the persistent builder of the GPU
         # image lives in one of them, with its cache volume.
         run: |
@@ -72,17 +82,17 @@ jobs:
           sudo rm -rf infra/database/dontsave 2>/dev/null || true
 
       - name: Use Node.js
-        if: needs.changes.outputs.help-only == 'false'
+        if: needs.changes.outputs.api-tests == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24.x'
 
       - name: Checkout code
-        if: needs.changes.outputs.help-only == 'false'
+        if: needs.changes.outputs.api-tests == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run tests
-        if: needs.changes.outputs.help-only == 'false'
+        if: needs.changes.outputs.api-tests == 'true'
         run: TEST_WORKERS=6 make tests-only-parallel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Kubernetes: authorizing an MCP server with OAuth works out of the box, the callback address follows the web URL.
 - Sign-in: an error returned by the identity provider is shown with a retry button instead of reloading endlessly.
 - (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
-- Kubernetes: authorizing an MCP server with OAuth works out of the box, the callback address follows the web URL.
 - Sign-in: an error returned by the identity provider is shown with a retry button instead of reloading endlessly.
 - (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.

--- a/deploy/helm/bayes-platform/templates/_helpers.tpl
+++ b/deploy/helm/bayes-platform/templates/_helpers.tpl
@@ -160,6 +160,12 @@ on other chart values.
 {{- end }}
 - name: FRONTEND_URL
   value: {{ .Values.urls.web | quote }}
+{{- if not (hasKey .Values.config "MCP_OAUTH_REDIRECT_URL") }}
+# Where MCP servers send the browser back after an OAuth authorization: a
+# route of the web front. Set config.MCP_OAUTH_REDIRECT_URL to override.
+- name: MCP_OAUTH_REDIRECT_URL
+  value: {{ printf "%s/oauth/mcp/callback" (trimSuffix "/" .Values.urls.web) | quote }}
+{{- end }}
 {{- if eq .Values.storage.mode "gcs" }}
 - name: GCS_STORAGE_BUCKET_NAME
   value: {{ required "storage.gcs.bucket is required when storage.mode is gcs" .Values.storage.gcs.bucket | quote }}

--- a/deploy/helm/bayes-platform/values.yaml
+++ b/deploy/helm/bayes-platform/values.yaml
@@ -18,6 +18,8 @@ global:
 # The web front is served by the API (app image) under /app on the api URL:
 # `web` is the address users open, `api` the origin the browser calls. Keep
 # them on the same host unless you serve the front from somewhere else.
+# The addresses the platform derives from `web` (the OAuth callback of MCP
+# servers, for example) follow it: no other URL setting is needed.
 urls:
   api: https://platform.example.org
   web: https://platform.example.org/app


### PR DESCRIPTION
## Summary

Replaces #784 and #785, one pull request instead of two runs on the self-hosted runner.

### API tests gated on paths
The tests job of `ci.yml` runs only when the pull request changes `apps/api/`, `packages/`, `infra/database/`, `package.json`, `package-lock.json` or the `Makefile`. A chart, workflow or docs change no longer queues on the self-hosted runner. The job still reports, on a GitHub runner with a skip step, so the required check is satisfied. The `help-only` rule for the checks stays.

### Web tests, at last
The vitest suite of `apps/web` (19 files, 168 tests, two seconds) never ran in CI. A `web-tests` job runs it on a GitHub runner when `apps/web/`, `packages/`, `package.json` or `package-lock.json` change. To add to the required checks once merged.

### Workers smoke on the self-hosted runner
The smoke builds the CPU and GPU images with `docker build`, 4 to 5 minutes on a GitHub runner, two of them installing Torch. The Docker daemon of the self-hosted runner keeps its build cache between runs. Concurrency group: one smoke at a time, the compose stack binds fixed ports. Push events fire for branches of this repository only, never for forks.

### MCP OAuth callback derived from the web URL
The chart did not set `MCP_OAUTH_REDIRECT_URL`, read with `getOrThrow` when a user authorizes an MCP server: a 500 on every install. Default `<urls.web>/oauth/mcp/callback`, `config.MCP_OAUTH_REDIRECT_URL` overrides it. The other `getOrThrow` settings are covered by the chart. `helm lint` and `helm template` checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)