### PR TITLE
feat(workers): graceful shutdown on SIGTERM, jobs survive a rollout

### DIFF
--- a/apps/api/.env-example
+++ b/apps/api/.env-example
@@ -74,6 +74,10 @@ DOCUMENT_EMBEDDING_STUCK_SWEEP_INTERVAL_SECONDS=900
 # and CPU instance types each set their own subset; locally we run a single
 # process that consumes every queue.
 WORKER_QUEUE_NAMES=evaluation-extraction-run-queue,evaluation-extraction-run-execute-queue,evaluation-conversation-run-queue,evaluation-conversation-run-execute-queue,agent-csv-extraction-run-queue,agent-csv-extraction-run-execute-queue,extraction-agent-session-queue,url-crawling,document-embeddings,document-embeddings-stuck-sweep,web-source-embeddings,pdf-exports-sweep
+# On SIGTERM the workers stop taking jobs and wait this long for the jobs in
+# progress before exiting (Kubernetes gives the pod 120 s, Cloud Run 10 s: set
+# it below the grace period of the platform). Default 100000.
+# WORKER_SHUTDOWN_TIMEOUT_MS=100000
 
 # Workers — which queue the /healthz Redis ping uses. REQUIRED; must be one of
 # the queues this instance consumes (see WORKER_QUEUE_NAMES).

--- a/apps/api/src/domains/documents/embeddings/document-embeddings.worker.ts
+++ b/apps/api/src/domains/documents/embeddings/document-embeddings.worker.ts
@@ -6,7 +6,12 @@ import type { CreateDocumentEmbeddingsJobPayload } from "./document-embeddings.t
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS DI
 import { DocumentEmbeddingsProcessorService } from "./document-embeddings-processor.service"
 
-@Processor(DOCUMENT_EMBEDDINGS_QUEUE_NAME)
+@Processor(DOCUMENT_EMBEDDINGS_QUEUE_NAME, {
+  // A job interrupted by a rollout goes back to the queue when its lock
+  // expires. Two rollouts in a row (chart, then image tag) must not fail it:
+  // the default of 1 did.
+  maxStalledCount: 3,
+})
 export class DocumentEmbeddingsWorker extends WorkerHost {
   private readonly logger = new Logger(DocumentEmbeddingsWorker.name)
 

--- a/apps/api/src/workers-main.ts
+++ b/apps/api/src/workers-main.ts
@@ -1,5 +1,5 @@
 import "./external/llm/open-telemetry-init" // must be first — patches http/pg before they are imported
-import { Logger } from "@nestjs/common"
+import { type INestApplication, Logger } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 import { getLogLevels, StructuredLogger } from "@/common/logger/structured-logger"
 import {
@@ -13,6 +13,9 @@ import { WorkersAppModule } from "./workers-app.module"
 
 const DEFAULT_WORKER_DOCLING_HEALTH_CHECK_TIMEOUT_MS = 30_000
 const DEFAULT_WORKER_HEALTH_PORT = 8080
+// Below the 120 s the Helm chart gives a workers pod to terminate. Cloud Run
+// gives 10 s: set WORKER_SHUTDOWN_TIMEOUT_MS lower there.
+const DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS = 100_000
 
 function getWorkerDoclingHealthCheckTimeoutMs(): number {
   const timeoutValue = process.env.WORKER_DOCLING_HEALTH_CHECK_TIMEOUT_MS
@@ -24,6 +27,59 @@ function getWorkerDoclingHealthCheckTimeoutMs(): number {
   return Number.isNaN(parsedTimeout)
     ? DEFAULT_WORKER_DOCLING_HEALTH_CHECK_TIMEOUT_MS
     : parsedTimeout
+}
+
+function getWorkerShutdownTimeoutMs(): number {
+  const timeoutValue = process.env.WORKER_SHUTDOWN_TIMEOUT_MS
+  if (!timeoutValue) {
+    return DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS
+  }
+
+  const parsedTimeout = Number.parseInt(timeoutValue, 10)
+  return Number.isNaN(parsedTimeout) || parsedTimeout < 0
+    ? DEFAULT_WORKER_SHUTDOWN_TIMEOUT_MS
+    : parsedTimeout
+}
+
+/**
+ * On SIGTERM (a rollout, a scale down), stop taking jobs and let the jobs in
+ * progress finish: app.close() runs the shutdown hooks, and the BullMQ module
+ * closes every worker, which waits for its active jobs. The wait is bounded:
+ * past the timeout the process exits and BullMQ hands the unfinished jobs
+ * back to the queue once their lock expires (maxStalledCount on the workers).
+ */
+function registerGracefulShutdown(app: INestApplication, timeoutMs: number): void {
+  let shuttingDown = false
+  const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+    if (shuttingDown) return
+    shuttingDown = true
+    Logger.log(
+      `${signal} received: no new jobs, waiting up to ${timeoutMs} ms for the jobs in progress`,
+      "WorkersMain",
+    )
+    const deadline = setTimeout(() => {
+      Logger.warn(
+        `Jobs still in progress after ${timeoutMs} ms, exiting; they go back to the queue`,
+        "WorkersMain",
+      )
+      process.exit(0)
+    }, timeoutMs)
+    deadline.unref()
+    try {
+      await app.close()
+      Logger.log("Workers closed, exiting", "WorkersMain")
+      process.exit(0)
+    } catch (error) {
+      Logger.error(
+        "Error while closing the workers",
+        error instanceof Error ? error.stack : String(error),
+        "WorkersMain",
+      )
+      process.exit(1)
+    }
+  }
+  process.once("SIGTERM", () => void shutdown("SIGTERM"))
+  process.once("SIGINT", () => void shutdown("SIGINT"))
 }
 
 function getWorkerHealthPort(): number {
@@ -45,6 +101,7 @@ async function bootstrapWorkersMain() {
   const app = await NestFactory.create(WorkersAppModule, {
     logger: isProduction ? new StructuredLogger(logLevels) : logLevels,
   })
+  registerGracefulShutdown(app, getWorkerShutdownTimeoutMs())
   const port = getWorkerHealthPort()
   await app.listen(port)
   Logger.log(`Workers app started, health endpoint listening on :${port}/healthz`, "WorkersMain")


### PR DESCRIPTION
## Summary

Seen on the staging install: a rollout of the GPU workers in the middle of a Docling job. The process exited at once on SIGTERM, the job came back only through BullMQ stall detection a minute later, and a second rollout would have failed it for good.

- `workers-main.ts`: on SIGTERM or SIGINT, `app.close()` runs the shutdown hooks; the BullMQ module closes every worker, which stops taking jobs and waits for the jobs in progress. The wait is bounded by `WORKER_SHUTDOWN_TIMEOUT_MS` (default 100 s, under the 120 s termination grace of the Helm chart): past it the process exits and the unfinished jobs go back to the queue when their lock expires.
- `DocumentEmbeddingsWorker`: `maxStalledCount: 3`, like the evaluation and CSV workers. The default of 1 fails a job interrupted twice.
- `.env-example` documents the variable.

## Cloud Run

Cloud Run gives an instance 10 s after SIGTERM, on worker pools as on services. A Docling job does not finish in that window: the benefit there is to stop taking new jobs during the window, and the unfinished job goes back to the queue as today. Set `WORKER_SHUTDOWN_TIMEOUT_MS` to about 8000 on Cloud Run so the process exits on its own before the kill.

## Checks

biome, tsc and `check:boundaries` pass. The bootstrap file has no test harness; the behaviour relies on `@nestjs/bullmq`'s `onApplicationShutdown`, which closes the registered workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)