### PR TITLE
fix(help): API base URL and site URL set at container start

### DIFF
--- a/apps/help/Dockerfile
+++ b/apps/help/Dockerfile
@@ -4,8 +4,12 @@
 # Build from the repository root:
 #   docker build -f apps/help/Dockerfile -t bayes-platform/help .
 #
-# PUBLIC_APP_URL (the "back to the app" link) is built with a placeholder and
-# replaced at container start, so one image serves every install.
+# The per-install URLs are built with placeholders and replaced at container
+# start (docker/40-runtime-config.sh), so one image serves every install:
+#   PUBLIC_APP_URL       the "back to the app" link
+#   PUBLIC_API_BASE_URL  the API base URL shown on the public API pages
+#   PUBLIC_SITE_URL      canonical links and sitemap; Astro requires a valid
+#                        URL at build time, hence a placeholder host
 #
 FROM node:24.20.0-bookworm-slim AS build
 
@@ -19,7 +23,9 @@ RUN npm ci \
     --workspace=@caseai-connect/help \
     --include-workspace-root
 
-ENV PUBLIC_APP_URL=__PUBLIC_APP_URL__
+ENV PUBLIC_APP_URL=__PUBLIC_APP_URL__ \
+    PUBLIC_API_BASE_URL=__PUBLIC_API_BASE_URL__ \
+    PUBLIC_SITE_URL=https://public-site-url.placeholder.invalid
 
 RUN npx turbo run build --filter=@caseai-connect/help
 

--- a/apps/help/README.md
+++ b/apps/help/README.md
@@ -54,6 +54,10 @@ draft: false # optional; drafts are hidden in production
   links and the sitemap. Falls back to `SITE_URL`.
 - `SITE_URL` / `SITE_TITLE` / `LOCALES` — see `src/consts.ts`.
 
+In the container image (`apps/help/Dockerfile`) the three `PUBLIC_*` variables are
+build-time placeholders replaced when the container starts, from its environment.
+One image serves every install; the Helm chart sets them from `urls`.
+
 ## Deployment
 
 Static output (`astro build` → `dist/`). Deploy the folder to any static host /

--- a/apps/help/docker/40-runtime-config.sh
+++ b/apps/help/docker/40-runtime-config.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Replace the build-time placeholder __PUBLIC_APP_URL__ with the container
-# environment. Runs from the nginx image entrypoint before nginx starts.
+# Replace the build-time placeholders with the container environment. Runs
+# from the nginx image entrypoint before nginx starts. See the Dockerfile for
+# the three variables.
 set -eu
 
 HTML_DIR=/usr/share/nginx/html
@@ -9,9 +10,15 @@ escape_value() {
   printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/[&|]/\\&/g'
 }
 
-files=$(find "$HTML_DIR" -type f \( -name '*.js' -o -name '*.html' \))
-escaped=$(escape_value "${PUBLIC_APP_URL:-}")
+# The site URL also lives in the sitemap and robots.txt. No trailing slash:
+# Astro appends the paths to the site URL.
+site_url=$(printf '%s' "${PUBLIC_SITE_URL:-}" | sed 's|/*$||')
+
+files=$(find "$HTML_DIR" -type f \( -name '*.js' -o -name '*.html' -o -name '*.xml' -o -name '*.txt' \))
 # shellcheck disable=SC2086
-echo "$files" | xargs sed -i "s|__PUBLIC_APP_URL__|${escaped}|g"
+echo "$files" | xargs sed -i \
+  -e "s|__PUBLIC_APP_URL__|$(escape_value "${PUBLIC_APP_URL:-}")|g" \
+  -e "s|__PUBLIC_API_BASE_URL__|$(escape_value "${PUBLIC_API_BASE_URL:-}")|g" \
+  -e "s|https://public-site-url.placeholder.invalid|$(escape_value "$site_url")|g"
 
 echo "runtime config applied to $(echo "$files" | wc -l | tr -d ' ') files"

--- a/deploy/helm/bayes-platform/templates/frontends.yaml
+++ b/deploy/helm/bayes-platform/templates/frontends.yaml
@@ -9,7 +9,7 @@ The main web front is served by the API itself (see api.yaml).
   {{- $fronts = append $fronts (dict "component" "web-embed" "values" .Values.webEmbed "env" (dict "VITE_API_URL" .Values.urls.api)) }}
 {{- end }}
 {{- if .Values.help.enabled }}
-  {{- $fronts = append $fronts (dict "component" "help" "values" .Values.help "env" (dict "PUBLIC_APP_URL" .Values.urls.web)) }}
+  {{- $fronts = append $fronts (dict "component" "help" "values" .Values.help "env" (dict "PUBLIC_APP_URL" .Values.urls.web "PUBLIC_API_BASE_URL" .Values.urls.api "PUBLIC_SITE_URL" .Values.urls.help)) }}
 {{- end }}
 {{- range $front := $fronts }}
 {{- $values := $front.values }}


### PR DESCRIPTION
## Summary

The help center reads `PUBLIC_API_BASE_URL` and `PUBLIC_SITE_URL` at build time (#767). The published `help` image is built once for every install, without them: the public API page shows the placeholder, and the canonical links and sitemap point at the default site.

Same mechanism as `PUBLIC_APP_URL`: the image is built with placeholders, replaced from the container environment by `docker/40-runtime-config.sh` before nginx starts.

- Dockerfile: the two placeholders. Astro requires a valid URL for `site`, so the site placeholder is a URL on a `.invalid` host.
- Runtime script: replaces the three placeholders, in `.xml` and `.txt` too (sitemap), and strips a trailing slash from the site URL since Astro appends the paths.
- Chart: the help container receives `PUBLIC_API_BASE_URL` from `urls.api` and `PUBLIC_SITE_URL` from `urls.help`.
- Help README: the image note.

## Checks

- Astro build with the placeholder values: the site placeholder lands in 67 files including the two sitemap files, the API placeholder in 2 pages.
- The substitution applied to that output leaves no placeholder; canonical links and sitemap entries carry the install's help URL.
- `helm lint` and `helm template` render the three variables on the help Deployment.

Docker was not available locally: the image build itself is checked by the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)