### PR TITLE
fix(web): honour the /app base path in full-page navigations and pathname checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses [CalVer](https://calver.org/) (YY.MM.Micro) for product versio
 ### Changed
 
 ### Fixed
+- Navigation: opening a workspace, a new project, another agent or session now lands on the right page when the platform is served under a sub-path.
 - Sign-in: an error returned by the identity provider is shown with a retry button instead of reloading endlessly.
 - (beta) MCP App cards: the reply text now stays on screen next to the card instead of disappearing once the card shows.
 - (beta) Conversations with MCP App cards now open at once, each card showing a placeholder until it is ready.

--- a/apps/web/src/common/components/breadcrumb/BreadcrumbAgent.tsx
+++ b/apps/web/src/common/components/breadcrumb/BreadcrumbAgent.tsx
@@ -16,6 +16,7 @@ import { getAgentIcon } from "@/common/features/agents/components/AgentIcon"
 import { useValue } from "@/common/hooks/use-value"
 import { ADS } from "@/common/store/async-data-status"
 import { useAppSelector } from "@/common/store/hooks"
+import { toAppHref } from "@/config/runtime-config"
 import type { DeskRoutes } from "@/desk/routes/helpers"
 import type { StudioRoutes } from "@/studio/routes/helpers"
 
@@ -36,7 +37,7 @@ export function BreadcrumbAgent({
     const nextAgent = agents.find((candidateAgent) => candidateAgent.id === agentId)
     if (!nextAgent) return
     const path = buildPath({ organizationId, projectId: agent.value.projectId, agentId })
-    window.location.assign(path)
+    window.location.assign(toAppHref(path))
   }
 
   if (agents.length === 1)

--- a/apps/web/src/common/components/breadcrumb/BreadcrumbAgentSession.tsx
+++ b/apps/web/src/common/components/breadcrumb/BreadcrumbAgentSession.tsx
@@ -24,6 +24,7 @@ import { selectCurrentProjectId } from "@/common/features/projects/projects.sele
 import { ADS } from "@/common/store/async-data-status"
 import { useAppSelector } from "@/common/store/hooks"
 import { buildSince } from "@/common/utils/build-date"
+import { toAppHref } from "@/config/runtime-config"
 import type { DeskRoutes } from "@/desk/routes/helpers"
 import type { StudioRoutes } from "@/studio/routes/helpers"
 
@@ -100,7 +101,7 @@ function WithData({
         agentId,
         agentSessionId,
       })
-      window.location.assign(path)
+      window.location.assign(toAppHref(path))
     }
   if (sessions.length === 1)
     return (

--- a/apps/web/src/common/components/home/WorkspaceItem.tsx
+++ b/apps/web/src/common/components/home/WorkspaceItem.tsx
@@ -25,6 +25,7 @@ import type { MyProject } from "@/common/features/projects/projects.models"
 import { useAbility } from "@/common/hooks/use-ability"
 import { useFeatureFlags } from "@/common/hooks/use-feature-flags"
 import { useAppSelector } from "@/common/store/hooks"
+import { toAppHref } from "@/config/runtime-config"
 import { DeskRoutes } from "@/desk/routes/helpers"
 import { EvalRoutes } from "@/eval/routes/helpers"
 import { ReviewerRoutes } from "@/reviewer/routes/helpers"
@@ -65,7 +66,7 @@ function OpenButton({ apps }: { apps: AppData[] }) {
     const app = apps[0]
     if (!app) return null
     return (
-      <Button variant="outline" onClick={() => window.location.assign(app.path)}>
+      <Button variant="outline" onClick={() => window.location.assign(toAppHref(app.path))}>
         {app.icon} {app.name} <ArrowRightIcon className="ml-4" />
       </Button>
     )
@@ -87,7 +88,7 @@ function OpenButton({ apps }: { apps: AppData[] }) {
       <div>
         <Button
           variant="outline"
-          onClick={() => window.location.assign(firstApp.path)}
+          onClick={() => window.location.assign(toAppHref(firstApp.path))}
           className="rounded-r-none"
         >
           {firstApp.icon} {firstApp.name} <div className="w-2" />
@@ -102,7 +103,10 @@ function OpenButton({ apps }: { apps: AppData[] }) {
         <DropdownMenuGroup>
           {filteredApps.map((app) => {
             return (
-              <DropdownMenuItem key={app.id} onClick={() => window.location.assign(app.path)}>
+              <DropdownMenuItem
+                key={app.id}
+                onClick={() => window.location.assign(toAppHref(app.path))}
+              >
                 {app.icon} {app.name}
               </DropdownMenuItem>
             )

--- a/apps/web/src/common/features/agents/agents.thunks.ts
+++ b/apps/web/src/common/features/agents/agents.thunks.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk } from "@reduxjs/toolkit"
 import type { RootState, ThunkExtraArg } from "@/common/store"
+import { getAppPathname } from "@/config/runtime-config"
 import { DeskRoutes } from "@/desk/routes/helpers"
 import { getCurrentId } from "../helpers"
 import type { Agent } from "./agents.models"
@@ -14,7 +15,7 @@ export const listAgents = createAsyncThunk<Agent[], void, ThunkConfig>(
     const projectId = getCurrentId({ state, name: "projectId" })
     const params = { organizationId, projectId }
     // FIXME: This is a temporary solution to avoid fetching drafts in the Desk app. We should refactor this logic to be more robust and not rely on the URL path.
-    const isDesk = window.location.pathname.startsWith(DeskRoutes.home.path)
+    const isDesk = getAppPathname().startsWith(DeskRoutes.home.path)
     return isDesk
       ? await services.agents.getAll(params)
       : await services.agents.getAllWithDrafts(params)

--- a/apps/web/src/config/runtime-config.spec.ts
+++ b/apps/web/src/config/runtime-config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { mergeRuntimeConfig, type RuntimeConfig } from "./runtime-config"
+import { getAppPathname, mergeRuntimeConfig, type RuntimeConfig, toAppHref } from "./runtime-config"
 
 const buildTime: RuntimeConfig = {
   apiUrl: "https://api.build",
@@ -29,5 +29,36 @@ describe("mergeRuntimeConfig", () => {
     } as unknown as Partial<RuntimeConfig>
     expect(mergeRuntimeConfig(buildTime, injected).appTitle).toBe("Build title")
     expect(mergeRuntimeConfig(buildTime, injected).helpCenterUrl).toBeUndefined()
+  })
+})
+
+describe("toAppHref", () => {
+  it("keeps the path as is when the app is served from the root", () => {
+    expect(toAppHref("/studio/o/1", "/")).toBe("/studio/o/1")
+  })
+
+  it("prefixes the path with the base path, without doubling the slash", () => {
+    expect(toAppHref("/studio/o/1", "/app/")).toBe("/app/studio/o/1")
+    expect(toAppHref("/studio/o/1", "/app")).toBe("/app/studio/o/1")
+  })
+})
+
+describe("getAppPathname", () => {
+  it("returns the pathname untouched when the app is served from the root", () => {
+    expect(getAppPathname("/app/o/1", "/")).toBe("/app/o/1")
+  })
+
+  it("strips the base path", () => {
+    expect(getAppPathname("/app/studio/o/1", "/app/")).toBe("/studio/o/1")
+    expect(getAppPathname("/app", "/app/")).toBe("/")
+    expect(getAppPathname("/app/", "/app/")).toBe("/")
+  })
+
+  it("does not strip a segment that only shares the base path as a prefix", () => {
+    expect(getAppPathname("/application/x", "/app/")).toBe("/application/x")
+  })
+
+  it("distinguishes the base path from a route of the same name", () => {
+    expect(getAppPathname("/app/app/o/1", "/app/")).toBe("/app/o/1")
   })
 })

--- a/apps/web/src/config/runtime-config.ts
+++ b/apps/web/src/config/runtime-config.ts
@@ -90,7 +90,34 @@ export const APP_BASE_PATH: string = import.meta.env.BASE_URL
 
 /** Absolute URL of the SPA root, without trailing slash. Used for Auth0 redirects. */
 export function getAppUrl(): string {
-  return `${window.location.origin}${APP_BASE_PATH.replace(/\/$/, "")}`
+  return `${window.location.origin}${trimTrailingSlash(APP_BASE_PATH)}`
+}
+
+/**
+ * Prefixes an app path (as built by the route helpers) with the SPA base path.
+ * React Router applies the basename itself; this is for full-page navigations
+ * (`window.location.assign`, `window.open`) that bypass it.
+ */
+export function toAppHref(path: string, basePath: string = APP_BASE_PATH): string {
+  return `${trimTrailingSlash(basePath)}${path}`
+}
+
+/**
+ * Current `window.location.pathname` with the SPA base path removed, so it can
+ * be compared with route paths the way React Router's `location.pathname` is.
+ */
+export function getAppPathname(
+  pathname: string = window.location.pathname,
+  basePath: string = APP_BASE_PATH,
+): string {
+  const base = trimTrailingSlash(basePath)
+  if (!base) return pathname
+  if (pathname === base) return "/"
+  return pathname.startsWith(`${base}/`) ? pathname.slice(base.length) : pathname
+}
+
+function trimTrailingSlash(path: string): string {
+  return path.replace(/\/$/, "")
 }
 
 /** URL of a file from `public/`, resolved against the SPA base path. */

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App.tsx"
 import { RouteNames } from "./common/routes/helpers.ts"
 import { store } from "./common/store/index.ts"
 import { auth0ProviderConfig } from "./config/auth0.config.ts"
+import { getAppPathname } from "./config/runtime-config.ts"
 import "./i18n"
 import "./index.css"
 
@@ -17,7 +18,7 @@ createRoot(document.getElementById("root")!).render(
         // Auth0 also uses ?code=&state= in its callbacks, so by default the SDK
         // consumes those params on ANY page load. The MCP OAuth callback carries
         // a third-party code/state pair that must reach our own handler intact.
-        skipRedirectCallback={window.location.pathname === RouteNames.MCP_OAUTH_CALLBACK}
+        skipRedirectCallback={getAppPathname() === RouteNames.MCP_OAUTH_CALLBACK}
       >
         <App />
       </Auth0Provider>

--- a/apps/web/src/studio/features/projects/components/ProjectCreator.tsx
+++ b/apps/web/src/studio/features/projects/components/ProjectCreator.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next"
 import { GridCard } from "@/common/components/grid/Grid"
 import type { Organization } from "@/common/features/organizations/organizations.models"
 import { useAppDispatch } from "@/common/store/hooks"
+import { toAppHref } from "@/config/runtime-config"
 import { ProjectForm } from "@/studio/features/projects/components/ProjectForm"
 import { createProject } from "@/studio/features/projects/projects.thunks"
 import { StudioRoutes } from "@/studio/routes/helpers"
@@ -54,7 +55,7 @@ export function ProjectCreator({
       projectId,
     })
     // NOTE: do not use navigate from react-router
-    window.location.assign(path)
+    window.location.assign(toAppHref(path))
   }
 
   return (

--- a/apps/web/src/studio/routes/helpers.ts
+++ b/apps/web/src/studio/routes/helpers.ts
@@ -1,4 +1,5 @@
 import { defineRoute } from "@/common/routes/helpers"
+import { getAppPathname } from "@/config/runtime-config"
 
 const home = defineRoute("/studio")
 const organization = home.extend("/o/:organizationId")
@@ -63,4 +64,4 @@ export const StudioRoutes = {
 }
 
 // FIXME: to be removed (alexis)
-export const isStudioInterface = () => window.location.pathname.startsWith(StudioRoutes.home.path)
+export const isStudioInterface = () => getAppPathname().startsWith(StudioRoutes.home.path)


### PR DESCRIPTION
## Problem

On staging the front is served by the API under `/app` (#764). React Router gets that basename, so `Link` and `navigate` are fine, but everything that touches `window.location` directly ignored the prefix:

- `window.location.assign` after creating a project, from the workspace buttons on the home page, and from the agent / session breadcrumbs sent the browser to `/studio/o/...` instead of `/app/studio/o/...` (404 on the API).
- `isDesk` in the agents thunk tested `pathname.startsWith("/app")`, the Desk home route. Under the prefix this was always true, so the Studio loaded agents without drafts.
- `isStudioInterface` never matched.
- The `skipRedirectCallback` guard in `main.tsx` never matched, so Auth0 consumed the MCP OAuth callback `code`/`state`.

## Fix

Two helpers in `runtime-config.ts`, built on the existing `APP_BASE_PATH`:

- `toAppHref(path)` prefixes a route-helper path for full-page navigations.
- `getAppPathname()` returns the pathname without the base, comparable with route paths.

All the call sites above use them. Unit tests cover both helpers, including the `/app/app/...` case where the base and the Desk route share a name.

## Checks

- `npm run biome:check`, `tsc --noEmit`, `vitest run` (174 tests) pass.
- Config note: `MCP_OAUTH_REDIRECT_URL` on staging must include `/app` (already done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
