### PR TITLE
feat(api): graceful shutdown on SIGTERM, requests in flight finish

### DIFF
--- a/apps/api/.env-example
+++ b/apps/api/.env-example
@@ -7,6 +7,11 @@ DIAGNOSTICS_SECRET=change-me # secret path for /diagnostics/<secret>/test-error
 # Port the API listens on (default 3000). Override to run several API instances
 # side by side.
 PORT=3000
+# On SIGTERM the API stops accepting connections and waits this long for the
+# requests in flight before exiting (Kubernetes gives the pod 35 s in the
+# chart, Cloud Run 10 s: set it below the grace period of the platform).
+# Default 25000.
+# API_SHUTDOWN_TIMEOUT_MS=25000
 
 GOOGLE_APPLICATION_CREDENTIALS=../../dontsave/caseai-connect-XXX.json
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,7 @@
 import "./external/llm/open-telemetry-init" // must be first — patches http/pg before they are imported
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
-import { Logger, ValidationPipe } from "@nestjs/common"
+import { type INestApplication, Logger, ValidationPipe } from "@nestjs/common"
 import { NestFactory } from "@nestjs/core"
 // biome-ignore lint/style/useImportType: Required at runtime for NestJS
 import { NestExpressApplication } from "@nestjs/platform-express"
@@ -17,6 +17,51 @@ import { BuiltInMcpServersService } from "./domains/mcp-servers/built-in/built-i
 
 const isProduction = process.env.NODE_ENV === "production"
 const logger = new Logger("Bootstrap")
+// Below the termination grace of the Helm chart (30 s). Cloud Run gives 10 s:
+// set API_SHUTDOWN_TIMEOUT_MS lower there.
+const DEFAULT_API_SHUTDOWN_TIMEOUT_MS = 25_000
+
+function getApiShutdownTimeoutMs(): number {
+  const timeoutValue = process.env.API_SHUTDOWN_TIMEOUT_MS
+  if (!timeoutValue) {
+    return DEFAULT_API_SHUTDOWN_TIMEOUT_MS
+  }
+  const parsedTimeout = Number.parseInt(timeoutValue, 10)
+  return Number.isNaN(parsedTimeout) || parsedTimeout < 0
+    ? DEFAULT_API_SHUTDOWN_TIMEOUT_MS
+    : parsedTimeout
+}
+
+/**
+ * On SIGTERM (a rollout, a scale down), stop accepting connections and let the
+ * requests in flight finish: app.close() closes the HTTP server, then runs the
+ * shutdown hooks (database pool, queues). Streams (SSE) hold the server open,
+ * so the wait is bounded: past the timeout the process exits and the clients
+ * reconnect.
+ */
+function registerGracefulShutdown(app: INestApplication, timeoutMs: number): void {
+  let shuttingDown = false
+  const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+    if (shuttingDown) return
+    shuttingDown = true
+    logger.log(`${signal} received: closing, waiting up to ${timeoutMs} ms for requests in flight`)
+    const deadline = setTimeout(() => {
+      logger.warn(`Connections still open after ${timeoutMs} ms, exiting`)
+      process.exit(0)
+    }, timeoutMs)
+    deadline.unref()
+    try {
+      await app.close()
+      logger.log("Closed, exiting")
+      process.exit(0)
+    } catch (error) {
+      logger.error("Error while closing", error instanceof Error ? error.stack : String(error))
+      process.exit(1)
+    }
+  }
+  process.once("SIGTERM", () => void shutdown("SIGTERM"))
+  process.once("SIGINT", () => void shutdown("SIGINT"))
+}
 
 async function bootstrap() {
   enableDbListeners()
@@ -60,6 +105,7 @@ async function bootstrap() {
       error instanceof Error ? error.stack : undefined,
     )
   }
+  registerGracefulShutdown(app, getApiShutdownTimeoutMs())
   const port = Number(process.env.PORT) || 3000
   await app.listen(port)
 }

--- a/deploy/helm/bayes-platform/templates/api.yaml
+++ b/deploy/helm/bayes-platform/templates/api.yaml
@@ -33,10 +33,19 @@ spec:
         fsGroup: 1000
       initContainers:
         {{- include "bayes-platform.waitForDatabase" . | nindent 8 }}
+      # SIGTERM is sent after the preStop sleep, which gives the Service
+      # endpoints and the Ingress the time to drop the pod: no request lands
+      # on a closing process. The API then drains its requests in flight
+      # (API_SHUTDOWN_TIMEOUT_MS, 25 s by default) within the grace period.
+      terminationGracePeriodSeconds: 35
       containers:
         - name: api
           image: {{ include "bayes-platform.image" (dict "root" . "image" .Values.api.image) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           ports:
             - name: http
               containerPort: {{ .Values.api.port }}


### PR DESCRIPTION
## Summary

Companion of #794 for the API. The process exited at once on SIGTERM, so every rollout cut the requests in flight.

- `main.ts`: on SIGTERM or SIGINT, `app.close()` stops accepting connections, drains the requests in flight, then runs the shutdown hooks (database pool, queues). The wait is bounded by `API_SHUTDOWN_TIMEOUT_MS` (default 25 s): the SSE streams hold the server open, past the timeout the process exits and the clients reconnect.
- Chart, `api.yaml`: a `preStop` sleep of 5 s so the Service endpoints and the Ingress drop the pod before SIGTERM reaches the process, and `terminationGracePeriodSeconds: 35` to cover sleep plus drain.
- `.env-example` documents the variable.

## Cloud Run

Cloud Run stops routing to an instance before SIGTERM and gives it 10 s: set `API_SHUTDOWN_TIMEOUT_MS` to about 8000 there so the process exits on its own before the kill. No preStop needed.

## Checks

biome and tsc pass, `helm lint` and `helm template` render the preStop and the grace period. The bootstrap file has no test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)